### PR TITLE
feat(tui): client-side interactive follow-up queue (ADR-028)

### DIFF
--- a/packages/ax-code/src/cli/cmd/tui/component/prompt/follow-up-queue-store.ts
+++ b/packages/ax-code/src/cli/cmd/tui/component/prompt/follow-up-queue-store.ts
@@ -96,8 +96,12 @@ type PromptAsyncBody = Parameters<SdkContext["client"]["session"]["promptAsync"]
 
 /**
  * Dispatch a single follow-up to the server via the normal async prompt route.
- * Concurrent dispatches for the same session are skipped (returns false). The
- * caller removes the item from the queue when this resolves true.
+ *
+ * Returns `true` when the item was dispatched (caller removes it from the queue)
+ * and `false` when the dispatch was skipped because another dispatch for the
+ * same session is already in flight (caller leaves it queued, no error). A real
+ * server/transport failure throws so callers can surface it — distinguishing a
+ * harmless skip from an actual failure.
  */
 export async function dispatchFollowUp(sdk: SdkContext, sessionID: string, item: QueuedFollowUp): Promise<boolean> {
   if (inflight.has(sessionID)) return false
@@ -111,8 +115,10 @@ export async function dispatchFollowUp(sdk: SdkContext, sessionID: string, item:
       variant: item.variant,
       parts: item.parts as PromptAsyncBody["parts"],
     })
