### PR TITLE
fix(isolation): close sandbox-widening + read-only bypass holes

### DIFF
--- a/packages/ax-code/src/isolation/index.ts
+++ b/packages/ax-code/src/isolation/index.ts
@@ -122,12 +122,17 @@ export namespace Isolation {
 
   export function canWrite(state: State, filepath: string, directory: string, worktree: string): boolean {
     if (state.mode === "full-access") return true
-    const resolved = resolvePath(filepath)
-    if (isBypassed(state, resolved)) return true
+    // read-only is an absolute floor: even an explicit per-path bypass cannot
+    // grant a write here. Checked before isBypassed so the bypass list can never
+    // override read-only (mirrors assertBash, which rejects read-only first).
     if (state.mode === "read-only") return false
+    if (isBypassed(state, resolvePath(filepath))) return true
     const targetPaths = securityPaths(filepath)
     const writeRoots = securityPaths(directory)
-    if (worktree !== "/") writeRoots.push(...securityPaths(worktree))
+    // Guard worktree truthiness the same way roots() does. A "" or undefined
+    // worktree must NOT be passed to securityPaths(): it resolves to the process
+    // cwd and would silently widen the write boundary (or throw on undefined).
+    if (worktree && worktree !== "/") writeRoots.push(...securityPaths(worktree))
     if (isProtected(state, filepath)) return false
     return isInsideAnyRoot(Array.from(new Set(writeRoots)), targetPaths)
   }
@@ -167,7 +172,9 @@ export namespace Isolation {
       throw new DeniedError("bash", "Isolation mode is read-only. Bash commands are not allowed.")
     }
     const roots = securityPaths(directory)
-    if (worktree !== "/") roots.push(...securityPaths(worktree))
+    // Same worktree truthiness guard as roots()/canWrite — a "" worktree
+    // resolves to cwd and would widen the bash boundary; undefined would throw.
+    if (worktree && worktree !== "/") roots.push(...securityPaths(worktree))
     const current = resolvePath(cwd)
     const currentPaths = securityPaths(cwd)
     // workspace-write: check cwd is within workspace

--- a/packages/ax-code/test/isolation/isolation.test.ts
+++ b/packages/ax-code/test/isolation/isolation.test.ts
@@ -220,3 +220,43 @@ describe("isolation.bypass", () => {
     )
   })
 })
+
+describe("isolation worktree guard", () => {
+  test("empty worktree does not widen the write boundary to the process cwd", () => {
+    const state = Isolation.resolve({ mode: "workspace-write", network: false }, root)
+    const cwdFile = path.join(process.cwd(), "outside-the-workspace.ts")
+    // A bogus empty worktree must not be resolved (it would resolve to cwd and
+    // widen the boundary). The write must stay confined to `root`.
+    expect(Isolation.canWrite(state, cwdFile, root, "")).toBe(false)
+    expect(() => Isolation.assertWrite(state, cwdFile, root, "")).toThrow("outside workspace boundary")
+  })
+
+  test("undefined worktree does not throw and stays confined to directory", () => {
+    const state = Isolation.resolve({ mode: "workspace-write", network: false }, root)
+    const wt = undefined as unknown as string
+    expect(() => Isolation.canWrite(state, path.join(root, "src/x.ts"), root, wt)).not.toThrow()
+    expect(Isolation.canWrite(state, path.join(root, "src/x.ts"), root, wt)).toBe(true)
+    expect(Isolation.canWrite(state, path.join(process.cwd(), "x.ts"), root, wt)).toBe(false)
+  })
+
+  test("assertBash tolerates empty worktree without widening to cwd", () => {
+    const state = Isolation.resolve({ mode: "workspace-write", network: false }, root)
+    // cwd is outside `root`; bash there must be rejected, not allowed via a
+    // cwd-widened root.
+    expect(() => Isolation.assertBash(state, process.cwd(), root, "", [])).toThrow("outside workspace boundary")
+  })
+})
+
+describe("isolation read-only floor", () => {
+  test("read-only denies writes even with an explicit bypass entry", () => {
+    const state: Isolation.State = {
+      ...Isolation.resolve({ mode: "read-only", network: false }, root),
+      bypass: [path.join(root, "allowed.ts")],
+    }
+    // A per-path bypass must never override read-only.
+    expect(Isolation.canWrite(state, path.join(root, "allowed.ts"), root, worktree)).toBe(false)
+    expect(() => Isolation.assertWrite(state, path.join(root, "allowed.ts"), root, worktree)).toThrow(
+      "Isolation mode is read-only",
+    )
+  })
+})


### PR DESCRIPTION
Focused sandbox/isolation bug-hunt (parallel finders + verification). Two real correctness/security bugs in the isolation core (`src/isolation/index.ts`):

### 1. Sandbox widening / crash via worktree guard
`roots()` guards `worktree && worktree !== "/"`, but `canWrite` and `assertBash` guarded only `worktree !== "/"`. `Instance.worktree` can legitimately be `""` or `undefined`, and then `securityPaths(worktree)` resolves the empty path to **the process cwd** (`path.resolve("") === cwd`) and adds it as a write/bash root — silently widening the sandbox to the entire launch directory — or throws a raw `TypeError` on `undefined` from inside the security check. Both call sites now use the same truthiness guard as `roots()`.

### 2. read-only floor bypassed
`canWrite` checked `isBypassed()` **before** the read-only mode check, so a per-path bypass entry granted writes even in read-only mode. read-only is now an absolute floor checked first, matching `assertBash` (which already rejects read-only before consulting bypass).

### Tests
Added cases (26 isolation tests pass): empty/undefined worktree stays confined to `directory` (no cwd widening, no throw) for `canWrite`/`assertWrite`/`assertBash`; read-only denies a bypassed path. `typecheck` + 94 isolation/prompt-tools/write/bash tests green locally.

### Found but NOT patched here (recorded for follow-up)
Real but inherent or large/risky — a naive patch would break usability or give false confidence:
- bash path-extraction can't see runtime env-var expansion (`$HOME/x` resolves as an in-cwd literal) — needs OS-level sandboxing, not heuristics.
- MCP tool execution path does not consult `Isolation` (gated only by per-tool permissions).
- check-then-write TOCTOU between `canWrite` and the deferred `Filesystem.write` rename.
- `tee` targets skip BlastRadius accounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)