### PR TITLE
fix(desktop): address valid Copilot review feedback

### DIFF
--- a/desktop/packages/ui/src/components/session/sidebar/hooks/useProjectSessionLists.ts
+++ b/desktop/packages/ui/src/components/session/sidebar/hooks/useProjectSessionLists.ts
@@ -1,6 +1,6 @@
 import React from "react"
 import type { Session } from "@ax-code/sdk/v2"
-import { dedupeSessionsById, isSessionOwnedByProject, normalizePath } from "../utils"
+import { dedupeSessionsById, normalizePath, resolveOwningProjectRoot } from "../utils"
 import type { WorktreeMeta } from "../types"
 
 type Args = {
@@ -32,6 +32,19 @@ export const useProjectSessionLists = (args: Args) => {
     })
     return next
   }, [sessions])
+
+  // Archived sections are built once per project. Resolve ownership once for
+  // each session instead of scanning every project root for every section.
+  const ownerProjectRootBySessionId = React.useMemo(() => {
+    const owners = new Map<string, string | null>()
+    for (const session of [...sessions, ...archivedSessions]) {
+      owners.set(
+        session.id,
+        resolveOwningProjectRoot(session, allProjectRoots, availableWorktreesByProject),
+      )
+    }
+    return owners
+  }, [allProjectRoots, archivedSessions, availableWorktreesByProject, sessions])
 
   const getSessionsForProject = React.useCallback(
     (project: { normalizedPath: string }) => {
@@ -65,7 +78,7 @@ export const useProjectSessionLists = (args: Args) => {
   const getArchivedSessionsForProject = React.useCallback(
     (project: { normalizedPath: string }) => {
       const ownsSession = (session: Session): boolean =>
-        isSessionOwnedByProject(session, project.normalizedPath, allProjectRoots, availableWorktreesByProject)
+        ownerProjectRootBySessionId.get(session.id) === project.normalizedPath
 
       const archived = archivedSessions.filter(ownsSession)
       const unassignedLive = sessions.filter((session) => {
@@ -87,7 +100,7 @@ export const useProjectSessionLists = (args: Args) => {
 
       return dedupeSessionsById([...archived, ...unassignedLive])
     },
-    [archivedSessions, allProjectRoots, availableWorktreesByProject, sessions],
+    [archivedSessions, ownerProjectRootBySessionId, sessions],
   )
 
   return {

--- a/desktop/packages/ui/src/components/session/sidebar/utils.tsx
+++ b/desktop/packages/ui/src/components/session/sidebar/utils.tsx
@@ -221,11 +221,13 @@ export const isSessionRelatedToProject = (
 
 /**
  * Resolve the single project a session belongs to: the most-specific
- * (longest-matching) registered project root — or worktree — that contains the
- * session's directory. Unlike {@link isSessionRelatedToProject}, which returns
- * true for a root *and every ancestor of it*, this picks one owner, so a broad
- * ancestor project (e.g. the home `~` project) no longer claims sessions that
- * live inside a more specific registered project nested beneath it.
+ * (longest-matching) registered project root that contains the session's
+ * directory. Registered worktrees participate in match strength, but the
+ * returned value is always the owning project root. Unlike
+ * {@link isSessionRelatedToProject}, which returns true for a root *and every
+ * ancestor of it*, this picks one owner, so a broad ancestor project (e.g. the
+ * home `~` project) no longer claims sessions that live inside a more specific
+ * registered project nested beneath it.
  */
 export const resolveOwningProjectRoot = (
   session: Session,

--- a/desktop/scripts/fix-node-pty-permissions.mjs
+++ b/desktop/scripts/fix-node-pty-permissions.mjs
@@ -7,7 +7,7 @@
 // terminal fails at runtime with "posix_spawnp failed" (EACCES on a
 // non-executable helper) even though node-pty itself loads fine. This makes the
 // bit deterministic. Idempotent; a no-op on Windows (no spawn-helper there).
-import { chmodSync, existsSync, readdirSync, statSync } from "node:fs"
+import { chmodSync, readdirSync, statSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 


### PR DESCRIPTION
## Summary

- remove an unused import from the node-pty postinstall helper
- clarify that session ownership resolves to a project root while using worktrees for match strength
- cache session ownership once per session-list update to avoid repeated project-root scans while rendering archived sections

## Verification

- `corepack pnpm --dir desktop/packages/ui exec vitest run src/components/session/sidebar/utils.test.ts`
- `corepack pnpm --dir desktop/packages/ui run lint`
- `corepack pnpm --dir desktop/packages/ui run type-check`
- `node --check desktop/scripts/fix-node-pty-permissions.mjs`