-    if (result && typeof result === "object" && "error" in result && (result as { error?: unknown }).error) {
-      return false
+    const error = result && typeof result === "object" ? (result as { error?: unknown }).error : undefined
+    if (error) {
+      const detail = (error as { data?: { message?: string }; message?: string })?.data?.message
+      throw new Error(detail ?? (error as { message?: string })?.message ?? "prompt_async failed")
     }
     return true
   } finally {

--- a/packages/ax-code/src/cli/cmd/tui/component/prompt/follow-up-queue-store.ts
+++ b/packages/ax-code/src/cli/cmd/tui/component/prompt/follow-up-queue-store.ts
@@ -4,6 +4,7 @@
  * client-owned, and per-session — matching the shipped ax-code-desktop model
  * and Codex CLI. Pure reducers/decisions live in `follow-up-queue.ts`.
  */
+import { createSignal } from "solid-js"
 import { createStore, produce } from "solid-js/store"
 import { MessageID } from "@/session/schema"
 import type { useSDK } from "@tui/context/sdk"
@@ -25,6 +26,11 @@ const [queues, setQueues] = createStore<Record<string, QueuedFollowUp[]>>({})
 const inflight = new Set<string>()
 const abortAt = new Map<string, number>()
 let counter = 0
+
+// Client-only "edit" channel: the sidebar removes a queued follow-up and asks
+// the prompt composer (which owns the textarea ref) to load its text back for
+// editing. A new object each request retriggers the prompt's consuming effect.
+const [editRequest, setEditRequest] = createSignal<{ sessionID: string; text: string } | undefined>()
 
 /** Reactive accessor — read inside a tracking scope to subscribe to changes. */
 export function followUpQueue(sessionID: string): QueuedFollowUp[] {
@@ -69,6 +75,20 @@ export function markFollowUpAbort(sessionID: string, now: number = Date.now()): 
 export function hasRecentFollowUpAbort(sessionID: string, now: number = Date.now()): boolean {
   const at = abortAt.get(sessionID)
   return at !== undefined && now - at < RECENT_ABORT_WINDOW_MS
+}
+
+/** Ask the prompt composer to load `text` for editing (see sidebar edit control). */
+export function requestFollowUpEdit(sessionID: string, text: string): void {
+  setEditRequest({ sessionID, text })
+}
+
+/** Reactive accessor for a pending edit request — consumed by the prompt composer. */
+export function followUpEditRequest(): { sessionID: string; text: string } | undefined {
+  return editRequest()
+}
+
+export function clearFollowUpEdit(): void {
+  setEditRequest(undefined)
 }
 
 type SdkContext = ReturnType<typeof useSDK>

--- a/packages/ax-code/src/cli/cmd/tui/component/prompt/follow-up-queue-store.ts
+++ b/packages/ax-code/src/cli/cmd/tui/component/prompt/follow-up-queue-store.ts
@@ -13,6 +13,7 @@ import {
   headFollowUp,
   makeFollowUp,
   removeFollowUp,
+  shouldDrainOnIdle,
   type FollowUpInput,
   type QueuedFollowUp,
 } from "./follow-up-queue"
@@ -97,11 +98,13 @@ type PromptAsyncBody = Parameters<SdkContext["client"]["session"]["promptAsync"]
 /**
  * Dispatch a single follow-up to the server via the normal async prompt route.
  *
- * Returns `true` when the item was dispatched (caller removes it from the queue)
- * and `false` when the dispatch was skipped because another dispatch for the
- * same session is already in flight (caller leaves it queued, no error). A real
- * server/transport failure throws so callers can surface it — distinguishing a
- * harmless skip from an actual failure.
+ * Returns `true` when the item was dispatched — it is removed from the queue
+ * here, while the in-flight guard is still held, so there is no window in which
+ * another caller can re-dispatch the same head. Returns `false` when skipped
+ * because another dispatch for the same session is already in flight (caller
+ * leaves it queued, no error). A real server/transport failure throws (the item
+ * stays queued) so callers can surface it — distinguishing a harmless skip from
+ * an actual failure.
  */
 export async function dispatchFollowUp(sdk: SdkContext, sessionID: string, item: QueuedFollowUp): Promise<boolean> {
   if (inflight.has(sessionID)) return false
@@ -120,8 +123,42 @@ export async function dispatchFollowUp(sdk: SdkContext, sessionID: string, item:
       const detail = (error as { data?: { message?: string }; message?: string })?.data?.message
       throw new Error(detail ?? (error as { message?: string })?.message ?? "prompt_async failed")
     }
+    removeQueuedFollowUp(sessionID, item.id)
     return true
   } finally {
     inflight.delete(sessionID)
   }
+}
+
+// Previous status per session, shared across every mounted Prompt instance so
+// the global drain dedupes: the first instance to observe a transition handles
+// it and updates the baseline; the rest see the new baseline and skip.
+const previousStatusBySession = new Map<string, string>()
+
+/**
+ * Drain the head follow-up of any session that just transitioned busy/retry ->
+ * idle. `snapshot` is `[sessionID, statusType]` for every known session. Safe to
+ * call from several Prompt instances (see `previousStatusBySession`); failures
+ * are reported via `onError` and leave the item queued.
+ */
+export function reconcileFollowUpDrain(
+  sdk: SdkContext,
+  snapshot: ReadonlyArray<readonly [string, string]>,
+  onError?: (sessionID: string, error: unknown) => void,
+): void {
+  for (const [sessionID, currentType] of snapshot) {
+    const previous = previousStatusBySession.get(sessionID)
+    previousStatusBySession.set(sessionID, currentType)
+    if (previous === undefined) continue
+    if (!shouldDrainOnIdle(previous, currentType)) continue
+    if (hasRecentFollowUpAbort(sessionID)) continue
+    const head = headFollowUp(queues[sessionID])
+    if (!head) continue
+    void dispatchFollowUp(sdk, sessionID, head).catch((error) => onError?.(sessionID, error))
+  }
+}
+
+/** Test-only: reset the global drain baseline so cases don't bleed into each other. */
+export function resetFollowUpDrainState(): void {
+  previousStatusBySession.clear()
 }

--- a/packages/ax-code/src/cli/cmd/tui/component/prompt/follow-up-queue-store.ts
+++ b/packages/ax-code/src/cli/cmd/tui/component/prompt/follow-up-queue-store.ts
@@ -1,0 +1,101 @@
+/**
+ * Reactive singleton store + server dispatch for the TUI interactive follow-up
+ * queue (ADR-028). The queue is ephemeral (in-memory, lost on TUI restart),
+ * client-owned, and per-session — matching the shipped ax-code-desktop model
+ * and Codex CLI. Pure reducers/decisions live in `follow-up-queue.ts`.
+ */
+import { createStore, produce } from "solid-js/store"
+import { MessageID } from "@/session/schema"
+import type { useSDK } from "@tui/context/sdk"
+import {
+  appendFollowUp,
+  headFollowUp,
+  makeFollowUp,
+  removeFollowUp,
+  type FollowUpInput,
+  type QueuedFollowUp,
+} from "./follow-up-queue"
+
+/** Window after a user interrupt during which we suppress auto-draining. */
+const RECENT_ABORT_WINDOW_MS = 2000
+
+const [queues, setQueues] = createStore<Record<string, QueuedFollowUp[]>>({})
+// Guards against two drains (e.g. idle effect + manual send-now) racing the same
+// session, which would double-dispatch the head item.
+const inflight = new Set<string>()
+const abortAt = new Map<string, number>()
+let counter = 0
+
+/** Reactive accessor — read inside a tracking scope to subscribe to changes. */
+export function followUpQueue(sessionID: string): QueuedFollowUp[] {
+  return queues[sessionID] ?? []
+}
+
+export function enqueueFollowUp(sessionID: string, input: FollowUpInput): QueuedFollowUp {
+  counter += 1
+  const item = makeFollowUp(input, `followup-${Date.now()}-${counter}`, Date.now())
+  setQueues(
+    produce((draft) => {
+      draft[sessionID] = appendFollowUp(draft[sessionID], item)
+    }),
+  )
+  return item
+}
+
+export function removeQueuedFollowUp(sessionID: string, id: string): void {
+  setQueues(
+    produce((draft) => {
+      if (draft[sessionID]) draft[sessionID] = removeFollowUp(draft[sessionID], id)
+    }),
+  )
+}
+
+export function peekQueuedFollowUp(sessionID: string): QueuedFollowUp | undefined {
+  return headFollowUp(queues[sessionID])
+}
+
+export function clearFollowUpQueue(sessionID: string): void {
+  setQueues(
+    produce((draft) => {
+      delete draft[sessionID]
+    }),
+  )
+}
+
+export function markFollowUpAbort(sessionID: string, now: number = Date.now()): void {
+  abortAt.set(sessionID, now)
+}
+
+export function hasRecentFollowUpAbort(sessionID: string, now: number = Date.now()): boolean {
+  const at = abortAt.get(sessionID)
+  return at !== undefined && now - at < RECENT_ABORT_WINDOW_MS
+}
+
+type SdkContext = ReturnType<typeof useSDK>
+type PromptAsyncBody = Parameters<SdkContext["client"]["session"]["promptAsync"]>[0]
+
+/**
+ * Dispatch a single follow-up to the server via the normal async prompt route.
+ * Concurrent dispatches for the same session are skipped (returns false). The
+ * caller removes the item from the queue when this resolves true.
+ */
+export async function dispatchFollowUp(sdk: SdkContext, sessionID: string, item: QueuedFollowUp): Promise<boolean> {
+  if (inflight.has(sessionID)) return false
+  inflight.add(sessionID)
+  try {
+    const result = await sdk.client.session.promptAsync({
+      sessionID,
+      messageID: MessageID.ascending(),
+      agent: item.agent,
+      model: item.model,
+      variant: item.variant,
+      parts: item.parts as PromptAsyncBody["parts"],
+    })
+    if (result && typeof result === "object" && "error" in result && (result as { error?: unknown }).error) {
+      return false
+    }
+    return true
+  } finally {
+    inflight.delete(sessionID)
+  }
+}

--- a/packages/ax-code/src/cli/cmd/tui/component/prompt/follow-up-queue.ts
+++ b/packages/ax-code/src/cli/cmd/tui/component/prompt/follow-up-queue.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure logic for the TUI interactive follow-up queue (ADR-028).
+ *
+ * While a session is busy, plain prompts the user types are buffered in a
+ * client-owned queue instead of being parked as durable `waiting_for_idle`
+ * task-queue rows on the server. When the session goes idle the head of the
+ * queue is replayed through the normal prompt route.
+ *
+ * This module holds the side-effect-free pieces (reducers + status decisions)
+ * so they can be unit tested without SolidJS or a live server. The reactive
+ * singleton store and the dispatch path live in `follow-up-queue-store.ts`.
+ */
+
+/** A prompt part as captured from the composer; shape mirrors the prompt body parts. */
+export type FollowUpPart = { id?: string; type: string; text?: string; [key: string]: unknown }
+
+export interface FollowUpInput {
+  parts: FollowUpPart[]
+  agent?: string
+  model?: { providerID: string; modelID: string }
+  variant?: string
+}
+
+export interface QueuedFollowUp extends FollowUpInput {
+  id: string
+  createdAt: number
+}
+
+export type SessionStatusType = "idle" | "busy" | "retry"
+
+export function makeFollowUp(input: FollowUpInput, id: string, createdAt: number): QueuedFollowUp {
+  return { ...input, id, createdAt }
+}
+
+export function appendFollowUp(list: readonly QueuedFollowUp[] | undefined, item: QueuedFollowUp): QueuedFollowUp[] {
+  return [...(list ?? []), item]
+}
+
+export function removeFollowUp(list: readonly QueuedFollowUp[] | undefined, id: string): QueuedFollowUp[] {
+  return (list ?? []).filter((item) => item.id !== id)
+}
+
+export function headFollowUp(list: readonly QueuedFollowUp[] | undefined): QueuedFollowUp | undefined {
+  return (list ?? [])[0]
+}
+
+/** A session is busy enough to buffer follow-ups when it is not idle. */
+export function isQueueableStatus(type: SessionStatusType | string | undefined): boolean {
+  return type === "busy" || type === "retry"
+}
+
+/**
+ * Drain the queue only on a real busy/retry -> idle transition. This mirrors the
+ * desktop auto-send rule so follow-ups run exactly once when a turn finishes,
+ * not on unrelated status churn.
+ */
+export function shouldDrainOnIdle(
+  previous: SessionStatusType | string | undefined,
+  current: SessionStatusType | string | undefined,
+): boolean {
+  return (previous === "busy" || previous === "retry") && current === "idle"
+}
+
+/** First non-empty text of a queued follow-up, used for display + tests. */
+export function followUpText(item: QueuedFollowUp): string {
+  for (const part of item.parts) {
+    if (part.type === "text" && typeof part.text === "string" && part.text.trim().length > 0) {
+      return part.text.trim()
+    }
+  }
+  return ""
+}

--- a/packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx
@@ -36,16 +36,13 @@ import { useSDK } from "@tui/context/sdk"
 import { useRoute } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
 import { MessageID, PartID, SessionID } from "@/session/schema"
-import { isQueueableStatus, shouldDrainOnIdle } from "./follow-up-queue"
+import { isQueueableStatus } from "./follow-up-queue"
 import {
   clearFollowUpEdit,
-  dispatchFollowUp,
   enqueueFollowUp,
   followUpEditRequest,
-  hasRecentFollowUpAbort,
   markFollowUpAbort,
-  peekQueuedFollowUp,
-  removeQueuedFollowUp,
+  reconcileFollowUpDrain,
 } from "./follow-up-queue-store"
 import { createStore, produce } from "solid-js/store"
 import { useKeybind } from "@tui/context/keybind"
@@ -216,43 +213,29 @@ export function Prompt(props: PromptProps) {
   // disabling falls back to immediate async send.
   const [queueModeEnabled] = kv.signal("prompt_queue_mode", true)
 
-  // Drain the client follow-up queue on a real busy/retry -> idle transition.
-  // Tracked per-session so navigating between sessions never fires a stale drain.
-  let drainSessionID: string | undefined
-  let previousStatusType: string | undefined
+  // Drain the client follow-up queue when any session transitions busy/retry ->
+  // idle. This watches every session's status (not just the one on screen) so a
+  // background session's queue still replays when it finishes — matching the
+  // desktop auto-send hook. The store dedupes across the multiple mounted Prompt
+  // instances, so running this effect in each is safe.
   createEffect(() => {
-    const sessionID = props.sessionID
-    const currentType = status().type
+    const record = sync.data.session_status ?? {}
+    const snapshot: Array<readonly [string, string]> = []
+    for (const id of Object.keys(record)) {
+      snapshot.push([id, (record[id] as { type?: string } | undefined)?.type ?? "idle"] as const)
+    }
     untrack(() => {
-      if (sessionID !== drainSessionID) {
-        drainSessionID = sessionID
-        previousStatusType = currentType
-        return
-      }
-      const previous = previousStatusType
-      previousStatusType = currentType
-      if (!sessionID) return
-      if (!shouldDrainOnIdle(previous, currentType)) return
-      if (hasRecentFollowUpAbort(sessionID)) return
-      const head = peekQueuedFollowUp(sessionID)
-      if (!head) return
-      void dispatchFollowUp(sdk, sessionID, head)
-        .then((dispatched) => {
-          // `false` means another dispatch is already in flight — leave the item
-          // queued for the next idle transition rather than flagging an error.
-          if (dispatched) removeQueuedFollowUp(sessionID, head.id)
+      reconcileFollowUpDrain(sdk, snapshot, (sessionID, error) => {
+        log.warn("follow-up queue drain failed", {
+          command: "tui.prompt.queue.drain",
+          status: "error",
+          sessionID,
+          error,
         })
-        .catch((error) => {
-          log.warn("follow-up queue drain failed", {
-            command: "tui.prompt.queue.drain",
-            status: "error",
-            sessionID,
-            error,
-          })
-          // Keep the item queued (it stays visible with send-now/edit) and let
-          // the user know the auto-send did not go through.
-          toast.show({ message: "Failed to send queued message", variant: "error" })
-        })
+        // Keep the item queued (it stays visible with send-now/edit) and let the
+        // user know the auto-send did not go through.
+        toast.show({ message: "Failed to send queued message", variant: "error" })
+      })
     })
   })
   const [localStatusTick, setLocalStatusTick] = createSignal(0)
@@ -445,7 +428,12 @@ export function Prompt(props: PromptProps) {
     const request = followUpEditRequest()
     if (!request) return
     untrack(() => {
-      if (request.sessionID === props.sessionID && input && !input.isDestroyed) {
+      // Several Prompt instances are mounted at once (session, permission,
+      // home). Only the instance the request targets consumes it — otherwise a
+      // non-matching instance could clear the request before the right one
+      // applies it, silently dropping the user's edited text.
+      if (request.sessionID !== props.sessionID) return
+      if (input && !input.isDestroyed) {
         input.insertText(request.text)
         requestInputLayoutRefresh({ gotoBufferEnd: true })
       }
@@ -1222,8 +1210,7 @@ export function Prompt(props: PromptProps) {
     // client-owned queue and let the drain effect replay them when idle. Slash
     // commands and shell input keep the existing async routes; new sessions and
     // idle sessions dispatch immediately below.
-    const isKnownSlashCommand =
-      inputText.startsWith("/") && sync.data.command.some((x) => x.name === firstLine.split(" ")[0].slice(1))
+    const isKnownSlashCommand = slashName != null && sync.data.command.some((x) => x.name === slashName)
     if (
       queueModeEnabled() &&
       currentMode === "normal" &&

--- a/packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx
@@ -36,7 +36,7 @@ import { useSDK } from "@tui/context/sdk"
 import { useRoute } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
 import { MessageID, PartID, SessionID } from "@/session/schema"
-import { shouldDrainOnIdle } from "./follow-up-queue"
+import { isQueueableStatus, shouldDrainOnIdle } from "./follow-up-queue"
 import {
   clearFollowUpEdit,
   dispatchFollowUp,
@@ -238,10 +238,20 @@ export function Prompt(props: PromptProps) {
       if (!head) return
       void dispatchFollowUp(sdk, sessionID, head)
         .then((dispatched) => {
+          // `false` means another dispatch is already in flight — leave the item
+          // queued for the next idle transition rather than flagging an error.
           if (dispatched) removeQueuedFollowUp(sessionID, head.id)
         })
         .catch((error) => {
-          log.warn("follow-up queue drain failed", { sessionID, error })
+          log.warn("follow-up queue drain failed", {
+            command: "tui.prompt.queue.drain",
+            status: "error",
+            sessionID,
+            error,
+          })
+          // Keep the item queued (it stays visible with send-now/edit) and let
+          // the user know the auto-send did not go through.
+          toast.show({ message: "Failed to send queued message", variant: "error" })
         })
     })
   })
@@ -1219,7 +1229,7 @@ export function Prompt(props: PromptProps) {
       currentMode === "normal" &&
       !isKnownSlashCommand &&
       props.sessionID &&
-      status().type !== "idle"
+      isQueueableStatus(status().type)
     ) {
       enqueueFollowUp(props.sessionID, {
         parts: [

--- a/packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx
@@ -38,8 +38,10 @@ import { useSync } from "@tui/context/sync"
 import { MessageID, PartID, SessionID } from "@/session/schema"
 import { shouldDrainOnIdle } from "./follow-up-queue"
 import {
+  clearFollowUpEdit,
   dispatchFollowUp,
   enqueueFollowUp,
+  followUpEditRequest,
   hasRecentFollowUpAbort,
   markFollowUpAbort,
   peekQueuedFollowUp,
@@ -426,6 +428,20 @@ export function Prompt(props: PromptProps) {
     requestInputLayoutRefresh({ gotoBufferEnd: true })
   })
   onCleanup(() => unsubPromptAppend())
+
+  // ADR-028: edit a queued follow-up — the sidebar removes it from the queue and
+  // requests its text here so the user can revise and resubmit it.
+  createEffect(() => {
+    const request = followUpEditRequest()
+    if (!request) return
+    untrack(() => {
+      if (request.sessionID === props.sessionID && input && !input.isDestroyed) {
+        input.insertText(request.text)
+        requestInputLayoutRefresh({ gotoBufferEnd: true })
+      }
+      clearFollowUpEdit()
+    })
+  })
 
   createEffect(() => {
     if (inputBlocked()) input.cursorColor = theme.backgroundElement

--- a/packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx
@@ -19,6 +19,7 @@ import {
   createSignal,
   onCleanup,
   on,
+  untrack,
   Show,
   Switch,
   Match,
@@ -35,6 +36,15 @@ import { useSDK } from "@tui/context/sdk"
 import { useRoute } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
 import { MessageID, PartID, SessionID } from "@/session/schema"
+import { shouldDrainOnIdle } from "./follow-up-queue"
+import {
+  dispatchFollowUp,
+  enqueueFollowUp,
+  hasRecentFollowUpAbort,
+  markFollowUpAbort,
+  peekQueuedFollowUp,
+  removeQueuedFollowUp,
+} from "./follow-up-queue-store"
 import { createStore, produce } from "solid-js/store"
 import { useKeybind } from "@tui/context/keybind"
 import { usePromptHistory, type PromptInfo } from "./history"
@@ -197,6 +207,42 @@ export function Prompt(props: PromptProps) {
   const [draftSessionID, setDraftSessionID] = createSignal<string | undefined>()
   const [expandedPastes, setExpandedPastes] = createSignal<Set<number>>(new Set<number>())
   const inputBlocked = createMemo(() => props.disabled || submitPending())
+
+  // ADR-028: interactive follow-up queueing. While the session is busy, plain
+  // prompts are buffered client-side and replayed when the session goes idle,
+  // instead of parking durable `waiting_for_idle` task-queue rows. Default on;
+  // disabling falls back to immediate async send.
+  const [queueModeEnabled] = kv.signal("prompt_queue_mode", true)
+
+  // Drain the client follow-up queue on a real busy/retry -> idle transition.
+  // Tracked per-session so navigating between sessions never fires a stale drain.
+  let drainSessionID: string | undefined
+  let previousStatusType: string | undefined
+  createEffect(() => {
+    const sessionID = props.sessionID
+    const currentType = status().type
+    untrack(() => {
+      if (sessionID !== drainSessionID) {
+        drainSessionID = sessionID
+        previousStatusType = currentType
+        return
+      }
+      const previous = previousStatusType
+      previousStatusType = currentType
+      if (!sessionID) return
+      if (!shouldDrainOnIdle(previous, currentType)) return
+      if (hasRecentFollowUpAbort(sessionID)) return
+      const head = peekQueuedFollowUp(sessionID)
+      if (!head) return
+      void dispatchFollowUp(sdk, sessionID, head)
+        .then((dispatched) => {
+          if (dispatched) removeQueuedFollowUp(sessionID, head.id)
+        })
+        .catch((error) => {
+          log.warn("follow-up queue drain failed", { sessionID, error })
+        })
+    })
+  })
   const [localStatusTick, setLocalStatusTick] = createSignal(0)
   const statusTick = () => props.statusTick?.() ?? localStatusTick()
   const pendingCancelHint = createMemo(() => {
@@ -623,6 +669,9 @@ export function Prompt(props: PromptProps) {
           }
 
           if (nextInterrupt >= 2) {
+            // Suppress auto-draining the follow-up queue right after a manual
+            // interrupt so we don't immediately resend on the busy -> idle edge.
+            markFollowUpAbort(props.sessionID)
             void sdk.client.session
               .abort({
                 sessionID: props.sessionID,
@@ -1141,6 +1190,37 @@ export function Prompt(props: PromptProps) {
           sessionID: nextSessionID,
         })
       }, 0)
+    }
+
+    // ADR-028: while the session is busy, buffer plain follow-up prompts in the
+    // client-owned queue and let the drain effect replay them when idle. Slash
+    // commands and shell input keep the existing async routes; new sessions and
+    // idle sessions dispatch immediately below.
+    const isKnownSlashCommand =
+      inputText.startsWith("/") && sync.data.command.some((x) => x.name === firstLine.split(" ")[0].slice(1))
+    if (
+      queueModeEnabled() &&
+      currentMode === "normal" &&
+      !isKnownSlashCommand &&
+      props.sessionID &&
+      status().type !== "idle"
+    ) {
+      enqueueFollowUp(props.sessionID, {
+        parts: [
+          {
+            id: PartID.ascending(),
+            type: "text",
+            text: inputText,
+          },
+          ...nonTextParts.map(assign),
+        ],
+        agent: local.agent.current().name,
+        model: selectedModel,
+        variant,
+      })
+      settlePromptLocally({ clearPrompt: true })
+      finishPendingSubmit()
+      return
     }
 
     try {

--- a/packages/ax-code/src/cli/cmd/tui/context/sync-state.ts
+++ b/packages/ax-code/src/cli/cmd/tui/context/sync-state.ts
@@ -47,6 +47,11 @@ export interface SyncStoreState {
   session_error: Record<string, unknown>
   session_risk: Record<string, SyncedSessionRisk>
   session_goal: Record<string, SessionGoal.PublicInfo | null>
+  // Durable server-owned task-queue items (workflow children, scheduled tasks,
+  // automations). Intentionally retained as a projection for the future
+  // workflow/queue supervision panel (ADR-025). It is deliberately NOT the
+  // source for the interactive "Queued" sidebar section, which uses the
+  // client-owned ephemeral follow-up queue instead (ADR-028).
   task_queue: SyncTaskQueueItem[]
   session_diff: Record<string, Snapshot.FileDiff[]>
   todo: Record<string, Todo[]>

--- a/packages/ax-code/src/cli/cmd/tui/context/sync-store-event.ts
+++ b/packages/ax-code/src/cli/cmd/tui/context/sync-store-event.ts
@@ -36,6 +36,8 @@ export interface SyncEventStoreState<
   session_error: Record<string, unknown>
   session_risk: Record<string, SyncedSessionRisk>
   session_goal: Record<string, unknown>
+  // Durable server task-queue projection retained for the future supervision
+  // panel (ADR-025); not the interactive follow-up queue (ADR-028).
   task_queue: SyncTaskQueueItem[]
   session: TSession[]
   message: Record<string, TMessage[]>

--- a/packages/ax-code/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -19,6 +19,7 @@ import { SessionRollbackView } from "./rollback"
 import { SessionSemanticDiff } from "@/session/semantic-diff"
 import { Todo } from "@/session/todo"
 import { footerSessionStatusOrIdle, footerSessionStatusView } from "./footer-view-model"
+import { dispatchFollowUp, followUpQueue, removeQueuedFollowUp } from "../../component/prompt/follow-up-queue-store"
 import { computeSidebarWidth } from "./layout"
 import { sidebarGraphIndexStatusText } from "./sidebar-index-view-model"
 import { Locale } from "@/util/locale"
@@ -47,6 +48,8 @@ const log = Log.create({ service: "tui.sidebar.queue" })
 
 const QUEUED_DELETE_ICON = "🗑️"
 const QUEUED_DELETE_ICON_WIDTH = 2
+const QUEUED_SEND_ICON = "▸"
+const QUEUED_SEND_ICON_WIDTH = 2
 const QUEUE_SNIPPET_MAX = 48
 
 function queuedSnippet(parts: { type: string; text?: string; synthetic?: boolean; ignored?: boolean }[]) {
@@ -134,28 +137,13 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean; statusTic
 
   const todoRemaining = createMemo(() => Todo.countActive(todo()))
 
-  // A user message is "queued" iff the loop has not yet picked it up,
-  // i.e. no assistant message references it as `parentID`. We can't gate
-  // on assistant `finish` strings: in autonomous tool-heavy turns the
-  // whole turn is a chain of `finish: "tool-calls"` steps with no
-  // terminal `stop` ever emitted, so a finish-based cutoff would treat
-  // already-addressed users as still pending and offer a delete that
-  // the server (correctly) refuses with a busy error. The parent-link
-  // signal matches what the server checks on delete.
-  //
-  // Do NOT gate on session status: the session is briefly "idle" between
-  // draining successive queued messages, and messages submitted before the
-  // session starts are also visible while status is idle. The parentID check
-  // is sufficient — a genuinely-finished session has assistant messages
-  // covering all user IDs, so queued() returns [] naturally.
-  const queued = createMemo(() => {
-    const msgs = messages()
-    const addressed = new Set<string>()
-    for (const m of msgs) {
-      if (m.role === "assistant") addressed.add(m.parentID)
-    }
-    return msgs.filter((m) => m.role === "user" && !addressed.has(m.id))
-  })
+  // ADR-028: the "Queued" section reflects the client-owned interactive
+  // follow-up queue, not persisted messages. Follow-ups typed while the
+  // session is busy are buffered client-side (see prompt/follow-up-queue-store)
+  // and replayed when the session goes idle, so this is the single source of
+  // truth for what is actually pending. Deriving from messages was wrong: a
+  // truly-queued follow-up has no persisted message until it runs.
+  const queued = createMemo(() => followUpQueue(props.sessionID))
 
   const [expanded, setExpanded] = createStore({
     mcp: true,
@@ -171,34 +159,29 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean; statusTic
     activity: true,
   })
 
-  async function dropQueued(messageID: string) {
-    if (!queued().some((m) => m.id === messageID)) return
-    // The generated SDK has ThrowOnError=false by default, so server-side
-    // 4xx/5xx come back via `result.error` instead of a thrown exception.
-    // Without this branch the failure was swallowed silently.
-    try {
-      const result = await sdk.client.session.deleteMessage({ sessionID: props.sessionID, messageID })
-      if (result.error) {
-        const detail = (result.error as { data?: { message?: string } })?.data?.message
-        log.warn("delete queued message rejected", {
-          command: "tui.sidebar.queue.delete",
-          status: "error",
-          sessionID: props.sessionID,
-          messageID,
-          error: result.error,
-        })
-        toast.show({ message: detail ?? "Failed to remove queued message", variant: "error" })
-      }
-    } catch (error) {
-      log.warn("delete queued message failed", {
-        command: "tui.sidebar.queue.delete",
+  // Removing a queued follow-up is purely client-side: the item never reached
+  // the server, so dropping it from the buffer guarantees it will not run.
+  function dropQueued(id: string) {
+    removeQueuedFollowUp(props.sessionID, id)
+  }
+
+  // Send a queued follow-up immediately. Dispatch first, then remove on success
+  // so a failed send keeps the item in the queue rather than losing it.
+  async function sendQueuedNow(id: string) {
+    const item = queued().find((entry) => entry.id === id)
+    if (!item) return
+    const dispatched = await dispatchFollowUp(sdk, props.sessionID, item).catch((error) => {
+      log.warn("send queued follow-up failed", {
+        command: "tui.sidebar.queue.send",
         status: "error",
         sessionID: props.sessionID,
-        messageID,
+        id,
         error,
       })
-      toast.show({ message: "Failed to remove queued message", variant: "error" })
-    }
+      return false
+    })
+    if (dispatched) removeQueuedFollowUp(props.sessionID, id)
+    else toast.show({ message: "Failed to send queued message", variant: "error" })
   }
 
   const activity = createMemo(() => {
@@ -539,19 +522,28 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean; statusTic
                   <box border={["top"]} borderColor={theme.borderSubtle} />
                   <Show when={queued().length <= 2 || expanded.queued}>
                     <For each={queued()}>
-                      {(message) => (
+                      {(item) => (
                         <box flexDirection="row" gap={1}>
+                          <box
+                            flexShrink={0}
+                            width={QUEUED_SEND_ICON_WIDTH}
+                            onMouseUp={() => {
+                              void sendQueuedNow(item.id)
+                            }}
+                          >
+                            <text style={{ fg: theme.primary }}>{QUEUED_SEND_ICON}</text>
+                          </box>
                           <box
                             flexShrink={0}
                             width={QUEUED_DELETE_ICON_WIDTH}
                             onMouseUp={() => {
-                              void dropQueued(message.id)
+                              dropQueued(item.id)
                             }}
                           >
                             <text style={{ fg: theme.warning }}>{QUEUED_DELETE_ICON}</text>
                           </box>
                           <text fg={theme.textMuted} wrapMode="word">
-                            {queuedSnippet(sync.data.part[message.id] ?? [])}
+                            {queuedSnippet(item.parts)}
                           </text>
                         </box>
                       )}

--- a/packages/ax-code/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -183,11 +183,15 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean; statusTic
   }
 
   // Send a queued follow-up immediately. Dispatch first, then remove on success
-  // so a failed send keeps the item in the queue rather than losing it.
+  // so a failed send keeps the item in the queue rather than losing it. A `false`
+  // result means another dispatch is in flight — leave it queued without error.
   async function sendQueuedNow(id: string) {
     const item = queued().find((entry) => entry.id === id)
     if (!item) return
-    const dispatched = await dispatchFollowUp(sdk, props.sessionID, item).catch((error) => {
+    try {
+      const dispatched = await dispatchFollowUp(sdk, props.sessionID, item)
+      if (dispatched) removeQueuedFollowUp(props.sessionID, id)
+    } catch (error) {
       log.warn("send queued follow-up failed", {
         command: "tui.sidebar.queue.send",
         status: "error",
@@ -195,10 +199,8 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean; statusTic
         id,
         error,
       })
-      return false
-    })
-    if (dispatched) removeQueuedFollowUp(props.sessionID, id)
-    else toast.show({ message: "Failed to send queued message", variant: "error" })
+      toast.show({ message: "Failed to send queued message", variant: "error" })
+    }
   }
 
   const activity = createMemo(() => {

--- a/packages/ax-code/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -182,15 +182,13 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean; statusTic
     requestFollowUpEdit(props.sessionID, followUpText(item))
   }
 
-  // Send a queued follow-up immediately. Dispatch first, then remove on success
-  // so a failed send keeps the item in the queue rather than losing it. A `false`
-  // result means another dispatch is in flight — leave it queued without error.
+  // Send a queued follow-up immediately. dispatchFollowUp removes it from the
+  // queue on success; a thrown error keeps it queued so the user can retry.
   async function sendQueuedNow(id: string) {
     const item = queued().find((entry) => entry.id === id)
     if (!item) return
     try {
-      const dispatched = await dispatchFollowUp(sdk, props.sessionID, item)
-      if (dispatched) removeQueuedFollowUp(props.sessionID, id)
+      await dispatchFollowUp(sdk, props.sessionID, item)
     } catch (error) {
       log.warn("send queued follow-up failed", {
         command: "tui.sidebar.queue.send",

--- a/packages/ax-code/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -19,7 +19,13 @@ import { SessionRollbackView } from "./rollback"
 import { SessionSemanticDiff } from "@/session/semantic-diff"
 import { Todo } from "@/session/todo"
 import { footerSessionStatusOrIdle, footerSessionStatusView } from "./footer-view-model"
-import { dispatchFollowUp, followUpQueue, removeQueuedFollowUp } from "../../component/prompt/follow-up-queue-store"
+import { followUpText } from "../../component/prompt/follow-up-queue"
+import {
+  dispatchFollowUp,
+  followUpQueue,
+  removeQueuedFollowUp,
+  requestFollowUpEdit,
+} from "../../component/prompt/follow-up-queue-store"
 import { computeSidebarWidth } from "./layout"
 import { sidebarGraphIndexStatusText } from "./sidebar-index-view-model"
 import { Locale } from "@/util/locale"
@@ -50,6 +56,8 @@ const QUEUED_DELETE_ICON = "🗑️"
 const QUEUED_DELETE_ICON_WIDTH = 2
 const QUEUED_SEND_ICON = "▸"
 const QUEUED_SEND_ICON_WIDTH = 2
+const QUEUED_EDIT_ICON = "✎"
+const QUEUED_EDIT_ICON_WIDTH = 2
 const QUEUE_SNIPPET_MAX = 48
 
 function queuedSnippet(parts: { type: string; text?: string; synthetic?: boolean; ignored?: boolean }[]) {
@@ -163,6 +171,15 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean; statusTic
   // the server, so dropping it from the buffer guarantees it will not run.
   function dropQueued(id: string) {
     removeQueuedFollowUp(props.sessionID, id)
+  }
+
+  // Editing pops the follow-up out of the queue and back into the composer so
+  // the user can revise and resubmit it.
+  function editQueued(id: string) {
+    const item = queued().find((entry) => entry.id === id)
+    if (!item) return
+    removeQueuedFollowUp(props.sessionID, id)
+    requestFollowUpEdit(props.sessionID, followUpText(item))
   }
 
   // Send a queued follow-up immediately. Dispatch first, then remove on success
@@ -524,6 +541,15 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean; statusTic
                     <For each={queued()}>
                       {(item) => (
                         <box flexDirection="row" gap={1}>
+                          <box
+                            flexShrink={0}
+                            width={QUEUED_EDIT_ICON_WIDTH}
+                            onMouseUp={() => {
+                              editQueued(item.id)
+                            }}
+                          >
+                            <text style={{ fg: theme.text }}>{QUEUED_EDIT_ICON}</text>
+                          </box>
                           <box
                             flexShrink={0}
                             width={QUEUED_SEND_ICON_WIDTH}

--- a/packages/ax-code/test/cli/tui/follow-up-queue.test.ts
+++ b/packages/ax-code/test/cli/tui/follow-up-queue.test.ts
@@ -126,10 +126,9 @@ describe("follow-up-queue-store", () => {
     clearFollowUpQueue(sid)
   })
 
-  test("dispatchFollowUp returns false on a server error result", async () => {
-    const sdk = { client: { session: { promptAsync: async () => ({ error: { message: "boom" } }) } } } as any
-    const ok = await dispatchFollowUp(sdk, "ses_err", item("1"))
-    expect(ok).toBe(false)
+  test("dispatchFollowUp throws on a server error result (so callers can surface it)", async () => {
+    const sdk = { client: { session: { promptAsync: async () => ({ error: { data: { message: "boom" } } }) } } } as any
+    expect(dispatchFollowUp(sdk, "ses_err", item("1"))).rejects.toThrow("boom")
   })
 
   test("edit channel carries a pending request and clears", () => {

--- a/packages/ax-code/test/cli/tui/follow-up-queue.test.ts
+++ b/packages/ax-code/test/cli/tui/follow-up-queue.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test"
+import {
+  appendFollowUp,
+  followUpText,
+  headFollowUp,
+  isQueueableStatus,
+  makeFollowUp,
+  removeFollowUp,
+  shouldDrainOnIdle,
+  type QueuedFollowUp,
+} from "../../../src/cli/cmd/tui/component/prompt/follow-up-queue"
+import {
+  clearFollowUpQueue,
+  dispatchFollowUp,
+  enqueueFollowUp,
+  followUpQueue,
+  hasRecentFollowUpAbort,
+  markFollowUpAbort,
+  peekQueuedFollowUp,
+  removeQueuedFollowUp,
+} from "../../../src/cli/cmd/tui/component/prompt/follow-up-queue-store"
+
+const item = (id: string, text = "hi"): QueuedFollowUp =>
+  makeFollowUp({ parts: [{ id: "p", type: "text", text }] }, id, 1)
+
+describe("follow-up-queue (pure)", () => {
+  test("makeFollowUp carries input and stamps id/createdAt", () => {
+    const made = makeFollowUp({ parts: [{ type: "text", text: "x" }], agent: "build" }, "a", 42)
+    expect(made).toEqual({ parts: [{ type: "text", text: "x" }], agent: "build", id: "a", createdAt: 42 })
+  })
+
+  test("appendFollowUp appends in order and tolerates undefined", () => {
+    const a = appendFollowUp(undefined, item("1"))
+    const b = appendFollowUp(a, item("2"))
+    expect(b.map((i) => i.id)).toEqual(["1", "2"])
+  })
+
+  test("removeFollowUp drops by id and tolerates undefined", () => {
+    expect(removeFollowUp(undefined, "x")).toEqual([])
+    const list = [item("1"), item("2"), item("3")]
+    expect(removeFollowUp(list, "2").map((i) => i.id)).toEqual(["1", "3"])
+  })
+
+  test("headFollowUp returns first or undefined", () => {
+    expect(headFollowUp(undefined)).toBeUndefined()
+    expect(headFollowUp([])).toBeUndefined()
+    expect(headFollowUp([item("1"), item("2")])?.id).toBe("1")
+  })
+
+  test("isQueueableStatus is true only while busy/retry", () => {
+    expect(isQueueableStatus("busy")).toBe(true)
+    expect(isQueueableStatus("retry")).toBe(true)
+    expect(isQueueableStatus("idle")).toBe(false)
+    expect(isQueueableStatus(undefined)).toBe(false)
+  })
+
+  test("shouldDrainOnIdle fires only on busy/retry -> idle", () => {
+    expect(shouldDrainOnIdle("busy", "idle")).toBe(true)
+    expect(shouldDrainOnIdle("retry", "idle")).toBe(true)
+    expect(shouldDrainOnIdle("idle", "idle")).toBe(false)
+    expect(shouldDrainOnIdle("busy", "busy")).toBe(false)
+    expect(shouldDrainOnIdle("busy", "retry")).toBe(false)
+    expect(shouldDrainOnIdle(undefined, "idle")).toBe(false)
+  })
+
+  test("followUpText returns first non-empty text", () => {
+    expect(followUpText(item("1", "  hello  "))).toBe("hello")
+    expect(followUpText(makeFollowUp({ parts: [{ type: "file" }, { type: "text", text: " y " }] }, "1", 1))).toBe("y")
+    expect(followUpText(makeFollowUp({ parts: [{ type: "file" }] }, "1", 1))).toBe("")
+  })
+})
+
+describe("follow-up-queue-store", () => {
+  test("enqueue/peek/remove/clear are per-session and ordered", () => {
+    const sid = "ses_store_basic"
+    clearFollowUpQueue(sid)
+    const a = enqueueFollowUp(sid, { parts: [{ type: "text", text: "one" }] })
+    const b = enqueueFollowUp(sid, { parts: [{ type: "text", text: "two" }] })
+    expect(followUpQueue(sid).map((i) => i.id)).toEqual([a.id, b.id])
+    expect(peekQueuedFollowUp(sid)?.id).toBe(a.id)
+
+    removeQueuedFollowUp(sid, a.id)
+    expect(followUpQueue(sid).map((i) => i.id)).toEqual([b.id])
+
+    clearFollowUpQueue(sid)
+    expect(followUpQueue(sid)).toEqual([])
+    // Other sessions are unaffected.
+    expect(followUpQueue("ses_other")).toEqual([])
+  })
+
+  test("recent-abort window suppresses draining", () => {
+    const sid = "ses_abort"
+    const now = 10_000
+    expect(hasRecentFollowUpAbort(sid, now)).toBe(false)
+    markFollowUpAbort(sid, now)
+    expect(hasRecentFollowUpAbort(sid, now + 1500)).toBe(true)
+    expect(hasRecentFollowUpAbort(sid, now + 2500)).toBe(false)
+  })
+
+  test("dispatchFollowUp posts the captured payload and resolves true", async () => {
+    const sid = "ses_dispatch_ok"
+    const calls: any[] = []
+    const sdk = {
+      client: { session: { promptAsync: async (args: any) => (calls.push(args), {}) } },
+    } as any
+    const queued = enqueueFollowUp(sid, {
+      parts: [{ id: "p1", type: "text", text: "go" }],
+      agent: "build",
+      model: { providerID: "anthropic", modelID: "claude" },
+      variant: "fast",
+    })
+    const ok = await dispatchFollowUp(sdk, sid, queued)
+    expect(ok).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      sessionID: sid,
+      agent: "build",
+      model: { providerID: "anthropic", modelID: "claude" },
+      variant: "fast",
+      parts: [{ id: "p1", type: "text", text: "go" }],
+    })
+    expect(typeof calls[0].messageID).toBe("string")
+    clearFollowUpQueue(sid)
+  })
+
+  test("dispatchFollowUp returns false on a server error result", async () => {
+    const sdk = { client: { session: { promptAsync: async () => ({ error: { message: "boom" } }) } } } as any
+    const ok = await dispatchFollowUp(sdk, "ses_err", item("1"))
+    expect(ok).toBe(false)
+  })
+
+  test("dispatchFollowUp skips a concurrent dispatch for the same session", async () => {
+    const sid = "ses_inflight"
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => (release = resolve))
+    const sdk = { client: { session: { promptAsync: async () => (await gate, {}) } } } as any
+
+    const first = dispatchFollowUp(sdk, sid, item("1"))
+    const second = await dispatchFollowUp(sdk, sid, item("2"))
+    expect(second).toBe(false)
+    release?.()
+    expect(await first).toBe(true)
+  })
+})

--- a/packages/ax-code/test/cli/tui/follow-up-queue.test.ts
+++ b/packages/ax-code/test/cli/tui/follow-up-queue.test.ts
@@ -19,8 +19,10 @@ import {
   hasRecentFollowUpAbort,
   markFollowUpAbort,
   peekQueuedFollowUp,
+  reconcileFollowUpDrain,
   removeQueuedFollowUp,
   requestFollowUpEdit,
+  resetFollowUpDrainState,
 } from "../../../src/cli/cmd/tui/component/prompt/follow-up-queue-store"
 
 const item = (id: string, text = "hi"): QueuedFollowUp =>
@@ -123,6 +125,9 @@ describe("follow-up-queue-store", () => {
       parts: [{ id: "p1", type: "text", text: "go" }],
     })
     expect(typeof calls[0].messageID).toBe("string")
+    // Removal happens inside dispatch (while the in-flight guard is held) so no
+    // other caller can re-dispatch the same head.
+    expect(followUpQueue(sid)).toEqual([])
     clearFollowUpQueue(sid)
   })
 
@@ -151,5 +156,68 @@ describe("follow-up-queue-store", () => {
     expect(second).toBe(false)
     release?.()
     expect(await first).toBe(true)
+  })
+})
+
+describe("reconcileFollowUpDrain", () => {
+  const fakeSdk = (calls: any[]) =>
+    ({ client: { session: { promptAsync: async (args: any) => (calls.push(args), {}) } } }) as any
+
+  test("dispatches the head only on a busy -> idle transition, once", () => {
+    resetFollowUpDrainState()
+    const sid = "ses_drain"
+    clearFollowUpQueue(sid)
+    enqueueFollowUp(sid, { parts: [{ type: "text", text: "next" }] })
+    const calls: any[] = []
+    const sdk = fakeSdk(calls)
+
+    // First observation only establishes a baseline — no drain.
+    reconcileFollowUpDrain(sdk, [[sid, "busy"]])
+    expect(calls).toHaveLength(0)
+
+    // busy -> idle drains the head.
+    reconcileFollowUpDrain(sdk, [[sid, "idle"]])
+    expect(calls).toHaveLength(1)
+    expect(calls[0].sessionID).toBe(sid)
+    clearFollowUpQueue(sid)
+  })
+
+  test("does not drain on idle -> idle or when there is no queued item", () => {
+    resetFollowUpDrainState()
+    const sid = "ses_drain_none"
+    clearFollowUpQueue(sid)
+    const calls: any[] = []
+    const sdk = fakeSdk(calls)
+    reconcileFollowUpDrain(sdk, [[sid, "busy"]])
+    reconcileFollowUpDrain(sdk, [[sid, "idle"]]) // no queued item
+    expect(calls).toHaveLength(0)
+  })
+
+  test("a recent abort suppresses the drain on that transition", () => {
+    resetFollowUpDrainState()
+    const sid = "ses_drain_abort"
+    clearFollowUpQueue(sid)
+    enqueueFollowUp(sid, { parts: [{ type: "text", text: "x" }] })
+    const calls: any[] = []
+    const sdk = fakeSdk(calls)
+    reconcileFollowUpDrain(sdk, [[sid, "busy"]])
+    markFollowUpAbort(sid)
+    reconcileFollowUpDrain(sdk, [[sid, "idle"]])
+    expect(calls).toHaveLength(0)
+    clearFollowUpQueue(sid)
+  })
+
+  test("shared baseline dedupes repeated reconcile calls for the same transition", () => {
+    resetFollowUpDrainState()
+    const sid = "ses_drain_dedupe"
+    clearFollowUpQueue(sid)
+    enqueueFollowUp(sid, { parts: [{ type: "text", text: "y" }] })
+    const calls: any[] = []
+    const sdk = fakeSdk(calls)
+    reconcileFollowUpDrain(sdk, [[sid, "busy"]])
+    reconcileFollowUpDrain(sdk, [[sid, "idle"]]) // drains
+    reconcileFollowUpDrain(sdk, [[sid, "idle"]]) // same baseline now idle -> no second drain
+    expect(calls).toHaveLength(1)
+    clearFollowUpQueue(sid)
   })
 })

--- a/packages/ax-code/test/cli/tui/follow-up-queue.test.ts
+++ b/packages/ax-code/test/cli/tui/follow-up-queue.test.ts
@@ -10,14 +10,17 @@ import {
   type QueuedFollowUp,
 } from "../../../src/cli/cmd/tui/component/prompt/follow-up-queue"
 import {
+  clearFollowUpEdit,
   clearFollowUpQueue,
   dispatchFollowUp,
   enqueueFollowUp,
+  followUpEditRequest,
   followUpQueue,
   hasRecentFollowUpAbort,
   markFollowUpAbort,
   peekQueuedFollowUp,
   removeQueuedFollowUp,
+  requestFollowUpEdit,
 } from "../../../src/cli/cmd/tui/component/prompt/follow-up-queue-store"
 
 const item = (id: string, text = "hi"): QueuedFollowUp =>
@@ -127,6 +130,15 @@ describe("follow-up-queue-store", () => {
     const sdk = { client: { session: { promptAsync: async () => ({ error: { message: "boom" } }) } } } as any
     const ok = await dispatchFollowUp(sdk, "ses_err", item("1"))
     expect(ok).toBe(false)
+  })
+
+  test("edit channel carries a pending request and clears", () => {
+    clearFollowUpEdit()
+    expect(followUpEditRequest()).toBeUndefined()
+    requestFollowUpEdit("ses_edit", "revise me")
+    expect(followUpEditRequest()).toEqual({ sessionID: "ses_edit", text: "revise me" })
+    clearFollowUpEdit()
+    expect(followUpEditRequest()).toBeUndefined()
   })
 
   test("dispatchFollowUp skips a concurrent dispatch for the same session", async () => {

--- a/packages/ax-code/test/cli/tui/render-anti-patterns.test.ts
+++ b/packages/ax-code/test/cli/tui/render-anti-patterns.test.ts
@@ -512,9 +512,12 @@ describe("tui OpenTUI stability guardrails", () => {
     expect(queuedBlock).toContain("width={QUEUED_DELETE_ICON_WIDTH}")
     expect(queuedBlock).toContain("dropQueued(item.id)")
     expect(queuedBlock).toContain("<text style={{ fg: theme.warning }}>{QUEUED_DELETE_ICON}</text>")
-    // The send-now control is also a fixed-width box so wide glyphs stay aligned.
+    // The send-now and edit controls are also fixed-width boxes so wide glyphs
+    // stay aligned.
     expect(queuedBlock).toContain("width={QUEUED_SEND_ICON_WIDTH}")
     expect(queuedBlock).toContain("void sendQueuedNow(item.id)")
+    expect(queuedBlock).toContain("width={QUEUED_EDIT_ICON_WIDTH}")
+    expect(queuedBlock).toContain("editQueued(item.id)")
     // Click handlers stay on the width-boxed containers, never on <text> (wide
     // emoji measured inside an interactive text node misaligns the row).
     expect(queuedBlock).not.toMatch(/<text[^>]*onMouseUp/)

--- a/packages/ax-code/test/cli/tui/render-anti-patterns.test.ts
+++ b/packages/ax-code/test/cli/tui/render-anti-patterns.test.ts
@@ -510,8 +510,13 @@ describe("tui OpenTUI stability guardrails", () => {
     expect(sidebar).toContain('const QUEUED_DELETE_ICON = "🗑️"')
     expect(sidebar).toContain("const QUEUED_DELETE_ICON_WIDTH = 2")
     expect(queuedBlock).toContain("width={QUEUED_DELETE_ICON_WIDTH}")
-    expect(queuedBlock).toContain("void dropQueued(message.id)")
+    expect(queuedBlock).toContain("dropQueued(item.id)")
     expect(queuedBlock).toContain("<text style={{ fg: theme.warning }}>{QUEUED_DELETE_ICON}</text>")
+    // The send-now control is also a fixed-width box so wide glyphs stay aligned.
+    expect(queuedBlock).toContain("width={QUEUED_SEND_ICON_WIDTH}")
+    expect(queuedBlock).toContain("void sendQueuedNow(item.id)")
+    // Click handlers stay on the width-boxed containers, never on <text> (wide
+    // emoji measured inside an interactive text node misaligns the row).
     expect(queuedBlock).not.toMatch(/<text[^>]*onMouseUp/)
   })
 


### PR DESCRIPTION
## Summary

Reduces (does not remove) the task queue per **ADR-028 / PRD-2026-06-07**: interactive "type while the agent is busy" follow-ups move off the durable server `TaskQueue` into a lightweight, ephemeral, **client-owned** queue — matching the shipped `ax-code-desktop` model and Codex CLI. The durable `TaskQueue` is unchanged and remains the substrate for workflow children, scheduled tasks, automations, and crash recovery.

This also fixes the original report ("task queue not working"): the sidebar "Queued" section derived from persisted messages, which can never show a truly-queued follow-up (it has no persisted message until it runs), while the real queue state was synced but unread.

## What changed
- **New** `follow-up-queue.ts` (pure reducers + status decisions) and `follow-up-queue-store.ts` (reactive singleton, `dispatchFollowUp` via `promptAsync` with in-flight guard, recent-abort suppression, edit channel, global `reconcileFollowUpDrain`).
- **Prompt**: buffer plain prompts while busy; **global** drain on any session's busy/retry → idle (background sessions replay too); suppress drain right after a manual interrupt; gated by `prompt_queue_mode` kv flag (default on). Slash/shell input and new/idle sessions are unaffected.
- **Sidebar "Queued"**: derives from the client store; per-item **edit / send-now / delete**. Removed the messages-based memo.
- `sync.data.task_queue` documented as the durable supervision projection (ADR-025), explicitly not the interactive queue.

## PRD success metrics — all met
- Follow-ups while busy show immediately, FIFO, with edit/delete/send-now; run when idle ✅
- Deleting a queued follow-up prevents it running ✅
- No `waiting_for_idle` rows for interactive follow-ups ✅
- `TaskQueue` workflow/scheduled/automation/recovery unaffected ✅
- No populated queue field unread without intent ✅

Explicitly deferred (recorded in ADR-028): steer-now keybindings, removing `prompt_async` as the interactive transport, kv persistence, durable-tasks supervision panel.

## Review pass (code-review high) fixes included
- Edit data loss across multiple mounted `Prompt` instances → clear only the targeted instance.
- Background-session auto-replay → global status watcher (desktop parity), deduped across instances.
- Double-dispatch window → removal moved inside the in-flight-guarded `dispatchFollowUp`.
- De-duplicated slash detection.

## Testing
- `bun run typecheck`, `bun run check:tui-layering`, `bun test test/cli/tui/` (**552 pass**, incl. new pure/store/`reconcileFollowUpDrain` unit tests) — all green.
- ⚠️ Not yet verified live: a `pnpm dev` manual pass of the chips (queue while busy → edit/send-now/delete → auto-replay on idle, including the background-session case). The interactive wiring is covered by unit tests + the render guardrail + typecheck and follows the desktop-proven pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)