### PR TITLE
fix(tui): second-pass bug sweep on follow-up queue (ADR-028)

### DIFF
--- a/.internal/adr/ADR-028-task-queue-layering-boundary.md
+++ b/.internal/adr/ADR-028-task-queue-layering-boundary.md
@@ -1,0 +1,138 @@
+# ADR-028: Separate interactive follow-up queueing from the durable task queue
+
+## Status
+
+Accepted - interactive follow-up queue implemented 2026-06-07 (ephemeral client-owned buffer with
+queue/drain/display/delete/send-now/edit). Deferred: steer-now keybindings, removing `prompt_async` as the
+interactive transport, optional kv persistence, and the durable-tasks supervision panel (see Consequences).
+
+## Date
+
+2026-06-07
+
+## Deciders
+
+ax-code maintainers
+
+## Related
+
+- `.internal/prd/PRD-2026-06-07-task-queue-layering.md`
+- `.internal/prd/TECH-SPEC-2026-06-07-task-queue-layering.md`
+- `.internal/adr/ADR-025-workflow-runtime-boundary.md`
+- `.internal/adr/ADR-022-codex-like-desktop-app-from-openchamber-baseline.md`
+- `.internal/adr/ADR-018-app-headless-sdk-boundary.md`
+- `.internal/adr/ADR-017-effect-framework-freeze.md`
+
+## Context
+
+AX Code uses a single durable `TaskQueue` (`packages/ax-code/src/session/task-queue.ts`) for two unrelated concerns:
+
+1. **Interactive follow-up queueing** — the user types another message while a turn is running and expects it to run next.
+2. **Durable orchestration** — workflow subagent fan-out, phase parallelism, pacing/budget, scheduled tasks, automations,
+   and crash recovery.
+
+The TUI routes **every** interactive prompt through `prompt_async` → `TaskQueue.enqueue` → `TaskQueueExecutor.start`
+(`cli/cmd/tui/component/prompt/index.tsx`, `server/routes/session.ts`). Follow-ups submitted while busy become durable
+`waiting_for_idle` rows, and the user message is **not persisted until the item executes** (creation lives inside
+`SessionPrompt.prompt` → `createUserMessage`). Meanwhile the TUI "Queued" sidebar derives from persisted messages with no
+assistant `parentID` (`cli/cmd/tui/routes/session/sidebar.tsx`), so it cannot show the real backlog. The genuine queue
+state is synced to `sync.data.task_queue` (`runtime/headless/projection.ts`) but is **never read by any TUI component**.
+Commit `1656f0c09` moved the memo onto messages, which cannot work for the async model: persisting a message at enqueue
+time would let the running loop re-scan and process it out of band, double-running it on drain.
+
+External and internal references reviewed 2026-06-07:
+
+- **Codex CLI** keeps interactive follow-up queueing lightweight and ephemeral, with two explicit modes — Enter (steer the
+  current turn), Tab (queue the next turn, FIFO), Esc (interrupt / send now). It is not durable.
+  (<https://developers.openai.com/codex/cli/features>, <https://github.com/openai/codex/pull/18542>,
+  <https://github.com/openai/codex/issues/13595>, <https://github.com/openai/codex/issues/9096>)
+- **Codex app / cloud** treats "queue" as multi-task orchestration (parallel sessions/worktrees, a "needs review" queue of
+  completed work, scheduled automations) — the analog of AX Code's Workflow Runtime and scheduled tasks, not in-session
+  message queueing. (<https://developers.openai.com/codex/cloud>, <https://developers.openai.com/codex/app/features>)
+- **ax-code-desktop** already ships the lightweight model: a client-side Zustand queue persisted to localStorage
+  (`messageQueueStore.ts`), chips UI with edit/send/delete (`QueuedMessageChips.tsx`), and `busy/retry → idle` FIFO
+  auto-send via the **normal** `sendMessage` SDK call (`useQueuedMessageAutoSend.ts`). It does not use `prompt_async` or
+  `/task-queue`.
+
+The durable parts of `TaskQueue` are load-bearing for ADR-025 (Workflow Runtime), scheduled tasks
+(`session/scheduled-task.ts`), and crash recovery (`project/bootstrap.ts` → `TaskQueue.recoverInterrupted`), so removing
+the queue wholesale is not viable.
+
+## Decision
+
+AX Code will treat task queueing as **two bounded layers with one source of truth each**, and will **reduce, not remove**,
+the queue:
+
+1. **Interactive follow-up queue = ephemeral, client-owned.** The TUI follow-up queue is a lightweight, in-memory,
+   per-session client buffer, mirroring `ax-code-desktop` and Codex CLI. The "Queued" display reads this buffer. Buffered
+   follow-ups are replayed FIFO via the **synchronous** prompt path on `busy/retry → idle`, reusing the desktop drain
+   guards (in-flight set, recent-abort window, idle re-check, remove-on-success). Plain interactive turns are **not**
+   routed through a durable queue and never create `waiting_for_idle` rows.
+
+2. **Durable orchestration queue = backend-only.** `TaskQueue`, its executor, the `/task-queue` management API, the
+   workflow scheduler, scheduled tasks, and `recoverInterrupted` are retained unchanged as the durable substrate for
+   Workflow Runtime (ADR-025), scheduling, and recovery. The `prompt_async`/`command_async`/`shell_async` routes remain
+   for non-interactive callers (headless runtime, SDK, workflow, scheduled, automation).
+
+3. **No out-of-band processing.** A queued user message is never persisted while a turn is running. Interactive replay
+   happens only when idle, through the normal prompt path.
+
+4. **Two-mode interactive UX.** Provide "queue next turn" (FIFO, default while busy) and "steer now" (inject into the
+   active turn), plus per-item edit / delete / send-now — matching Codex CLI and the desktop chips.
+
+5. **No dead or misleading queue state.** Either consume `sync.data.task_queue` through an explicit (future) durable-tasks
+   panel or remove it from interactive consumption; do not leave it populated-but-unread. Remove the messages-based
+   `queued` memo introduced by `1656f0c09`.
+
+This decision constrains where each queue may be used; the implementation design lives in the tech spec.
+
+## Consequences
+
+### Positive
+
+- Fixes the user-reported "task queue is not working": follow-ups become visible, ordered, editable, and reliably
+  deletable, with no resurrection or double-run.
+- Removes durable rows and async routing from a transient UX concern, simplifying the interactive path.
+- Aligns TUI and desktop behavior, and with the proven Codex CLI model, so users learn one mental model.
+- Preserves the Workflow Runtime / scheduling / recovery substrate without change.
+- Eliminates a dead, misleading store field and a memo that cannot work for the async model.
+
+### Negative / Costs
+
+- Interactive follow-ups become non-durable (lost on TUI restart), matching Codex CLI and desktop. Durable needs must use
+  `TaskQueue` explicitly.
+- Introduces a small TUI follow-up state machine; it must reuse desktop's guards to avoid Codex-style "stuck/duplicate
+  send" edge cases.
+- Two queueing concepts coexist; docs and code must keep the boundary explicit to avoid re-conflation.
+
+### Follow-ups
+
+Landed 2026-06-07 (commit on `feat/tui-follow-up-queue`):
+
+- `follow-up-queue.ts` (pure reducers + status decisions) and `follow-up-queue-store.ts` (reactive singleton, dispatch
+  with in-flight guard, recent-abort suppression, edit channel).
+- Prompt: buffer plain prompts while busy, drain FIFO on busy/retry -> idle, suppress drain right after a manual
+  interrupt; gated by the `prompt_queue_mode` kv flag (default on).
+- Sidebar: "Queued" derives from the client store; per-item delete, send-now, and edit (pop-to-input). The
+  messages-based memo is removed.
+- The durable `task_queue` projection is explicitly documented as retained for the future supervision panel, not the
+  interactive queue (resolves "no populated field unread without intent").
+- Unit tests for the pure module + store; the render guardrail covers the new controls.
+
+Review hardening pass (2026-06-07, code-review high):
+
+- **Edit could be silently dropped** — several `Prompt` instances are mounted at once (session, permission, home), all consuming the global edit-request signal. The consuming effect now clears the request only in the instance it targets, so a non-matching instance can't swallow the edited text (the item was already removed from the queue, so this was real data loss).
+- **Background sessions didn't auto-replay** — the drain now watches every session's status (`reconcileFollowUpDrain` over a snapshot of `session_status`), not just the on-screen session, so a queue replays when its session finishes even while another session is in view. This matches the desktop global auto-send hook. A shared previous-status baseline dedupes across the multiple mounted Prompt instances.
+- **Double-dispatch window closed** — `dispatchFollowUp` now removes the item from the queue while the in-flight guard is still held, eliminating the gap between in-flight release and removal in which the same head could be dispatched twice.
+- **Slash detection de-duplicated** — the busy-submit interception reuses the already-computed `slashName` instead of a third copy of the slash-command lookup.
+
+Consciously accepted (not changed): the module-level singleton store (mirrors the desktop Zustand singleton; a context provider would be heavier with no behavior gain), the ad-hoc `followup-<ts>-<n>` id scheme (ephemeral client ids; `Identifier.ascending` needs a registered prefix), and the `queuedSnippet`/`followUpText` split (queue items don't carry synthetic/ignored text parts, so they don't diverge in practice).
+
+Explicitly deferred (not required by the success metrics; recorded so the boundary stays honest):
+
+- **Steer-now keybindings** (Enter = inject into current turn vs. Tab = queue next turn). The tech spec lists TUI
+  keybinding reconciliation as an open question; send-now already covers "run this one now."
+- **Removing `prompt_async` as the interactive transport.** Idle submits still dispatch via `prompt_async`, which claims
+  and runs immediately (no `waiting_for_idle` row), so the measurable metric holds without a risky transport rewrite.
+- **Optional kv persistence** of the follow-up buffer (currently ephemeral, matching Codex CLI) and the **durable-tasks
+  supervision panel** sourced from `task_queue` (defer to workflow supervision UI under ADR-025).

--- a/.internal/adr/INDEX.md
+++ b/.internal/adr/INDEX.md
@@ -1,0 +1,52 @@
+# Architecture Decision Records
+
+This index tracks the local ADR set for `ax-code`. ADRs are historical decisions, so consolidation normally means
+reclassifying an ADR as runtime-spine, standing foundation, absorbed, or deferred rather than deleting it.
+
+**Maintenance rule:** When adding or updating an ADR, update its row here. Status must reflect the current implementation
+state and its role in the roadmap.
+
+**Last reviewed:** 2026-06-04
+**Market alignment:** Opus 4.8 and Claude Code Dynamic Workflows make Workflow Runtime the current architecture spine.
+
+## Runtime Spine ADRs
+
+| ADR | Title | Status |
+| --- | --- | --- |
+| [ADR-026](ADR-026-opus48-market-response-boundary.md) | Organize the Opus 4.8 market response around Workflow Runtime, not vendor feature cloning | Proposed - umbrella market response boundary |
+| [ADR-027](ADR-027-opencode-low-risk-feature-learning-boundary.md) | Learn low-risk OpenCode and OpenTUI patterns without copying high-risk runtime features | Accepted - supporting feature-learning boundary; OpenTUI, structured error, projection, and metadata foundations landed |
+| [ADR-025](ADR-025-workflow-runtime-boundary.md) | Make Dynamic Workflow Runtime a bounded orchestration boundary | Proposed - P0 market alignment boundary |
+| [ADR-028](ADR-028-task-queue-layering-boundary.md) | Separate interactive follow-up queueing from the durable task queue | Proposed - supporting interactive UX boundary; reduce-not-remove the queue |
+| [ADR-006](ADR-006-v5-agent-control-plane.md) | Make Agent Control Plane the v5 autonomous architecture foundation | Partially implemented; now supplies policy and safety under Workflow Runtime |
+| [ADR-005](ADR-005-subagent-orchestration.md) | Subagent orchestration via explicit dispatcher with parallel Task fan-out | Accepted; lower-level fan-out primitive absorbed under ADR-025 |
+| [ADR-004](ADR-004-autonomous-mode-hardening.md) | Harden autonomous mode with confidence-aware escalation, blast-radius caps, and a critic pass | Accepted; required safety policy for long workflows |
+| [ADR-012](ADR-012-autonomous-continuation-contracts.md) | Make autonomous continuation prompts and terminal semantics explicit contracts | Accepted; informs workflow continuation and compact synthesis |
+| [ADR-013](ADR-013-qwen37-max-cloud-agent-backend.md) | Treat Qwen3.7-Max as a premium cloud-agent backend, not a Qwen-specific runtime architecture | Accepted; provider-neutral premium workflow policy now also applies to Opus 4.8 |
+| [ADR-014](ADR-014-durable-session-goals.md) | Treat `/goal` as durable session state | Accepted; goals become workflow objectives and stop conditions |
+| [ADR-016](ADR-016-agent-routing-architecture.md) | Agent routing is keyword-only; no LLM tier, intent gates, or delegation modes | Accepted; workflow planner/model policy owns multi-agent routing |
+| [ADR-019](ADR-019-graph-first-agent-context-boundary.md) | Make Graph-First Agent Context a Product Boundary | Accepted; implementation shipped; now context substrate for workflows |
+| [ADR-022](ADR-022-codex-like-desktop-app-from-openchamber-baseline.md) | Build a Codex-Like Desktop App from an OpenChamber Product Baseline | Accepted; staged implementation underway; workflow supervision is the next competitive surface |
+| [ADR-023](ADR-023-remote-surface-security-gates.md) | Gate Remote Surfaces Behind Separate Security Reviews | Accepted; required before routine/webhook/remote workflow surfaces |
+| [ADR-008](ADR-008-server-operation-mode-boundary.md) | Define Server Operation Mode Boundaries | Accepted; implementation pending; required for API and remote routines |
+
+## Standing Foundation ADRs
+
+| ADR | Title | Status |
+| --- | --- | --- |
+| [ADR-002](ADR-002-distribution-source-plus-bun.md) | Distribute source + Bun runtime instead of `bun build --compile` binary | Accepted |
+| [ADR-003](ADR-003-opentui-bun-mainline-hardening.md) | Keep OpenTUI and Bun as the mainline runtime and harden them directly | Accepted |
+| [ADR-007](ADR-007-headless-agent-runtime-boundary.md) | Establish a Headless Agent Runtime Boundary | Accepted |
+| [ADR-009](ADR-009-package-organization-boundary-hardening.md) | Harden Package Organization Boundaries Before Splitting Packages | Accepted; implemented |
+| [ADR-010](ADR-010-alibaba-thinking-shape-and-budget-clamping.md) | Alibaba Thinking Shape and Budget Clamping | Accepted |
+| [ADR-011](ADR-011-tui-session-tool-renderer-boundary.md) | Make TUI Session Tool Rendering a Named Boundary | Accepted; initial extraction implemented |
+| [ADR-015](ADR-015-session-prompt-module-boundary.md) | Extract pure logic from session/prompt.ts into focused prompt-* modules | Accepted; extraction in progress |
+| [ADR-017](ADR-017-effect-framework-freeze.md) | Freeze Effect framework usage at v2.11.0 boundaries | Accepted; enforced by CI |
+| [ADR-018](ADR-018-app-headless-sdk-boundary.md) | Promote Headless SDK as the Short-Term App Backend Boundary | Accepted; foundation implemented |
+| [ADR-020](ADR-020-mcp-security-trust-boundary.md) | Make MCP Security a Trust-Boundary Contract | Accepted; implemented |
+| [ADR-021](ADR-021-html-dev-browser-boundary.md) | Establish HTML Dev Browser Boundary via Playwright MCP and Behavioral Policy | Accepted; implemented |
+
+## Deferred ADRs
+
+| ADR | Title | Status |
+| --- | --- | --- |
+| [ADR-024](ADR-024-skill-evaluation-optimization-boundary.md) | Make Skill Evaluation and Optimization an Offline Boundary | Proposed; defer implementation behind Workflow Runtime traces |

--- a/.internal/prd/INDEX.md
+++ b/.internal/prd/INDEX.md
@@ -1,0 +1,75 @@
+# Product Requirement Documents
+
+This index tracks the local planning set for `ax-code`. It intentionally separates market-priority work from supporting,
+deferred, implemented, and strategy documents so old plans do not obscure the current product direction.
+
+**Maintenance rule:** When editing any PRD, update its row here. Implemented PRDs should move to Archive Candidates until
+they are deleted or moved to `.internal/archive/`.
+
+**Last reviewed:** 2026-06-04
+**Market alignment:** Opus 4.8 and Claude Code Dynamic Workflows make Workflow Runtime the near-term roadmap spine. See
+[Planning Consolidation: Opus 4.8 and Dynamic Workflow Market Alignment](PLAN-2026-05-29-opus48-planning-consolidation.md).
+
+---
+
+## Market Priority PRDs
+
+| PRD | Status | Phase | Last Reviewed | Done When |
+| --- | --- | --- | --- | --- |
+| [Opus 4.8 Market Response Program](PRD-2026-05-29-opus48-market-response.md) | Draft - umbrella P0 proposal | Program PRD, ADR, and implementation plan created | 2026-05-29 | Workflow Runtime MVP, supervision surfaces, routine trigger design, effort/model policy, and verified bug sweep evaluation are complete |
+| [Workflow Runtime](PRD-2026-05-29-workflow-runtime.md) | Draft - P0 proposal | ADR, PRD, and implementation plan created; implementation not started | 2026-05-29 | Feature-flagged workflow runtime can run a verified bug sweep with durable phase/agent/budget/evidence state |
+| [Codex-Like AX Code Desktop App](PRD-2026-05-28-codex-like-desktop-app.md) | Draft - implementation underway | Continue, but prioritize Workflow Runtime supervision surfaces over broad UI expansion | 2026-05-29 | First-party desktop app beta starts/attaches to local backend and supervises workflow, queue, review, approval, and evidence state |
+| [v5 Agent Control Plane](PRD-v5-agent-control-plane.md) | In progress - supporting runtime policy | Shadow mode complete; runtime enforcement remains support work for Workflow Runtime | 2026-05-29 | ExecutionController governs workflow budgets, permissions, goals, stops, and completion gates at runtime parity |
+| [Server Mode Hardening](PRD-server-mode-hardening.md) | Draft - supporting security work | Required before API/webhook routine surfaces move beyond local preview | 2026-05-29 | ADR-008 implementation phases 1-5 all landed and verified |
+| [Remote Surface Security Gates](PRD-2026-05-28-remote-surface-security-gates.md) | Draft - gated follow-up | Keep remote hosts, tunnels, PWA network access, and VS Code embedded surfaces disabled until reviewed | 2026-05-29 | Each remote surface has accepted security review before implementation or remains disabled |
+
+---
+
+## Deferred Or Supporting PRDs
+
+| PRD | Status | Why It Is Not P0 |
+| --- | --- | --- |
+| [Low-Risk OpenCode and OpenTUI Learning](PRD-2026-06-04-opencode-low-risk-feature-learning.md) | Draft - supporting product scope; OpenTUI, structured error, projection, and metadata foundations landed | Converts OpenCode release learnings and OpenTUI runtime guidance into app/API/review/TUI hardening while deferring high-risk runtime, provider, remote, autonomy, and snapshot dependency topics |
+| [Task Queue Layering](PRD-2026-06-07-task-queue-layering.md) | Draft - proposal; root cause confirmed (ADR-028) | Interactive UX fix that reduces (not removes) the queue: keep durable `TaskQueue` for workflow/scheduled/automation/recovery, move interactive follow-ups to a lightweight ephemeral client queue aligned with ax-code-desktop and Codex CLI |
+| [Skill Evaluation and Optimization](PRD-2026-05-29-skill-evaluation-optimization.md) | Draft - defer behind Workflow Runtime | Workflow traces and verification artifacts should become the eval substrate before skill optimization ships |
+| [Stability Audit Remediation](PRD-2026-05-17-stability-audit-remediation.md) | Operational remediation open | Important engineering hygiene, but not the market catch-up spine |
+| [Source + Bun Distribution Rollout](PRD-source-bun-distribution.md) | Operational release work | Release channel stability remains necessary but is not an Opus 4.8 feature response |
+
+---
+
+## Archive Candidates
+
+These PRDs or implementation plans are implemented or absorbed. Keep them discoverable until a separate cleanup moves
+them to `.internal/archive/` or removes them from the active tree.
+
+| Document | Status | Consolidation |
+| --- | --- | --- |
+| [App Headless SDK Foundation](PRD-2026-05-25-app-headless-sdk-foundation.md) | Implemented | Foundation for app/workflow routes |
+| [Graph-First Agent Context](PRD-2026-05-26-graph-first-agent-context.md) | Implemented | Future graph expansion belongs in Workflow Runtime context-packing phases |
+| [MCP Security Layer Hardening](PRD-2026-05-26-mcp-security-layer-hardening.md) | Implemented | Standing trust boundary for workflow child agents |
+| [HTML Dev Browser Integration](PRD-2026-05-26-html-dev-browser-integration.md) | Implemented | Browser verification becomes a workflow/template capability |
+| [HTML Dev Browser Implementation Plan](PLAN-html-dev-browser-integration.md) | Implemented | Archive with the HTML Dev Browser PRD |
+
+---
+
+## Active Implementation Plans
+
+| Plan | Status | Notes |
+| --- | --- | --- |
+| [Low-Risk OpenCode and OpenTUI Learning Implementation Plan](PLAN-2026-06-04-opencode-opentui-learning-implementation.md) | Draft - OpenTUI, structured error, projection, and metadata foundations complete; review models next | Phased execution plan for structured errors, event projection fixtures, metadata schemas, review view models, desktop diagnostics, and future OpenTUI upgrade gates |
+| [Low-Risk OpenCode and OpenTUI Learning Tech Spec](TECH-SPEC-2026-06-04-opencode-low-risk-feature-learning.md) | Draft - OpenTUI, structured error, projection, and metadata foundations implemented | Technical sequencing for structured errors, event projection fixtures, session metadata schemas, review view models, desktop diagnostics, and OpenTUI upgrade validation |
+| [Task Queue Layering Tech Spec](TECH-SPEC-2026-06-07-task-queue-layering.md) | Draft - design for ADR-028 | Ephemeral client-side interactive follow-up queue (Option A) + retain durable `TaskQueue` for orchestration; migration, test plan, open questions |
+| [Workflow Runtime Implementation Plan](PLAN-2026-05-29-workflow-runtime-implementation.md) | Draft - P0 next | Main near-term implementation plan |
+| [Opus 4.8 Market Response Implementation Plan](PLAN-2026-05-29-opus48-market-response-implementation.md) | Draft - umbrella plan | Program-level sequencing across workflow runtime, supervision, routines, effort policy, and evaluation |
+| [Codex-Like Desktop App Implementation Plan](PLAN-2026-05-28-codex-like-desktop-app-implementation.md) | Draft - active implementation | Continue as app tracker, with Workflow Runtime supervision as the competitive priority |
+| [Opus 4.8 Planning Consolidation](PLAN-2026-05-29-opus48-planning-consolidation.md) | Draft - local planning review | PRD/ADR disposition review and roadmap consolidation |
+
+---
+
+## Strategy Documents
+
+| Document | Status | Last Reviewed | Summary |
+| --- | --- | --- | --- |
+| [Debug, Refactor, and QA Competitive Closeout](PRD-debug-refactor-qa-competitive-closeout.md) | Accepted direction | 2026-05-29 | Defines AX Code as both coding agent and assurance agent. New assurance implementation should flow through verified workflows and evidence gates. |
+
+---

--- a/.internal/prd/PRD-2026-06-07-task-queue-layering.md
+++ b/.internal/prd/PRD-2026-06-07-task-queue-layering.md
@@ -1,0 +1,151 @@
+# PRD: Task Queue Layering — Separate Durable Orchestration from Interactive Follow-up Queueing
+
+**Date:** 2026-06-07
+**Status:** Implemented 2026-06-07 (interactive follow-up queue); steer-now keybindings, `prompt_async` transport
+removal, kv persistence, and the durable-tasks panel explicitly deferred (see ADR-028 Follow-ups)
+**Scope:** Internal
+**Owner:** ax-code maintainers
+**Related:** ADR-028, ADR-025 (Workflow Runtime boundary), ADR-022 (Codex-like desktop app), ADR-018 (app/headless SDK boundary),
+`.internal/prd/TECH-SPEC-2026-06-07-task-queue-layering.md`
+**Archive criteria:** Archive when the interactive follow-up queue ships as a lightweight ephemeral model in the TUI, the
+broken messages-based "Queued" display is removed, and the durable `TaskQueue` is documented as a backend-only
+orchestration primitive — or when this direction is explicitly rejected with implementation evidence.
+
+---
+
+## Purpose
+
+Decide whether to remove or reduce AX Code's task queue, and define the right shape for "queue work while the agent is
+busy." The conclusion is **reduce, not remove**: keep the durable server-owned `TaskQueue` as a backend orchestration
+primitive, and replace the heavyweight, currently-broken interactive queue path with a lightweight, ephemeral,
+client-side follow-up queue aligned with `ax-code-desktop` and Codex CLI.
+
+## Problem
+
+AX Code conflates two very different concerns under one mechanism:
+
+1. **Interactive follow-up queueing** — a user types another message while the current turn is running and expects it to
+   run next. This is a per-session, ephemeral UX concern.
+2. **Durable task orchestration** — workflow subagent fan-out, phase parallelism, pacing/budget, scheduled tasks,
+   automations, and crash recovery. This is a backend, durable, multi-item concern.
+
+Today both go through the same durable `TaskQueue`:
+
+- The TUI submits **every** interactive prompt through the async route
+  (`packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx` → `prompt_async`/`command_async`/`shell_async`).
+- The server handler enqueues a durable queue item and starts the executor
+  (`packages/ax-code/src/server/routes/session.ts` `startAsyncSessionHandler` → `TaskQueue.enqueue` +
+  `TaskQueueExecutor.start`).
+- Items submitted while busy become `waiting_for_idle` queue rows
+  (`packages/ax-code/src/session/task-queue-executor.ts` `shouldWaitForIdle`), and the **user message is not persisted
+  until the item executes** (creation happens inside `SessionPrompt.prompt` → `createUserMessage`).
+
+The TUI's "Queued" sidebar section is derived from **persisted messages without an assistant parent**
+(`packages/ax-code/src/cli/cmd/tui/routes/session/sidebar.tsx`, the `queued` memo). Because truly-queued
+(`waiting_for_idle`) items have no persisted message yet, the section cannot show the real backlog. The actual queue
+state is synced to the TUI store as `sync.data.task_queue`
+(`packages/ax-code/src/runtime/headless/projection.ts`, `sync-store-event.ts`, `sync-state.ts`) but is **never read by
+any TUI component**. A recent fix (`1656f0c09`) moved the memo onto messages, which cannot work for the async-queue model
+because persisting a message at enqueue time would let the running loop re-scan and process it out of band, double-running
+it on drain.
+
+Net effect: the user-facing queue is over-engineered (durable rows, statuses, positions for a transient UX) and visibly
+broken, while the parts of `TaskQueue` that matter — workflows, scheduled tasks, automations, recovery — are legitimate
+and must be preserved.
+
+## Research Inputs
+
+Reviewed 2026-06-07.
+
+- **Codex CLI** (local TUI): lightweight, in-memory, ephemeral follow-up queue with two explicit modes — **Enter** injects
+  into the current turn (steer), **Tab** queues a follow-up (text / slash / `!` shell) for the next turn (FIFO), **Esc**
+  interrupts / sends immediately. The queue is not durable (it is cleared on agent switch). Sources:
+  - <https://developers.openai.com/codex/cli/features>
+  - <https://github.com/openai/codex/pull/18542> (queue slash/shell prompts in the TUI)
+  - <https://github.com/openai/codex/issues/13595> (Enter = immediate, Tab = queue)
+  - <https://github.com/openai/codex/issues/9096> (queue new instructions instead of interrupting)
+- **Codex app / cloud**: the "queue" is multi-task orchestration, not in-session message queueing — multiple
+  threads/agents, parallel tasks via worktrees, a **"needs review" queue** of completed results, and scheduled
+  automations. Sources:
+  - <https://developers.openai.com/codex/cloud>
+  - <https://developers.openai.com/codex/app/features>
+- **ax-code-desktop** (`/Users/akiralam/code/ax-code-desktop`): already ships a lightweight client-side message queue —
+  Zustand store persisted to localStorage (`packages/ui/src/stores/messageQueueStore.ts`), chips UI with per-item
+  edit/send/delete (`packages/ui/src/components/chat/QueuedMessageChips.tsx`), and idle auto-send via the **normal**
+  `sendMessage()` SDK call on `busy/retry → idle` (`packages/ui/src/hooks/useQueuedMessageAutoSend.ts`). It does **not**
+  use `prompt_async` or `/task-queue`.
+
+Local AX Code context:
+
+- ADR-025 makes the Workflow Runtime the durable-orchestration spine; `TaskQueue` is its execution substrate
+  (`workflow/scheduler.ts` enqueues children; phase parallelism and pacing live in the executor).
+- Scheduled tasks enqueue durable items (`packages/ax-code/src/session/scheduled-task.ts`).
+- Crash recovery requeues interrupted items at boot (`packages/ax-code/src/project/bootstrap.ts` →
+  `TaskQueue.recoverInterrupted`).
+- ADR-022 keeps desktop renderer state reconstructable from backend state; ADR-018 keeps app/TUI on typed SDK/projection
+  contracts.
+
+## Goals
+
+1. Resolve the user-reported "task queue is not working" by giving interactive follow-up queueing a single, correct data
+   source and a working display.
+2. Preserve durable `TaskQueue` for workflow, scheduled-task, automation, and recovery use.
+3. Stop routing ordinary interactive turns through a durable queue when a lightweight model is sufficient.
+4. Adopt the proven two-mode UX (steer now vs. queue next turn) with per-item edit / delete / send-now.
+5. Keep one authoritative queue source per layer; remove the dead `sync.data.task_queue` path or wire it intentionally.
+6. Align TUI and desktop behavior so the two clients teach users the same mental model.
+
+## Non-Goals
+
+- Removing or rewriting the Workflow Runtime, scheduled tasks, automations, or crash recovery.
+- Building Codex-cloud-style multi-session parallel orchestration or a "needs review" queue inside a single TUI session.
+- Introducing remote/transport surfaces (still gated by ADR-023).
+- Any new Effect usage (ADR-017).
+
+## Users and Use Cases
+
+- **Interactive user (TUI/desktop):** "While Claude is working, let me line up the next instruction(s), see them, edit or
+  cancel them, optionally push one to run now, and have them run in order when the turn finishes." → lightweight ephemeral
+  queue.
+- **Workflow/automation author:** "Fan out N subagents with phase parallelism, pacing, and budgets; survive a restart." →
+  durable `TaskQueue` (unchanged).
+- **Scheduler:** "Enqueue a prompt to run later / on a cron." → durable `TaskQueue` (unchanged).
+
+## Proposed Direction
+
+**Two layers, one source of truth each.**
+
+1. **Interactive follow-up queue (reduce):** Make the TUI follow-up queue lightweight, ephemeral, and client-owned, mirror
+   the desktop model — buffer pending follow-ups in renderer state, render them from that buffer, and replay them via the
+   ordinary synchronous prompt path on `busy/retry → idle`. Remove the messages-based `queued` memo and the per-prompt
+   `prompt_async → TaskQueue` routing for plain interactive turns.
+2. **Durable orchestration queue (keep):** Reserve `TaskQueue` for workflow children, scheduled tasks, automations, and
+   recovery. Its synced `task_queue` projection is either consumed by an explicit (future) "background tasks" panel or
+   removed from the interactive store to avoid a dead, misleading field.
+3. **Two-mode UX:** "Queue next turn" (FIFO, default while busy) and "Steer now" (inject into the active turn), plus
+   per-item edit / delete / send-now, matching Codex CLI and the desktop chips.
+
+The technical design, options, and trade-offs are in the tech spec; the boundary decision is recorded in ADR-028.
+
+## Success Metrics / Done When
+
+- [done] Submitting follow-up messages while busy shows them immediately in the TUI, in order, with edit/delete/send-now,
+  and they run FIFO when the session goes idle.
+- [done] Deleting a queued follow-up reliably prevents it from running (no resurrection, no double-run).
+- [done] Plain interactive turns no longer create durable `waiting_for_idle` rows (follow-ups are buffered client-side;
+  idle dispatch claims and runs immediately rather than parking a waiting row).
+- [done] `TaskQueue` continues to drive workflow/scheduled/automation/recovery with no regression in their tests.
+- [done] No populated queue field goes unread without intent: `sync.data.task_queue` is documented as the durable
+  supervision projection (ADR-025), and the interactive "Queued" section reads the client store.
+
+Implementation note (2026-06-07): landed on `feat/tui-follow-up-queue`. See ADR-028 Follow-ups for the file list and the
+explicitly-deferred items (steer-now keybindings, `prompt_async` transport removal, kv persistence, durable-tasks panel).
+
+## Risks
+
+- **Behavioral divergence during migration:** while both paths exist, ordering/visibility could differ. Mitigate by
+  landing the TUI follow-up queue and removing the async-per-prompt routing in the same change.
+- **Loss of durability for follow-ups:** ephemeral follow-ups are lost on crash/restart. This matches Codex CLI and
+  desktop and is acceptable for transient input; durable needs stay on `TaskQueue`.
+- **Hidden dependencies on `prompt_async`:** other clients (headless runtime, SDK) may rely on the async route; keep the
+  route for those callers and only change the interactive TUI submission policy.

--- a/.internal/prd/TECH-SPEC-2026-06-07-task-queue-layering.md
+++ b/.internal/prd/TECH-SPEC-2026-06-07-task-queue-layering.md
@@ -1,0 +1,169 @@
+# Tech Spec: Task Queue Layering
+
+**Date:** 2026-06-07
+**Status:** Implemented 2026-06-07 (Option A) - interactive follow-up queue landed; deferred items recorded in
+ADR-028 Follow-ups
+**Scope:** Internal technical design
+**Related:** `.internal/prd/PRD-2026-06-07-task-queue-layering.md`, ADR-028, ADR-025, ADR-022, ADR-018, ADR-017
+
+---
+
+## Summary
+
+Split AX Code's single durable task queue into two clearly-bounded layers:
+
+1. an **ephemeral interactive follow-up queue** owned by the client (TUI), mirroring the shipped `ax-code-desktop` model
+   and Codex CLI; and
+2. the existing **durable `TaskQueue`** reserved for workflow children, scheduled tasks, automations, and crash recovery.
+
+The interactive queue stops flowing through `prompt_async → TaskQueue` and stops being derived from persisted messages.
+This both fixes the broken "Queued" display and removes durable rows from a transient UX concern. The durable queue and
+its subsystems are unchanged.
+
+## Current AX Code Substrate
+
+Interactive submission and display:
+
+- `packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx` — every interactive submit calls `submitAsyncRoute` with
+  `prompt_async` / `command_async` / `shell_async`; `settlePromptLocally` clears input but does **not** insert an
+  optimistic message.
+- `packages/ax-code/src/server/routes/session.ts` — `startAsyncSessionHandler` enqueues a `TaskQueue` item and calls
+  `TaskQueueExecutor.start`, returning `202` before the turn runs.
+- `packages/ax-code/src/cli/cmd/tui/routes/session/sidebar.tsx` — the `queued` memo lists user messages with no assistant
+  `parentID`. This is the wrong source: `waiting_for_idle` items have no message yet.
+- `packages/ax-code/src/cli/cmd/tui/routes/session/index.tsx` — `UserMessage` marks a "queued" badge using
+  `pending` (`messages().findLast(assistant && !time.completed)?.id`) and `message.id > pending`.
+- `packages/ax-code/src/runtime/headless/projection.ts`, `context/sync-store-event.ts`, `context/sync-state.ts` —
+  `task.queue.created/updated/deleted` events maintain `sync.data.task_queue`, which **no TUI component reads**.
+
+Durable queue and its consumers (keep):
+
+- `packages/ax-code/src/session/task-queue.ts` — durable rows: `status` (`queued`, `waiting_for_idle`, `running`,
+  `blocked_permission`, `blocked_question`, `paused`, `failed`, `completed`, `cancelled`), `position`, `priority`,
+  payload; `enqueue`, `claimForExecution`, `recoverInterrupted`, `reorder`, `sendNow`, etc.
+- `packages/ax-code/src/session/task-queue-executor.ts` — `start`, `drainNextForSession`, `shouldWaitForIdle`,
+  workflow phase parallelism (`shouldWaitForWorkflowPhaseSlot`), pacing (`workflowPacingWaitMs`), and detached execution.
+- `packages/ax-code/src/workflow/scheduler.ts` — enqueues workflow children.
+- `packages/ax-code/src/session/scheduled-task.ts` — enqueues scheduled prompts.
+- `packages/ax-code/src/project/bootstrap.ts` — `TaskQueue.recoverInterrupted` at boot.
+- `packages/ax-code/src/server/routes/task-queue.ts` — full management API (list/get/status/pause/resume/cancel/retry/
+  send-now/reorder/delete).
+
+Reference implementation already shipped in desktop:
+
+- `ax-code-desktop/packages/ui/src/stores/messageQueueStore.ts` (Zustand, per-session, localStorage, `queueModeEnabled`).
+- `ax-code-desktop/packages/ui/src/components/chat/QueuedMessageChips.tsx` (edit / send / delete chips).
+- `ax-code-desktop/packages/ui/src/hooks/useQueuedMessageAutoSend.ts` (`busy/retry → idle` FIFO auto-send via normal
+  `sendMessage`, captured send config, in-flight + recent-abort guards).
+
+## Design Principles
+
+1. **One source of truth per layer.** Interactive queue reads its own client buffer; durable queue reads `task_queue`.
+2. **Ephemeral by default for interactive input.** Follow-ups are transient; durability stays on `TaskQueue`.
+3. **No out-of-band processing.** Never persist a queued user message while a turn is running (the loop would re-scan and
+   double-run it on drain). Replay through the normal prompt path only when idle.
+4. **Contract reuse.** Interactive replay uses the existing synchronous `/prompt` path; durable needs use existing
+   `/task-queue` and `prompt_async` routes (kept for non-interactive callers).
+5. **No new Effect** (ADR-017); async/await + Zod + `Result`/`try-catch` at boundaries.
+6. **Cross-client parity.** TUI follow-up semantics match desktop so users learn one model.
+
+## Options Considered
+
+### Option A — Lightweight client-side interactive queue (recommended)
+
+Mirror desktop in the TUI. Buffer follow-ups in renderer state (a session-scoped signal/store), render the "Queued"
+section from that buffer, and replay FIFO via the synchronous prompt path on `busy/retry → idle`. Plain interactive turns
+call `/prompt` directly (or `prompt_async` only for the *first* dispatch), never creating `waiting_for_idle` rows for
+manually-typed follow-ups.
+
+- **Pros:** matches shipped desktop + Codex CLI; removes the broken memo and dead `task_queue` read; minimal backend
+  change; no double-run risk; cheap edit/delete/send-now.
+- **Cons:** follow-ups are not durable across restart; introduces a small TUI state machine (must reuse desktop's
+  in-flight/recent-abort guards to avoid known Codex-style "stuck/duplicate send" bugs).
+
+### Option B — Make the TUI read the durable queue
+
+Keep `prompt_async → TaskQueue`, but render the "Queued" section from `sync.data.task_queue`
+(`status ∈ {queued, waiting_for_idle}`, session-scoped, ordered by `position`), wire delete to
+`POST /task-queue/:id/cancel`, send-now to `/task-queue/:id/send-now`, reorder to `/task-queue/:id/reorder`, and load the
+initial list on session open.
+
+- **Pros:** durable follow-ups; reuses the full management API; single backend queue.
+- **Cons:** heavyweight for transient input; diverges from desktop; requires snippet rendering from item payload, bootstrap
+  fetch, and careful lifecycle wiring (delete must cancel the row, not just remove a message); keeps every keystroke-turn
+  on durable rows.
+
+### Option C — Remove interactive queueing entirely
+
+Drop the "Queued" UI; messages typed while busy are rejected or steer the current turn only.
+
+- **Rejected:** regresses a real, expected UX that both Codex and desktop support.
+
+**Decision (see ADR-028):** Option A for interactive follow-ups; retain `TaskQueue` for durable orchestration. Option B's
+machinery is preserved for a future explicit "background/durable tasks" panel, not the interactive follow-up section.
+
+## Detailed Design (Option A)
+
+### Client state
+
+- A session-scoped follow-up buffer in TUI state (parallel to desktop's `messageQueueStore`): ordered list of
+  `{ id, parts, agent, model, variant, createdAt }`. Ephemeral (in-memory; optional kv persistence later).
+- A `queueModeEnabled`-equivalent and a "steer vs queue" submit decision in the prompt component.
+
+### Submit flow
+
+1. On submit while `sessionPhase !== 'idle'` and queue-mode/queue-key active → push to the buffer (do **not** hit the
+   server).
+2. On submit while idle → dispatch immediately via `/prompt`.
+3. **Steer now** (Codex `Enter`-equivalent) → dispatch immediately (server appends to the active turn via the existing
+   loop re-scan; no buffer entry).
+4. **Queue next turn** (Codex `Tab`-equivalent) → push to buffer.
+
+### Drain flow
+
+- Subscribe to session status; on `busy/retry → idle`, pop the head of the buffer and dispatch via `/prompt` using the
+  captured send config. Reuse desktop guards: per-session in-flight set, recent-abort window, idle re-check before send,
+  remove-on-success. This directly mirrors `useQueuedMessageAutoSend.ts`.
+
+### Display
+
+- Replace the `queued` memo in `sidebar.tsx` with a read of the client buffer (snippet from buffered parts; count;
+  expand/collapse unchanged).
+- `dropQueued(id)` removes the buffer entry (no server call). Add send-now (dispatch immediately + remove) and edit
+  (pop back to input).
+- Reconcile the in-conversation "queued" badge in `index.tsx`/`view-model.ts` with the same buffer concept, or scope it to
+  the brief pre-assistant window only.
+
+### Backend changes
+
+- Interactive TUI no longer routes plain follow-ups through `prompt_async`. The async route and `/task-queue` API remain
+  for headless runtime, SDK, workflow, scheduled, and automation callers.
+- Either delete `task_queue` from the interactive sync store/projection consumption or keep it strictly for a future
+  durable-tasks panel; do not leave it populated-but-unread.
+
+## Migration / Rollout
+
+1. Land the TUI follow-up buffer + drain + display, and switch interactive submission off `prompt_async`, in one change to
+   avoid mixed-source ordering.
+2. Keep `TaskQueue`, executor, `/task-queue` routes, scheduler, scheduled-task, and recovery untouched.
+3. Remove or quarantine the dead `task_queue` interactive read.
+4. Revert/remove the messages-based `queued` memo from `1656f0c09`.
+
+## Test Plan
+
+- Unit: follow-up buffer ops (add/remove/pop/clear/order); steer-vs-queue decision; drain dispatch decision
+  (`busy/retry → idle`, idle re-check, recent-abort, in-flight) — port the desktop `useQueuedMessageAutoSend.test.ts`
+  cases.
+- Integration: submit-while-busy shows buffered item; FIFO drain on idle; delete prevents run; send-now runs immediately;
+  no `waiting_for_idle` rows created for interactive follow-ups.
+- Regression: existing `task-queue.test.ts`, `task-queue-routes.test.ts`, workflow phase/pacing, scheduled-task, and
+  `recoverInterrupted` tests stay green.
+- Guard: assert no TUI component reads an unpopulated queue field and no populated field is unread without intent.
+
+## Open Questions
+
+- Should interactive follow-ups gain optional kv persistence (survive TUI restart) like desktop's localStorage, or stay
+  fully ephemeral like Codex CLI? Default: ephemeral, with kv as a later opt-in.
+- Do we expose a separate "background/durable tasks" panel sourced from `task_queue` now, or defer until workflow
+  supervision UI lands (ADR-025)? Default: defer; remove the dead read meanwhile.
+- Keybindings for steer-vs-queue in the TUI (Codex uses Enter/Tab/Esc); reconcile with existing AX Code TUI bindings.

--- a/packages/ax-code/src/cli/cmd/tui/component/prompt/follow-up-queue-store.ts
+++ b/packages/ax-code/src/cli/cmd/tui/component/prompt/follow-up-queue-store.ts
@@ -28,10 +28,12 @@ const inflight = new Set<string>()
 const abortAt = new Map<string, number>()
 let counter = 0
 
-// Client-only "edit" channel: the sidebar removes a queued follow-up and asks
-// the prompt composer (which owns the textarea ref) to load its text back for
-// editing. A new object each request retriggers the prompt's consuming effect.
-const [editRequest, setEditRequest] = createSignal<{ sessionID: string; text: string } | undefined>()
+// Client-only "edit" channel: the sidebar asks the prompt composer (which owns
+// the textarea ref) to load a queued follow-up's text back for editing. The
+// composer removes the item from the queue only once the text actually lands,
+// so a dropped request never loses the message. A new object each request
+// retriggers the prompt's consuming effect.
+const [editRequest, setEditRequest] = createSignal<{ sessionID: string; id: string; text: string } | undefined>()
 
 /** Reactive accessor — read inside a tracking scope to subscribe to changes. */
 export function followUpQueue(sessionID: string): QueuedFollowUp[] {
@@ -69,6 +71,17 @@ export function clearFollowUpQueue(sessionID: string): void {
   )
 }
 
+/**
+ * Forget all client state for a session that no longer exists (deleted/forked
+ * away). Prevents the queue, drain baseline, and abort marks from leaking — and
+ * stops a recreated id from inheriting a stale baseline and mis-draining.
+ */
+export function forgetFollowUpSession(sessionID: string): void {
+  clearFollowUpQueue(sessionID)
+  previousStatusBySession.delete(sessionID)
+  abortAt.delete(sessionID)
+}
+
 export function markFollowUpAbort(sessionID: string, now: number = Date.now()): void {
   abortAt.set(sessionID, now)
 }
@@ -78,13 +91,13 @@ export function hasRecentFollowUpAbort(sessionID: string, now: number = Date.now
   return at !== undefined && now - at < RECENT_ABORT_WINDOW_MS
 }
 
-/** Ask the prompt composer to load `text` for editing (see sidebar edit control). */
-export function requestFollowUpEdit(sessionID: string, text: string): void {
-  setEditRequest({ sessionID, text })
+/** Ask the prompt composer to load a queued item's `text` for editing (sidebar edit control). */
+export function requestFollowUpEdit(sessionID: string, id: string, text: string): void {
+  setEditRequest({ sessionID, id, text })
 }
 
 /** Reactive accessor for a pending edit request — consumed by the prompt composer. */
-export function followUpEditRequest(): { sessionID: string; text: string } | undefined {
+export function followUpEditRequest(): { sessionID: string; id: string; text: string } | undefined {
   return editRequest()
 }
 
@@ -148,12 +161,23 @@ export function reconcileFollowUpDrain(
 ): void {
   for (const [sessionID, currentType] of snapshot) {
     const previous = previousStatusBySession.get(sessionID)
-    previousStatusBySession.set(sessionID, currentType)
-    if (previous === undefined) continue
-    if (!shouldDrainOnIdle(previous, currentType)) continue
-    if (hasRecentFollowUpAbort(sessionID)) continue
+    if (previous === undefined) {
+      previousStatusBySession.set(sessionID, currentType)
+      continue
+    }
+    if (!shouldDrainOnIdle(previous, currentType)) {
+      previousStatusBySession.set(sessionID, currentType)
+      continue
+    }
+    // busy/retry -> idle edge. If a dispatch for this session is already in
+    // flight (e.g. a manual send-now), do NOT consume the edge: keep the
+    // baseline so the next status change retries, rather than stranding the
+    // head with no future transition to drain it.
     const head = headFollowUp(queues[sessionID])
+    if (head && !hasRecentFollowUpAbort(sessionID) && inflight.has(sessionID)) continue
+    previousStatusBySession.set(sessionID, currentType)
     if (!head) continue
+    if (hasRecentFollowUpAbort(sessionID)) continue
     void dispatchFollowUp(sdk, sessionID, head).catch((error) => onError?.(sessionID, error))
   }
 }

--- a/packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx
@@ -41,8 +41,10 @@ import {
   clearFollowUpEdit,
   enqueueFollowUp,
   followUpEditRequest,
+  forgetFollowUpSession,
   markFollowUpAbort,
   reconcileFollowUpDrain,
+  removeQueuedFollowUp,
 } from "./follow-up-queue-store"
 import { createStore, produce } from "solid-js/store"
 import { useKeybind } from "@tui/context/keybind"
@@ -433,11 +435,33 @@ export function Prompt(props: PromptProps) {
       // non-matching instance could clear the request before the right one
       // applies it, silently dropping the user's edited text.
       if (request.sessionID !== props.sessionID) return
+      // Remove from the queue only once the text actually lands in the composer,
+      // so a request that arrives while the input is unavailable doesn't lose
+      // the message (it stays queued and can be edited again).
       if (input && !input.isDestroyed) {
         input.insertText(request.text)
         requestInputLayoutRefresh({ gotoBufferEnd: true })
+        removeQueuedFollowUp(request.sessionID, request.id)
       }
       clearFollowUpEdit()
+    })
+  })
+
+  // Forget client follow-up state for sessions that no longer exist so queues,
+  // drain baselines, and abort marks don't leak (and a recreated id can't
+  // inherit a stale baseline). Runs in every Prompt instance; forget is
+  // idempotent. Skip pruning when the list is empty — that is almost always a
+  // transient bootstrap/reconnect blip, and forgetting then would drop live
+  // queues for sessions that are about to reappear.
+  let knownFollowUpSessions = new Set<string>()
+  createEffect(() => {
+    const current = new Set((sync.data.session ?? []).map((s) => s.id))
+    untrack(() => {
+      if (current.size === 0) return
+      for (const id of knownFollowUpSessions) {
+        if (!current.has(id)) forgetFollowUpSession(id)
+      }
+      knownFollowUpSessions = current
     })
   })
 

--- a/packages/ax-code/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -173,13 +173,13 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean; statusTic
     removeQueuedFollowUp(props.sessionID, id)
   }
 
-  // Editing pops the follow-up out of the queue and back into the composer so
-  // the user can revise and resubmit it.
+  // Editing loads the follow-up's text back into the composer so the user can
+  // revise it. The composer removes it from the queue only once the text lands
+  // (see the prompt edit effect), so a dropped request never loses the message.
   function editQueued(id: string) {
     const item = queued().find((entry) => entry.id === id)
     if (!item) return
-    removeQueuedFollowUp(props.sessionID, id)
-    requestFollowUpEdit(props.sessionID, followUpText(item))
+    requestFollowUpEdit(props.sessionID, id, followUpText(item))
   }
 
   // Send a queued follow-up immediately. dispatchFollowUp removes it from the
@@ -188,7 +188,10 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean; statusTic
     const item = queued().find((entry) => entry.id === id)
     if (!item) return
     try {
-      await dispatchFollowUp(sdk, props.sessionID, item)
+      const dispatched = await dispatchFollowUp(sdk, props.sessionID, item)
+      // `false` = a dispatch for this session is already in flight; the item is
+      // left queued and will drain — tell the user the click wasn't a no-op.
+      if (!dispatched) toast.show({ message: "Already sending — left in queue", variant: "info" })
     } catch (error) {
       log.warn("send queued follow-up failed", {
         command: "tui.sidebar.queue.send",

--- a/packages/ax-code/test/cli/tui/follow-up-queue.test.ts
+++ b/packages/ax-code/test/cli/tui/follow-up-queue.test.ts
@@ -16,6 +16,7 @@ import {
   enqueueFollowUp,
   followUpEditRequest,
   followUpQueue,
+  forgetFollowUpSession,
   hasRecentFollowUpAbort,
   markFollowUpAbort,
   peekQueuedFollowUp,
@@ -136,13 +137,23 @@ describe("follow-up-queue-store", () => {
     expect(dispatchFollowUp(sdk, "ses_err", item("1"))).rejects.toThrow("boom")
   })
 
-  test("edit channel carries a pending request and clears", () => {
+  test("edit channel carries a pending request (with item id) and clears", () => {
     clearFollowUpEdit()
     expect(followUpEditRequest()).toBeUndefined()
-    requestFollowUpEdit("ses_edit", "revise me")
-    expect(followUpEditRequest()).toEqual({ sessionID: "ses_edit", text: "revise me" })
+    requestFollowUpEdit("ses_edit", "followup-1", "revise me")
+    expect(followUpEditRequest()).toEqual({ sessionID: "ses_edit", id: "followup-1", text: "revise me" })
     clearFollowUpEdit()
     expect(followUpEditRequest()).toBeUndefined()
+  })
+
+  test("forgetFollowUpSession clears queue, baseline, and abort marks", () => {
+    const sid = "ses_forget"
+    enqueueFollowUp(sid, { parts: [{ type: "text", text: "x" }] })
+    markFollowUpAbort(sid)
+    expect(followUpQueue(sid).length).toBe(1)
+    forgetFollowUpSession(sid)
+    expect(followUpQueue(sid)).toEqual([])
+    expect(hasRecentFollowUpAbort(sid)).toBe(false)
   })
 
   test("dispatchFollowUp skips a concurrent dispatch for the same session", async () => {
@@ -204,6 +215,33 @@ describe("reconcileFollowUpDrain", () => {
     markFollowUpAbort(sid)
     reconcileFollowUpDrain(sdk, [[sid, "idle"]])
     expect(calls).toHaveLength(0)
+    clearFollowUpQueue(sid)
+  })
+
+  test("does not dispatch (or strand) the head while another dispatch is in flight", async () => {
+    resetFollowUpDrainState()
+    const sid = "ses_drain_inflight"
+    clearFollowUpQueue(sid)
+    enqueueFollowUp(sid, { parts: [{ type: "text", text: "head" }] })
+
+    // A manual send grabs the per-session in-flight guard.
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => (release = resolve))
+    const gatedSdk = { client: { session: { promptAsync: async () => (await gate, {}) } } } as any
+    const manual = dispatchFollowUp(gatedSdk, sid, peekQueuedFollowUp(sid)!)
+
+    // The auto-drain edge arrives while the manual dispatch is in flight: it must
+    // not dispatch again (no double-send).
+    const calls: any[] = []
+    const drainSdk = fakeSdk(calls)
+    reconcileFollowUpDrain(drainSdk, [[sid, "busy"]])
+    reconcileFollowUpDrain(drainSdk, [[sid, "idle"]])
+    expect(calls).toHaveLength(0)
+
+    release?.()
+    expect(await manual).toBe(true)
+    // The manual dispatch removed the head on success — nothing stranded.
+    expect(followUpQueue(sid)).toEqual([])
     clearFollowUpQueue(sid)
   })
 


### PR DESCRIPTION
Follow-up to #230. An independent bug-hunt (two finder rounds + adversarial verify, which returned no remaining findings) over the merged follow-up-queue feature surfaced and fixed:

- **Edit could lose the message** — the sidebar removed the queued item before its text reached the composer; if the input was briefly unavailable the text was gone. The edit channel now carries the item id and the prompt removes it **only after** `input.insertText` succeeds, so a dropped request leaves the item queued (editable again).
- **No cleanup on session deletion** — queues, drain baselines, and abort marks leaked, and a recreated id could inherit a stale baseline and mis-drain. A new effect forgets a session's follow-up state when it leaves `sync.data.session`, **guarded to skip an empty list** (transient bootstrap/reconnect blip) so live queues are never dropped.
- **In-flight stranding** — `reconcileFollowUpDrain` no longer consumes the busy→idle edge when a dispatch is already in flight, so the head retries on the next transition instead of being stranded.
- **send-now feedback** — shows an info toast on an in-flight skip instead of silently no-op'ing.

Refuted (no change): stale part offsets (text+parts captured together), discarded submit-time messageID (queued items mint one at dispatch), history recall (intended).

Also tracks the planning docs (PRD/tech-spec/ADR-028) under `.internal` (force-added).

## Testing
`bun run typecheck`, `bun run check:tui-layering`, and `bun test test/cli/tui/` (**554 pass**, incl. new in-flight-drain / `forgetFollowUpSession` / edit-id unit tests) all green.

⚠️ Not verified live (no TUI here): a `pnpm dev` pass of the chips, incl. editing while busy, deleting a session with queued items, and the in-flight/send-now interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)