### PR TITLE
fix(desktop): resolve node-pty helper from workspace root

### DIFF
--- a/desktop/scripts/fix-node-pty-permissions.mjs
+++ b/desktop/scripts/fix-node-pty-permissions.mjs
@@ -15,7 +15,7 @@ if (process.platform === "win32") {
   process.exit(0)
 }
 
-const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const repoRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))))
 
 // Search only inside node-pty package trees to keep the walk cheap and bounded.
 const searchRoots = [


### PR DESCRIPTION
## Summary

Restore the correct workspace-root calculation after the postinstall helper moved from `scripts/` to `desktop/scripts/`. The helper now repairs `node_modules/.pnpm/.../node-pty/prebuilds/.../spawn-helper` instead of scanning the nonexistent `desktop/node_modules`.

## Verification

- Removed the execute bit from the real local `spawn-helper`; `node desktop/scripts/fix-node-pty-permissions.mjs` restored it and reported one repaired binary.
- `corepack pnpm --dir desktop/packages/web run test`
- `corepack pnpm --dir desktop/packages/ui run type-check`
- `corepack pnpm run check:structure`
- `corepack pnpm run check:desktop-electron-runtime`