### PR TITLE
fix: resolve 14 bugs from eleventh systematic audit

### DIFF
--- a/packages/ax-code/src/cli/cmd/github-agent/index.ts
+++ b/packages/ax-code/src/cli/cmd/github-agent/index.ts
@@ -1044,9 +1044,11 @@ export const GithubRunCommand = cmd({
           await gitStatus(["fetch", "origin", base, "--depth=1"])
           const retry = await gitStatus(["rev-list", "--count", `origin/${base}..${head}`])
           if (retry.exitCode !== 0) return true // assume dirty if we can't tell
-          return parseInt(retry.stdout.toString().trim()) > 0
+          const count = parseInt(retry.stdout.toString().trim(), 10)
+          return Number.isFinite(count) && count > 0
         }
-        return parseInt(result.stdout.toString().trim()) > 0
+        const count = parseInt(result.stdout.toString().trim(), 10)
+        return Number.isFinite(count) && count > 0
       }
 
       async function assertPermissions() {

--- a/packages/ax-code/src/cli/cmd/tui/util/terminal.ts
+++ b/packages/ax-code/src/cli/cmd/tui/util/terminal.ts
@@ -40,10 +40,13 @@ export namespace Terminal {
         if (colorStr.startsWith("rgb:")) {
           const parts = colorStr.substring(4).split("/")
           if (parts.length !== 3) return null
-          const r = parseInt(parts[0], 16) >> 8
-          const g = parseInt(parts[1], 16) >> 8
-          const b = parseInt(parts[2], 16) >> 8
-          if (!Number.isFinite(r) || !Number.isFinite(g) || !Number.isFinite(b)) return null
+          const rRaw = parseInt(parts[0], 16)
+          const gRaw = parseInt(parts[1], 16)
+          const bRaw = parseInt(parts[2], 16)
+          if (!Number.isFinite(rRaw) || !Number.isFinite(gRaw) || !Number.isFinite(bRaw)) return null
+          const r = rRaw >> 8
+          const g = gRaw >> 8
+          const b = bRaw >> 8
           return RGBA.fromInts(r, g, b, 255)
         }
         if (colorStr.startsWith("#")) {

--- a/packages/ax-code/src/code-intelligence/lockfile.ts
+++ b/packages/ax-code/src/code-intelligence/lockfile.ts
@@ -65,8 +65,11 @@ export namespace IndexLock {
     }
     // wx = create+exclusive. Throws EEXIST if the file exists.
     const handle = await fs.open(target, "wx")
-    await handle.writeFile(JSON.stringify(body))
-    await handle.close()
+    try {
+      await handle.writeFile(JSON.stringify(body))
+    } finally {
+      await handle.close()
+    }
   }
 
   async function readLockBody(target: string): Promise<LockBody | undefined> {

--- a/packages/ax-code/src/config/config.ts
+++ b/packages/ax-code/src/config/config.ts
@@ -122,14 +122,15 @@ export namespace Config {
           log.warn("wellknown config URL rejected by SSRF guard", { url, err })
           continue
         }
-        const response = await fetch(endpoint)
+        const response = await Ssrf.pinnedFetch(endpoint)
           .then((res) => {
             if (res.ok || res.status !== 404) return res
-            return fetch(legacy)
+            return Ssrf.pinnedFetch(legacy)
           })
-          .catch(() => fetch(legacy))
+          .catch(() => Ssrf.pinnedFetch(legacy))
         if (!response.ok) {
-          throw new Error(`failed to fetch remote config from ${url}: ${response.status}`)
+          log.warn("failed to fetch remote config", { url, status: response.status })
+          continue
         }
         const wellknown = (await response.json()) as Record<string, unknown>
         const remoteConfig = (wellknown.config ?? {}) as Record<string, unknown>

--- a/packages/ax-code/src/mcp/index.ts
+++ b/packages/ax-code/src/mcp/index.ts
@@ -134,17 +134,22 @@ export namespace MCP {
       description: mcpTool.description ?? "",
       inputSchema: jsonSchema(schema),
       execute: async (args: unknown) => {
-        return client.callTool(
-          {
-            name: mcpTool.name,
-            arguments: (args || {}) as Record<string, unknown>,
-          },
-          CallToolResultSchema,
-          {
-            resetTimeoutOnProgress: true,
-            timeout,
-          },
-        )
+        try {
+          return await client.callTool(
+            {
+              name: mcpTool.name,
+              arguments: (args || {}) as Record<string, unknown>,
+            },
+            CallToolResultSchema,
+            {
+              resetTimeoutOnProgress: true,
+              timeout,
+            },
+          )
+        } catch (e) {
+          log.error("MCP tool call failed", { tool: mcpTool.name, error: e instanceof Error ? e.message : String(e) })
+          throw e
+        }
       },
     })
   }
@@ -244,7 +249,9 @@ export namespace MCP {
         for (const dpid of await descendants(pid)) {
           try {
             process.kill(dpid, "SIGTERM")
-          } catch {}
+          } catch (e: any) {
+            if (e?.code !== "ESRCH") log.debug("failed to kill descendant", { dpid, error: e?.code })
+          }
         }
       }
 
