### PR TITLE
fix(desktop): diff viewer — hunk revert path + comment-send data loss

### DIFF
--- a/desktop/packages/ui/src/components/views/DiffCommentSummaryBar.tsx
+++ b/desktop/packages/ui/src/components/views/DiffCommentSummaryBar.tsx
@@ -19,10 +19,10 @@ export const DiffCommentSummaryBar: React.FC<DiffCommentSummaryBarProps> = memo(
   const drafts = useInlineCommentDraftStore(
     React.useCallback((s) => (sessionKey ? (s.drafts[sessionKey] ?? EMPTY_DRAFTS) : EMPTY_DRAFTS), [sessionKey]),
   )
-  const consumeDrafts = useInlineCommentDraftStore((s) => s.consumeDrafts)
   const clearDrafts = useInlineCommentDraftStore((s) => s.clearDrafts)
   const currentSessionId = useSessionUIStore((s) => s.currentSessionId)
   const draftCount = drafts.length
+  const sendingRef = React.useRef(false)
 
   if (draftCount === 0) return null
 
@@ -31,24 +31,32 @@ export const DiffCommentSummaryBar: React.FC<DiffCommentSummaryBarProps> = memo(
       toast.error(t("diffView.comments.noSession"))
       return
     }
+    if (sendingRef.current) return
 
-    const consumed = consumeDrafts(sessionKey)
-    if (!consumed || consumed.length === 0) return
+    // Read the drafts without consuming them, so a failed send does not throw
+    // the user's comments away. Clear only after the send succeeds. The ref
+    // guards against a double-click re-sending while the first await is pending.
+    const pending = useInlineCommentDraftStore.getState().drafts[sessionKey] ?? EMPTY_DRAFTS
+    if (pending.length === 0) return
 
-    const formatted = formatInlineCommentDrafts(consumed)
+    const formatted = formatInlineCommentDrafts(pending)
     const config = useConfigStore.getState()
     const providerId = config.currentProviderId ?? ""
     const modelId = config.currentModelId ?? ""
 
+    sendingRef.current = true
     try {
       await useSessionUIStore
         .getState()
         .sendMessage(formatted, providerId, modelId, undefined, undefined, undefined, undefined, undefined, "normal", {
           sessionId: currentSessionId,
         })
+      clearDrafts(sessionKey)
       toast.success(t("diffView.comments.sent"))
     } catch {
       toast.error(t("diffView.comments.sendFailed"))
+    } finally {
+      sendingRef.current = false
     }
   }
 

--- a/desktop/packages/ui/src/components/views/useDiffHunkRevert.ts
+++ b/desktop/packages/ui/src/components/views/useDiffHunkRevert.ts
@@ -4,6 +4,7 @@ import { useGitStore } from "@/stores/useGitStore"
 import { useRuntimeAPIs } from "@/hooks/useRuntimeAPIs"
 import { useI18n } from "@/lib/i18n"
 import { revertHunk } from "./diffHunkRevert"
+import { toViewAbsolutePath } from "./viewPathUtils"
 
 interface UseDiffHunkRevertOptions {
   directory: string | null
@@ -33,7 +34,11 @@ export function useDiffHunkRevert({ directory, filePath, diff }: UseDiffHunkReve
       setRevertingHunkIndex(hunkIndex)
       try {
         const reconstructed = revertHunk(diff.original, diff.modified, hunkIndex, filePath)
-        const result = await files.writeFile(filePath, reconstructed)
+        // Write back through the same endpoint as the editor's save action. The
+        // fs/write route resolves relative paths against the server process cwd
+        // (not the project dir), so a git-relative filePath lands "outside the
+        // active workspace" and 400s. Send an absolute path like the editor does.
+        const result = await files.writeFile(toViewAbsolutePath(directory, filePath), reconstructed)
         if (!result?.success) {
           throw new Error("write failed")
         }


### PR DESCRIPTION
Two diff-viewer fixes (one branch per category).

- **#347** — per-hunk revert wrote a git-relative path to `/api/fs/write`, which resolves against the server process cwd (not the project dir), so it 400'd "Path is outside of active workspace" and revert silently failed. Now sends an absolute path via `toViewAbsolutePath()`, matching the file editor's save.
- **#349** — "Send to chat" cleared the comment drafts *before* awaiting the send, so any failure permanently lost the user's comments. Now clears only on success, with a double-send guard.

Tested: ESLint + ui `tsc --noEmit` pass; `diffHunkRevert` unit test 3/3; runtime `/api/fs/write` verified (relative → 400, absolute → 200 + file written).

Closes #347
Closes #349