@@ -458,6 +465,7 @@ export namespace MCP {
             break
           }
 
+          await transport.close?.().catch(() => {})
           log.debug("transport connection failed", {
             key,
             transport: name,
@@ -908,6 +916,7 @@ export namespace MCP {
         pendingOAuthTransports.set(mcpName, transport)
         return { authorizationUrl: capturedUrl.toString() }
       }
+      await transport.close?.().catch(() => {})
       throw error
     }
   }
@@ -1016,8 +1025,8 @@ export namespace MCP {
       }
 
       // Re-add the MCP server to establish connection
-      pendingOAuthTransports.delete(mcpName)
       const result = await add(mcpName, mcpConfig)
+      pendingOAuthTransports.delete(mcpName)
 
       const statusRecord = result.status as Record<string, Status>
       return statusRecord[mcpName] ?? { status: "failed", error: "Unknown error after auth" }

--- a/packages/ax-code/src/session/instruction.ts
+++ b/packages/ax-code/src/session/instruction.ts
@@ -156,7 +156,7 @@ export namespace InstructionPrompt {
         log.warn("instruction URL rejected by SSRF guard", { url, err })
         return ""
       }
-      return fetch(url, { signal: AbortSignal.timeout(5000) })
+      return Ssrf.pinnedFetch(url, { signal: AbortSignal.timeout(5000) })
         .then((res) => {
           if (!res.ok) {
             log.warn("instruction URL returned non-ok", { url, status: res.status })

--- a/packages/ax-code/src/session/prompt.ts
+++ b/packages/ax-code/src/session/prompt.ts
@@ -717,7 +717,10 @@ export namespace SessionPrompt {
             messageID: lastUser.id,
           },
           msgs,
-        ).catch((e) => log.warn("summarize failed", { error: e }))
+        ).catch(async (e) => {
+          log.warn("summarize failed, setting fallback title", { error: e })
+          await Session.setTitle({ sessionID, title: "Untitled session" }).catch(() => {})
+        })
       }
 
       // Ephemerally wrap queued user messages with a reminder to stay on track

--- a/packages/ax-code/src/util/filelock.ts
+++ b/packages/ax-code/src/util/filelock.ts
@@ -32,8 +32,11 @@ export namespace FileLock {
       host: process.env.HOSTNAME ?? "",
     }
     const handle = await fs.open(target, "wx")
-    await handle.writeFile(JSON.stringify(body))
-    await handle.close()
+    try {
+      await handle.writeFile(JSON.stringify(body))
+    } finally {
+      await handle.close()
+    }
   }
 
   async function readLockBody(target: string): Promise<LockBody | undefined> {


### PR DESCRIPTION
## Summary

Fixes 14 confirmed bugs from the eleventh systematic audit (BUG-175 through BUG-195), including 2 critical SSRF redirect bypass vulnerabilities, 3 MCP transport resource leaks, and several error handling improvements.

### Security fixes
| Bug | File | Fix |
|-----|------|-----|
| **#175** | `config/config.ts` | SSRF redirect bypass — `fetch()` → `Ssrf.pinnedFetch()` for well-known config |
| **#176** | `session/instruction.ts` | SSRF redirect bypass — `fetch()` → `Ssrf.pinnedFetch()` for instruction URLs |

### Resource leak fixes
| Bug | File | Fix |
|-----|------|-----|
| **#178** | `mcp/index.ts` | Close transport on non-OAuth connection failure |
| **#179** | `mcp/index.ts` | Close transport before re-throw in startAuth |
| **#180** | `mcp/index.ts` | Delete pendingOAuth transport after add() succeeds |
| **#183** | `filelock.ts`, `lockfile.ts` | try/finally for file handle cleanup |

### Error handling & logic fixes
| Bug | File | Fix |
|-----|------|-----|
| **#177** | `config/config.ts` | Non-ok response logs warning + continues instead of throwing |
| **#185** | `terminal.ts` | Validate parseInt before bitshift to prevent NaN→0 coercion |
| **#187** | `github-agent/index.ts` | Add `Number.isFinite()` guard on parseInt results |
| **#191** | `mcp/index.ts` | Log MCP tool call errors before re-throwing |
| **#194** | `mcp/index.ts` | Only swallow ESRCH in process.kill catch, log others |
| **#195** | `session/prompt.ts` | Set fallback title on summarize failure |

### Not included (7 deferred)
- #181 (TOCTOU race — needs FileLock integration), #182 (config validation), #184 (CORS), #186 (connect lock race), #188/#189 (DB query indexing — by design with `| undefined` types), #190 (empty bin — edge case), #192 (event retry), #193 (non-null assertions — safe at runtime)

## Test plan
- [x] `bun typecheck` passes
- [x] 377 tests pass