### PR TITLE
fix(tui): lifecycle-safe suspend and session-leave prune (ADR-047)

### DIFF
--- a/packages/ax-code/script/self-scan-baseline.json
+++ b/packages/ax-code/script/self-scan-baseline.json
@@ -1666,57 +1666,57 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "407ec4dda615d32c776708ff7e6a398d07b1c4f60491efd9d00efb5ff80a0504",
+          "fingerprint": "5aefa34d00ebc03c1fd699cd0d96ef808dcab9087a99629b27b83aeb56134510",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 377,
+          "line": 381,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "1a4d27aaf441f38579bdbc8516cb527deaa6316e0f8c39abe55cf8e8774aaf46",
+          "fingerprint": "bcc965193aa3f936e2584c911cc86798ed1a0bfa334a44d024c63107cf41dce6",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 420,
+          "line": 424,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "afbc270245435d8daca6f539a278d2b78b6d2ffcac6471514daef0d627cf4343",
+          "fingerprint": "890507e19bbcf74ba9340ce15f721ed8b81f701b50eedc17c51285b967069fbc",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 461,
+          "line": 465,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "4fb750d6b02e5d8eb03a26c040f06cdea2d516f6d4271599517cda40aacdf627",
+          "fingerprint": "866a1c98710e49be9436a453ebaacb76a2287a7206e7e00863ffbfc78e3ea4aa",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 584,
+          "line": 588,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "6134247c21c73ab15b5c27311349e5acb9edb57fafebe99c876f32d3a3e49875",
+          "fingerprint": "e62f3ba1d79e1047f63d1daf3a70c36a934de95a4d1ea15990517343a103fcaf",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 1018,
+          "line": 1022,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "65730503f6e9427801126ac420c6d64277f5be7f46f2420a92b56d8bc799892c",
+          "fingerprint": "2ff32b8d46af2292498bf90f6ba344e154f9fba76f0cd96b43e3e275258cccd7",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 1216,
+          "line": 1220,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "527ad21246ba4773babd48126b041b8e2959aa295681c554689e08e102845e1b",
+          "fingerprint": "be2df0f7aa3b4619f946b93c3ea0ba3c8522c00ebbb0d82a1a30ba8cf4622160",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 1219,
+          "line": 1223,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"

--- a/packages/ax-code/script/self-scan-baseline.json
+++ b/packages/ax-code/script/self-scan-baseline.json
@@ -839,7 +839,7 @@
       ]
     },
     "lifecycle_scan": {
-      "count": 190,
+      "count": 191,
       "findings": [
         {
           "fingerprint": "030c87b86efa17dba640e6927ec8a4ef6f9532dd4790bb566afbc3794cd0767c",
@@ -1666,49 +1666,57 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "35b981feceaae3c89e917ecc091583b7bc33e485a6143853b7bae21eaf690950",
+          "fingerprint": "407ec4dda615d32c776708ff7e6a398d07b1c4f60491efd9d00efb5ff80a0504",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 408,
+          "line": 377,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "4fb6e75c195a10e5dbf5cffd6bc27dadeb9fb16f32d0f7840d4a88ffdc5509b6",
+          "fingerprint": "1a4d27aaf441f38579bdbc8516cb527deaa6316e0f8c39abe55cf8e8774aaf46",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 449,
+          "line": 420,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "672c104d097cc7c8d0469d723fa642d419ff38e803f1731761ab1ce0f739293b",
+          "fingerprint": "afbc270245435d8daca6f539a278d2b78b6d2ffcac6471514daef0d627cf4343",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 572,
+          "line": 461,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "67106e77e049d8abefb66175a3451e2cf8e75d5de795b90e7b0e61d178513363",
+          "fingerprint": "4fb750d6b02e5d8eb03a26c040f06cdea2d516f6d4271599517cda40aacdf627",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 1006,
+          "line": 584,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "65eabb0824929d11cd15245389d632ff0573529c530614df6795ad8ce756dc03",
+          "fingerprint": "6134247c21c73ab15b5c27311349e5acb9edb57fafebe99c876f32d3a3e49875",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 1204,
+          "line": 1018,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "3f880c16e9e637802b0de852db30affafa9283a09921642da8f1101b251278b6",
+          "fingerprint": "65730503f6e9427801126ac420c6d64277f5be7f46f2420a92b56d8bc799892c",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 1207,
+          "line": 1216,
+          "severity": "medium",
+          "kind": "map_growth:unbounded_growth",
+          "summary": "map_growth:unbounded_growth"
+        },
+        {
+          "fingerprint": "527ad21246ba4773babd48126b041b8e2959aa295681c554689e08e102845e1b",
+          "file": "src/cli/cmd/tui/routes/session/index.tsx",
+          "line": 1219,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"

--- a/packages/ax-code/src/cli/cmd/tui/app.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/app.tsx
@@ -74,6 +74,7 @@ import { scheduleTuiTimeout } from "@tui/util/timer"
 import { beginTuiStartup, createTuiStartupSpan, recordTuiStartup, recordTuiStartupOnce } from "@tui/util/startup-trace"
 import { responseErrorMessage, unknownErrorMessage } from "@tui/util/error-message"
 import { registerTuiEventListener } from "@tui/util/lifecycle"
+import { createTerminalSuspendController } from "@tui/util/terminal-suspend"
 import { resolveSessionFirstRoute } from "./navigation/launch-policy"
 import { resolveDesktopHandoff } from "./navigation/desktop-handoff"
 import { launchWebUi } from "@/desktop/webui"
@@ -472,7 +473,11 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         options: { once: true },
       })
     }
-    const timer = setTimeout(() => ctrl.abort(), 10_000)
+    const cancelTimer = scheduleTuiTimeout(() => ctrl.abort(), {
+      name: "app-put-json-timeout",
+      delayMs: 10_000,
+      unref: true,
+    })
     try {
       const response = await sdk.fetch(`${sdk.url}${path}`, {
         method: "PUT",
@@ -487,7 +492,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         throw new Error(await responseErrorMessage(response))
       }
     } finally {
-      clearTimeout(timer)
+      cancelTimer()
       removeAbortListener?.()
     }
   }
@@ -591,6 +596,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     })
   }
 
+  const terminalSuspend = createTerminalSuspendController()
+
   onCleanup(() => {
     forkRetryDisposed = true
     for (const cancel of retryTimers) cancel()
@@ -598,6 +605,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     smartLlmToggle.dispose()
     runModeController?.abort()
     sandboxPutController?.abort()
+    terminalSuspend.dispose()
   })
 
   function scheduleRetry(fn: () => void, delay = RETRY_DELAY_MS) {
@@ -1104,13 +1112,12 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       category: "System",
       hidden: true,
       onSelect: () => {
-        process.once("SIGCONT", () => {
-          renderer.resume()
+        // Lifecycle-managed SIGCONT (ADR-047 D2). Disposed on App cleanup and
+        // replaced if suspend is invoked again before resume.
+        terminalSuspend.suspend({
+          suspend: () => renderer.suspend(),
+          resume: () => renderer.resume(),
         })
-
-        renderer.suspend()
-        // pid=0 means send the signal to all processes in the process group
-        process.kill(0, "SIGTSTP")
       },
     },
     {

--- a/packages/ax-code/src/cli/cmd/tui/context/sync-result.ts
+++ b/packages/ax-code/src/cli/cmd/tui/context/sync-result.ts
@@ -15,7 +15,7 @@ export interface SyncResultStoreState<
 export function createSyncContextValue<
   TStore extends SyncResultStoreState<any, any>,
   TSet,
-  TSessionSync extends (sessionID: string) => unknown,
+  TSessionSync extends (sessionID: string, options?: { force?: boolean; missing?: "ignore" | "throw" }) => unknown,
   TWorkspaceSync extends () => unknown,
   TBootstrap extends () => unknown,
   TRuntime extends object,
@@ -23,6 +23,8 @@ export function createSyncContextValue<
   store: TStore
   setStore: TSet
   sessionSync: TSessionSync
+  /** Drop fullSynced/in-flight marks so the next sync reloads heavy state (leave prune). */
+  sessionClear?: (sessionID: string) => void
   workspaceSync: TWorkspaceSync
   bootstrap: TBootstrap
   runtime: TRuntime
@@ -55,6 +57,9 @@ export function createSyncContextValue<
         )
       },
       sync: input.sessionSync,
+      clear(sessionID: string) {
+        input.sessionClear?.(sessionID)
+      },
     },
     workspace: {
       get(workspaceID: string) {

--- a/packages/ax-code/src/cli/cmd/tui/context/sync-session-coordinator.ts
+++ b/packages/ax-code/src/cli/cmd/tui/context/sync-session-coordinator.ts
@@ -29,32 +29,66 @@ export function createSessionSyncController<TSnapshot>(input: {
   onMissingSnapshot?: (sessionID: string) => void
 }): SessionSyncController {
   const fullSyncedSessions = new Set<string>()
-  const inFlightSessions = new Set<string>()
+  /** sessionID -> epoch when the current in-flight sync started (if any). */
+  const inFlightEpoch = new Map<string, number>()
+  /**
+   * sessionID -> generation. Bumped by clear/reset so an in-flight fetch that
+   * completes after leave-prune cannot applySnapshot or re-mark fullSynced
+   * (ADR-047 leave prune + re-enter).
+   */
+  const epoch = new Map<string, number>()
+
+  function currentEpoch(sessionID: string) {
+    return epoch.get(sessionID) ?? 0
+  }
+
+  function bumpEpoch(sessionID: string) {
+    const next = currentEpoch(sessionID) + 1
+    epoch.set(sessionID, next)
+    return next
+  }
 
   return {
     clear(sessionID) {
       fullSyncedSessions.delete(sessionID)
-      inFlightSessions.delete(sessionID)
+      inFlightEpoch.delete(sessionID)
+      bumpEpoch(sessionID)
     },
     reset() {
       fullSyncedSessions.clear()
-      inFlightSessions.clear()
+      // Bump every session that has ever synced or is in-flight so late
+      // applySnapshot cannot re-mark fullSynced after reset. Keep the epoch
+      // map (do not zero it) so in-flight work started at epoch 0 goes stale.
+      for (const sessionID of new Set([...epoch.keys(), ...inFlightEpoch.keys()])) {
+        bumpEpoch(sessionID)
+      }
+      inFlightEpoch.clear()
     },
     async sync(sessionID, options) {
-      if ((!options?.force && fullSyncedSessions.has(sessionID)) || inFlightSessions.has(sessionID)) return
+      if (!options?.force && fullSyncedSessions.has(sessionID)) return
+      if (inFlightEpoch.has(sessionID)) return
 
-      inFlightSessions.add(sessionID)
+      const startedEpoch = currentEpoch(sessionID)
+      inFlightEpoch.set(sessionID, startedEpoch)
       try {
         const snapshot = await input.fetchSnapshot(sessionID)
+        // Leave/clear ran while we were fetching — drop the result.
+        if (startedEpoch !== currentEpoch(sessionID)) return
         if (!snapshot) {
           input.onMissingSnapshot?.(sessionID)
           if (options?.missing === "throw") throw new MissingSessionSnapshotError(sessionID)
           return
         }
         input.applySnapshot(sessionID, snapshot)
+        // Leave/clear ran between apply and mark — do not trust fullSynced.
+        if (startedEpoch !== currentEpoch(sessionID)) return
         fullSyncedSessions.add(sessionID)
       } finally {
-        inFlightSessions.delete(sessionID)
+        // Only release in-flight if we still own this flight. A clear()+new
+        // sync may have replaced inFlightEpoch with a newer epoch.
+        if (inFlightEpoch.get(sessionID) === startedEpoch) {
+          inFlightEpoch.delete(sessionID)
+        }
       }
     },
   }

--- a/packages/ax-code/src/cli/cmd/tui/context/sync-session-store.ts
+++ b/packages/ax-code/src/cli/cmd/tui/context/sync-session-store.ts
@@ -135,3 +135,31 @@ export function applySessionDeleteCleanup<
   delete store.todo[sessionID]
   delete store.message[sessionID]
 }
+
+/**
+ * Drop heavy transcript projection for a session the user just left, without
+ * removing the session list row or in-flight permission/question/status.
+ * Re-entry reloads heavy fields via the normal session sync path (ADR-047 D3).
+ */
+export function applySessionLeavePrune<TMessage extends { id: string }, TPart, TDiff, TRisk, TGoal, TTodo>(
+  store: {
+    session_risk: Record<string, TRisk>
+    session_goal: Record<string, TGoal | null>
+    session_diff: Record<string, TDiff[]>
+    todo: Record<string, TTodo[]>
+    message: Record<string, TMessage[]>
+    part: Record<string, TPart[]>
+  },
+  sessionID: string,
+) {
+  const removedMessages = store.message[sessionID] ?? []
+  for (const message of removedMessages) {
+    delete store.part[message.id]
+  }
+
+  delete store.session_risk[sessionID]
+  delete store.session_goal[sessionID]
+  delete store.session_diff[sessionID]
+  delete store.todo[sessionID]
+  delete store.message[sessionID]
+}

--- a/packages/ax-code/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/context/sync.tsx
@@ -250,6 +250,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       store,
       setStore,
       sessionSync: sessionSync.sync,
+      sessionClear: sessionSync.clear,
       workspaceSync: syncWorkspaces,
       runtime: {
         syncSuperLong,

--- a/packages/ax-code/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/routes/session/index.tsx
@@ -371,9 +371,13 @@ export function Session() {
         const generation = ++sessionSyncGeneration
         runInitialSessionSync(sessionID, generation, createSessionEntrySyncRetryState())
         // ADR-047 D3: when this sessionID effect re-runs or the session route
-        // unmounts, drop heavy transcript projection for the left session.
-        // Permission/question/status and the session list row are retained.
+        // unmounts, drop heavy transcript projection for the left session and
+        // clear the session-sync fullSynced mark so re-entry reloads without
+        // force. Permission/question/status and the session list row stay.
+        // clear() also bumps the coordinator epoch so an in-flight fetch for
+        // this session cannot re-apply after prune.
         onCleanup(() => {
+          sync.session.clear(sessionID)
           sync.set(
             produce((draft) => {
               applySessionLeavePrune(draft, sessionID)

--- a/packages/ax-code/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/routes/session/index.tsx
@@ -99,6 +99,8 @@ import { firstCompactionMessageID, shouldShowCompactionNotice } from "./compacti
 import { createReconnectRecoveryGate } from "../../util/reconnect-recovery"
 import { recordTuiStartupOnce } from "@tui/util/startup-trace"
 import { isMissingSessionSnapshotError } from "../../context/sync-session-coordinator"
+import { applySessionLeavePrune } from "../../context/sync-session-store"
+import { produce } from "solid-js/store"
 import {
   createSessionEntrySyncRetryState,
   nextSessionEntrySyncRetry,
@@ -368,6 +370,16 @@ export function Session() {
       (sessionID) => {
         const generation = ++sessionSyncGeneration
         runInitialSessionSync(sessionID, generation, createSessionEntrySyncRetryState())
+        // ADR-047 D3: when this sessionID effect re-runs or the session route
+        // unmounts, drop heavy transcript projection for the left session.
+        // Permission/question/status and the session list row are retained.
+        onCleanup(() => {
+          sync.set(
+            produce((draft) => {
+              applySessionLeavePrune(draft, sessionID)
+            }),
+          )
+        })
       },
     ),
   )

--- a/packages/ax-code/src/cli/cmd/tui/util/terminal-suspend.ts
+++ b/packages/ax-code/src/cli/cmd/tui/util/terminal-suspend.ts
@@ -1,0 +1,100 @@
+import { Log } from "@/util/log"
+import { registerTuiProcessHandler, runTuiCleanup, type TuiLifecycleOptions } from "./lifecycle"
+
+const log = Log.create({ service: "tui.terminal-suspend" })
+
+export type TerminalSuspendDeps = {
+  /**
+   * Register a process signal handler. Defaults to `registerTuiProcessHandler`.
+   * Injected in tests so SIGCONT can be simulated without touching the real process.
+   */
+  registerProcessHandler?: (
+    event: string | symbol,
+    handler: (...args: unknown[]) => void,
+    input: TuiLifecycleOptions,
+  ) => () => void
+  /** Send SIGTSTP to the process group. Defaults to `process.kill(0, "SIGTSTP")`. */
+  sendStop?: () => void
+  logger?: Pick<Log.Logger, "warn">
+}
+
+export type TerminalSuspendTarget = {
+  suspend: () => void
+  resume: () => void
+}
+
+/**
+ * Suspend the TUI renderer and park a lifecycle-managed SIGCONT handler that
+ * resumes it. Returns a dispose function that removes any pending SIGCONT
+ * handler (safe to call after resume already fired).
+ *
+ * Calling this again while a previous suspend is still pending disposes the
+ * previous handler first so only one resume is armed.
+ */
+export function createTerminalSuspendController(deps: TerminalSuspendDeps = {}) {
+  const register = deps.registerProcessHandler ?? registerTuiProcessHandler
+  const sendStop =
+    deps.sendStop ??
+    (() => {
+      process.kill(0, "SIGTSTP")
+    })
+  const logger = deps.logger ?? log
+
+  let disposePending: (() => void) | undefined
+
+  const dispose = () => {
+    if (!disposePending) return
+    const cancel = disposePending
+    disposePending = undefined
+    runTuiCleanup(cancel, { name: "terminal-suspend-sigcont-dispose", logger })
+  }
+
+  const suspend = (target: TerminalSuspendTarget) => {
+    // Replace any prior pending resume so repeated suspend doesn't stack handlers.
+    dispose()
+
+    const unregister = register(
+      "SIGCONT",
+      () => {
+        // once semantics: drop the dispose slot before resume so a re-entrant
+        // suspend from resume cannot double-unregister.
+        disposePending = undefined
+        runTuiCleanup(unregister, { name: "terminal-suspend-sigcont-once", logger })
+        try {
+          target.resume()
+        } catch (error) {
+          logger.warn("tui terminal resume failed", { error })
+        }
+      },
+      { name: "terminal-suspend-sigcont", logger },
+    )
+    disposePending = unregister
+
+    try {
+      target.suspend()
+    } catch (error) {
+      dispose()
+      logger.warn("tui terminal suspend failed", { error })
+      return
+    }
+
+    try {
+      sendStop()
+    } catch (error) {
+      // If we failed to stop the process group, resume immediately so the UI
+      // is not left suspended with a hanging SIGCONT wait.
+      dispose()
+      try {
+        target.resume()
+      } catch (resumeError) {
+        logger.warn("tui terminal resume after stop failure failed", { error: resumeError })
+      }
+      logger.warn("tui terminal stop signal failed", { error })
+    }
+  }
+
+  return {
+    suspend,
+    dispose,
+  }
+}

--- a/packages/ax-code/src/provider/models-snapshot.json
+++ b/packages/ax-code/src/provider/models-snapshot.json
@@ -5500,6 +5500,34 @@
           "output": 0
         }
       },
+      "google/gemini-omni-flash-preview": {
+        "id": "google/gemini-omni-flash-preview",
+        "name": "Gemini Omni Flash Preview",
+        "description": "Omni-modal model for text, vision, audio, and multimodal agent tasks",
+        "family": "gemini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": false,
+        "temperature": true,
+        "release_date": "2026-06-30",
+        "last_updated": "2026-06-30",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 57920
+        }
+      },
       "google/gemini-3.1-flash-image-preview": {
         "id": "google/gemini-3.1-flash-image-preview",
         "name": "Gemini 3.1 Flash Image Preview (Nano Banana 2)",
@@ -6538,6 +6566,49 @@
           "output": 0
         }
       },
+      "openai/gpt-5.6-luna": {
+        "id": "openai/gpt-5.6-luna",
+        "name": "GPT 5.6 Luna",
+        "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        }
+      },
       "openai/gpt-5.1-codex-mini": {
         "id": "openai/gpt-5.1-codex-mini",
         "name": "GPT-5.1 Codex mini",
@@ -6575,6 +6646,91 @@
         "limit": {
           "context": 400000,
           "input": 272000,
+          "output": 128000
+        }
+      },
+      "openai/gpt-realtime-2.1": {
+        "id": "openai/gpt-realtime-2.1",
+        "name": "gpt-realtime-2.1",
+        "description": "Speech generation model for controllable voice, narration, and audio delivery",
+        "family": "gpt",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": false,
+        "structured_output": false,
+        "temperature": true,
+        "knowledge": "2024-09-30",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-06",
+        "modalities": {
+          "input": [
+            "text",
+            "audio"
+          ],
+          "output": [
+            "text",
+            "audio"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 128000,
+          "input": 96000,
+          "output": 32000
+        }
+      },
+      "openai/gpt-5.6-terra": {
+        "id": "openai/gpt-5.6-terra",
+        "name": "GPT 5.6 Terra",
+        "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
           "output": 128000
         }
       },
@@ -7016,6 +7172,49 @@
           "context": 131072,
           "input": 122880,
           "output": 8192
+        }
+      },
+      "openai/gpt-5.6-sol": {
+        "id": "openai/gpt-5.6-sol",
+        "name": "GPT 5.6 Sol",
+        "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
         }
       },
       "openai/gpt-5.2-codex": {
@@ -7656,7 +7855,7 @@
         ],
         "tool_call": true,
         "temperature": true,
-        "release_date": "2026-06-16",
+        "release_date": "2026-06-23",
         "last_updated": "2026-06-16",
         "modalities": {
           "input": [
@@ -8622,6 +8821,7 @@
         ],
         "tool_call": true,
         "temperature": true,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -8701,7 +8901,7 @@
         "tool_call": true,
         "interleaved": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-24",
         "last_updated": "2025-11-24",
         "modalities": {
@@ -11029,6 +11229,47 @@
           "output": 100000
         }
       },
+      "meta/muse-spark-1.1": {
+        "id": "meta/muse-spark-1.1",
+        "name": "Muse Spark 1.1",
+        "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
+        "family": "muse",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 1048576
+        }
+      },
       "meta/llama-3.2-1b": {
         "id": "meta/llama-3.2-1b",
         "name": "Llama 3.2 1B Instruct",
@@ -11731,6 +11972,58 @@
         "limit": {
           "context": 204800,
           "output": 131072
+        }
+      },
+      "kwaipilot/kat-coder-air-v2.5": {
+        "id": "kwaipilot/kat-coder-air-v2.5",
+        "name": "Kat Coder Air V2.5",
+        "description": "Coding model for repository understanding, refactors, and agentic engineering tasks",
+        "family": "kat-coder",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-07-10",
+        "last_updated": "2026-07-10",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 256000,
+          "output": 80000
+        }
+      },
+      "kwaipilot/kat-coder-pro-v2.5": {
+        "id": "kwaipilot/kat-coder-pro-v2.5",
+        "name": "Kat Coder Pro V2.5",
+        "description": "Coding model for repository understanding, refactors, and agentic engineering tasks",
+        "family": "kat-coder",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-07-10",
+        "last_updated": "2026-07-10",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 256000,
+          "output": 80000
         }
       },
       "kwaipilot/kat-coder-pro-v1": {
@@ -20202,6 +20495,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -26114,6 +26408,34 @@
           "output": 32768
         }
       },
+      "gemini-omni-flash-preview": {
+        "id": "gemini-omni-flash-preview",
+        "name": "Gemini Omni Flash Preview",
+        "description": "Video generation and editing model for fast, conversational text- and image-to-video workflows",
+        "family": "gemini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": false,
+        "temperature": true,
+        "release_date": "2026-06-30",
+        "last_updated": "2026-06-30",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "video"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 131072,
+          "output": 65536
+        }
+      },
       "gemini-3.1-flash-image-preview": {
         "id": "gemini-3.1-flash-image-preview",
         "name": "Nano Banana 2",
@@ -29694,6 +30016,47 @@
           "output": 8192
         }
       },
+      "openai-gpt-56-terra-pro": {
+        "id": "openai-gpt-56-terra-pro",
+        "name": "GPT-5.6 Terra Pro",
+        "description": "Frontier GPT model for professional reasoning, coding, and multimodal work",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
       "qwen3-235b-a22b-instruct-2507": {
         "id": "qwen3-235b-a22b-instruct-2507",
         "name": "Qwen 3 235B A22B Instruct 2507",
@@ -29717,6 +30080,47 @@
         "limit": {
           "context": 128000,
           "output": 16384
+        }
+      },
+      "openai-gpt-56-sol-pro": {
+        "id": "openai-gpt-56-sol-pro",
+        "name": "GPT-5.6 Sol Pro",
+        "description": "Frontier GPT model for professional reasoning, coding, and multimodal work",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
         }
       },
       "nvidia-nemotron-cascade-2-30b-a3b": {
@@ -29859,7 +30263,7 @@
         "tool_call": true,
         "structured_output": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-12-06",
         "last_updated": "2026-06-11",
         "modalities": {
@@ -30448,6 +30852,47 @@
           "output": 131072
         }
       },
+      "openai-gpt-56-terra": {
+        "id": "openai-gpt-56-terra",
+        "name": "GPT-5.6 Terra",
+        "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
       "google-gemma-3-27b-it": {
         "id": "google-gemma-3-27b-it",
         "name": "Google Gemma 3 27B Instruct",
@@ -30474,6 +30919,47 @@
           "output": 16384
         }
       },
+      "openai-gpt-56-luna": {
+        "id": "openai-gpt-56-luna",
+        "name": "GPT-5.6 Luna",
+        "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
       "aion-labs-aion-3-0-mini": {
         "id": "aion-labs-aion-3-0-mini",
         "name": "Aion 3.0 Mini",
@@ -30484,7 +30970,6 @@
           {
             "type": "effort",
             "values": [
-              "none",
               "low",
               "medium",
               "high"
@@ -30520,6 +31005,7 @@
         "tool_call": true,
         "structured_output": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-06-11",
         "modalities": {
@@ -30636,6 +31122,7 @@
         "tool_call": true,
         "structured_output": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-06-11",
         "modalities": {
@@ -31512,6 +31999,47 @@
           "output": 50000
         }
       },
+      "openai-gpt-56-luna-pro": {
+        "id": "openai-gpt-56-luna-pro",
+        "name": "GPT-5.6 Luna Pro",
+        "description": "Frontier GPT model for professional reasoning, coding, and multimodal work",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
       "nvidia-nemotron-3-ultra-550b-a55b": {
         "id": "nvidia-nemotron-3-ultra-550b-a55b",
         "name": "NVIDIA Nemotron 3 Ultra",
@@ -31559,7 +32087,6 @@
           {
             "type": "effort",
             "values": [
-              "none",
               "low",
               "medium",
               "high"
@@ -31660,6 +32187,47 @@
           "output": 32768
         }
       },
+      "openai-gpt-56-sol": {
+        "id": "openai-gpt-56-sol",
+        "name": "GPT-5.6 Sol",
+        "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
       "minimax-m25": {
         "id": "minimax-m25",
         "name": "MiniMax M2.5",
@@ -31724,6 +32292,996 @@
       }
     }
   },
+  "crossmodel": {
+    "id": "crossmodel",
+    "env": [
+      "CROSSMODEL_API_KEY"
+    ],
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.crossmodel.ai/v1",
+    "name": "CrossModel",
+    "doc": "https://www.crossmodel.ai/docs",
+    "models": {
+      "z-ai/glm-5.2": {
+        "id": "z-ai/glm-5.2",
+        "name": "GLM-5.2",
+        "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-06-13",
+        "last_updated": "2026-06-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "z-ai/glm-5": {
+        "id": "z-ai/glm-5",
+        "name": "GLM-5",
+        "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-02-12",
+        "last_updated": "2026-02-12",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 200000,
+          "output": 128000
+        }
+      },
+      "openai/gpt-5.4-nano": {
+        "id": "openai/gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
+        "description": "Cheapest GPT-5.4 lane for simple routing, extraction, and bulk automation",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "openai/gpt-5.4": {
+        "id": "openai/gpt-5.4",
+        "name": "GPT-5.4",
+        "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-05",
+        "last_updated": "2026-03-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        }
+      },
+      "openai/gpt-5.4-mini": {
+        "id": "openai/gpt-5.4-mini",
+        "name": "GPT-5.4 mini",
+        "description": "Strong small GPT for coding subagents, quick tool use, and high-volume work",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "openai/gpt-4o-mini": {
+        "id": "openai/gpt-4o-mini",
+        "name": "GPT-4o mini",
+        "description": "Small omni GPT for cheap multimodal assistance and production-scale traffic",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2023-09",
+        "release_date": "2024-07-18",
+        "last_updated": "2024-07-18",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        }
+      },
+      "xiaomi/mimo-v2.5": {
+        "id": "xiaomi/mimo-v2.5",
+        "name": "MiMo-V2.5",
+        "description": "Open MiMo model for multimodal coding agents and long-context automation",
+        "family": "mimo",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-04-22",
+        "last_updated": "2026-04-22",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "xiaomi/mimo-v2.5-pro": {
+        "id": "xiaomi/mimo-v2.5-pro",
+        "name": "MiMo-V2.5-Pro",
+        "description": "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution",
+        "family": "mimo",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-04-22",
+        "last_updated": "2026-04-22",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "anthropic/claude-opus-4-7": {
+        "id": "anthropic/claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-04-16",
+        "last_updated": "2026-04-16",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "anthropic/claude-sonnet-5": {
+        "id": "anthropic/claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-06-30",
+        "last_updated": "2026-06-30",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "anthropic/claude-opus-4-8": {
+        "id": "anthropic/claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01",
+        "release_date": "2026-05-28",
+        "last_updated": "2026-05-28",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "anthropic/claude-fable-5": {
+        "id": "anthropic/claude-fable-5",
+        "name": "Claude Fable 5",
+        "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+        "family": "claude-fable",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-06-09",
+        "last_updated": "2026-06-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "anthropic/claude-haiku-4-5": {
+        "id": "anthropic/claude-haiku-4-5",
+        "name": "Claude Haiku 4.5 (latest)",
+        "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",
+        "family": "claude-haiku",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "budget_tokens",
+            "min": 1024
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-02-28",
+        "release_date": "2025-10-15",
+        "last_updated": "2025-10-15",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        }
+      },
+      "anthropic/claude-sonnet-4-6": {
+        "id": "anthropic/claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1024
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-02-17",
+        "last_updated": "2026-03-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        }
+      },
+      "tencent/hy3-preview": {
+        "id": "tencent/hy3-preview",
+        "name": "Hy3 preview",
+        "description": "Tencent Hy reasoning model for coding, instruction following, and agent tasks",
+        "family": "Hy",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-04-20",
+        "last_updated": "2026-04-20",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 256000,
+          "output": 128000
+        }
+      },
+      "moonshot/kimi-k2.7-code": {
+        "id": "moonshot/kimi-k2.7-code",
+        "name": "Kimi K2.7 Code",
+        "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+        "family": "kimi-k2",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-01",
+        "release_date": "2026-06-12",
+        "last_updated": "2026-06-12",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262000,
+          "output": 262000
+        }
+      },
+      "gemini/gemini-3.5-flash": {
+        "id": "gemini/gemini-3.5-flash",
+        "name": "Gemini 3.5 Flash",
+        "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+        "family": "gemini-flash",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-05-19",
+        "last_updated": "2026-05-19",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        }
+      },
+      "gemini/gemini-3.1-pro-preview": {
+        "id": "gemini/gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro Preview",
+        "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
+        "family": "gemini-pro",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-02-19",
+        "last_updated": "2026-02-19",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        }
+      },
+      "gemini/gemini-3-flash-preview": {
+        "id": "gemini/gemini-3-flash-preview",
+        "name": "Gemini 3 Flash Preview",
+        "description": "New Gemini flash lane bringing frontier-style multimodal reasoning to cheaper runs",
+        "family": "gemini-flash",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2025-12-17",
+        "last_updated": "2025-12-17",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        }
+      },
+      "qwen/qwen3.7-plus": {
+        "id": "qwen/qwen3.7-plus",
+        "name": "Qwen3.7 Plus",
+        "description": "Multimodal Qwen workhorse for long-context agents, visual inputs, and coding",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "budget_tokens"
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2026-06-02",
+        "last_updated": "2026-06-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        }
+      },
+      "qwen/qwen3.7-max": {
+        "id": "qwen/qwen3.7-max",
+        "name": "Qwen3.7 Max",
+        "description": "Qwen frontier model tuned for agent frameworks, coding assistants, and long tasks",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "budget_tokens"
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-05-21",
+        "last_updated": "2026-05-21",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        }
+      },
+      "qwen/qwen3.6-flash": {
+        "id": "qwen/qwen3.6-flash",
+        "name": "Qwen3.6 Flash",
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+        "family": "qwen3.6",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "budget_tokens"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-27",
+        "last_updated": "2026-04-27",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        }
+      },
+      "qwen/qwen3.6-plus": {
+        "id": "qwen/qwen3.6-plus",
+        "name": "Qwen3.6 Plus",
+        "description": "Earlier Qwen multimodal workhorse for million-token agent and document tasks",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "budget_tokens"
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        }
+      },
+      "deepseek/deepseek-v4-flash": {
+        "id": "deepseek/deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash",
+        "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+        "family": "deepseek-flash",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 65000
+        }
+      },
+      "deepseek/deepseek-v4-pro": {
+        "id": "deepseek/deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro",
+        "description": "Open MoE flagship with million-token context for coding and long agent runs",
+        "family": "deepseek-thinking",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 65000
+        }
+      },
+      "minimax/minimax-m3": {
+        "id": "minimax/minimax-m3",
+        "name": "MiniMax-M3",
+        "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+        "family": "minimax",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-06-01",
+        "last_updated": "2026-06-01",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1024000,
+          "output": 512000
+        }
+      },
+      "minimax/minimax-m2.7": {
+        "id": "minimax/minimax-m2.7",
+        "name": "MiniMax-M2.7",
+        "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-03-18",
+        "last_updated": "2026-03-18",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        }
+      }
+    }
+  },
   "poolside": {
     "id": "poolside",
     "env": [
@@ -31737,26 +33295,16 @@
       "poolside/laguna-xs.2": {
         "id": "poolside/laguna-xs.2",
         "name": "Laguna XS.2",
-        "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
+        "description": "Agentic coding model from Poolside in the XS size class for local deployment",
+        "family": "laguna",
         "attachment": false,
         "reasoning": true,
-        "reasoning_options": [
-          {
-            "type": "effort",
-            "values": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
-          }
-        ],
+        "reasoning_options": [],
         "tool_call": true,
         "interleaved": {
           "field": "reasoning_content"
         },
+        "structured_output": false,
         "temperature": true,
         "release_date": "2026-04-28",
         "last_updated": "2026-06-13",
@@ -31777,26 +33325,16 @@
       "poolside/laguna-m.1": {
         "id": "poolside/laguna-m.1",
         "name": "Laguna M.1",
-        "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
+        "description": "Poolside's flagship agentic coding model for long-horizon work",
+        "family": "laguna",
         "attachment": false,
         "reasoning": true,
-        "reasoning_options": [
-          {
-            "type": "effort",
-            "values": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
-          }
-        ],
+        "reasoning_options": [],
         "tool_call": true,
         "interleaved": {
           "field": "reasoning_content"
         },
+        "structured_output": false,
         "temperature": true,
         "release_date": "2026-04-28",
         "last_updated": "2026-06-13",
@@ -31808,10 +33346,82 @@
             "text"
           ]
         },
-        "open_weights": false,
+        "open_weights": true,
         "limit": {
           "context": 262144,
           "output": 32768
+        }
+      },
+      "poolside/laguna-xs-2.1": {
+        "id": "poolside/laguna-xs-2.1",
+        "name": "Laguna XS 2.1",
+        "description": "Agentic coding model from Poolside in the XS size class for local deployment",
+        "family": "laguna",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": false,
+        "temperature": true,
+        "release_date": "2026-07-02",
+        "last_updated": "2026-07-02",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        }
+      }
+    }
+  },
+  "zenifra": {
+    "id": "zenifra",
+    "env": [
+      "ZENIFRA_AI_KEY"
+    ],
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://ai.zenifra.com/v1",
+    "name": "Zenifra",
+    "doc": "https://docs.zenifra.com",
+    "models": {
+      "alibaba/qwen3.6-35b-a3b": {
+        "id": "alibaba/qwen3.6-35b-a3b",
+        "name": "Qwen3.6 35B-A3B",
+        "description": "Open multimodal Qwen MoE for local agents that need vision, audio, and code",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-17",
+        "last_updated": "2026-04-17",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 65536
+        },
+        "provider": {
+          "shape": "completions"
         }
       }
     }
@@ -33656,6 +35266,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -35033,6 +36644,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -35386,6 +36998,557 @@
       }
     }
   },
+  "model-oracle-ai": {
+    "id": "model-oracle-ai",
+    "env": [
+      "MODEL_ORACLE_API_KEY"
+    ],
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.modeloracle.com/api/v1",
+    "name": "Model Oracle AI",
+    "doc": "https://modeloracle.com/setup/",
+    "models": {
+      "gpt-5": {
+        "id": "gpt-5",
+        "name": "GPT-5",
+        "description": "Original GPT-5 workhorse for reasoning, coding, writing, and tool workflows",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "release_date": "2025-08-07",
+        "last_updated": "2025-08-07",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "claude-haiku-4.5": {
+        "id": "claude-haiku-4.5",
+        "name": "Claude Haiku 4.5 (latest)",
+        "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",
+        "family": "claude-haiku",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-02-28",
+        "release_date": "2025-10-15",
+        "last_updated": "2025-10-15",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        }
+      },
+      "o4-mini": {
+        "id": "o4-mini",
+        "name": "o4-mini",
+        "description": "Fast o-series model for compact reasoning, coding, and tool use",
+        "family": "o-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-05",
+        "release_date": "2025-04-16",
+        "last_updated": "2025-04-16",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        }
+      },
+      "deepseek-v4-pro": {
+        "id": "deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro",
+        "description": "Open MoE flagship with million-token context for coding and long agent runs",
+        "family": "deepseek-thinking",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "high",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        }
+      },
+      "claude-sonnet-5": {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-06-30",
+        "last_updated": "2026-06-30",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "gpt-5.4-nano": {
+        "id": "gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
+        "description": "Cheapest GPT-5.4 lane for simple routing, extraction, and bulk automation",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "glm-5.2": {
+        "id": "glm-5.2",
+        "name": "GLM-5.2",
+        "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-06-13",
+        "last_updated": "2026-06-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      },
+      "claude-opus-4.8": {
+        "id": "claude-opus-4.8",
+        "name": "Claude Opus 4.8",
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01",
+        "release_date": "2026-05-28",
+        "last_updated": "2026-05-28",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "claude-fable-5": {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+        "family": "claude-fable",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-06-09",
+        "last_updated": "2026-06-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "gpt-5.4": {
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-05",
+        "last_updated": "2026-03-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        }
+      },
+      "gpt-5.4-mini": {
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 mini",
+        "description": "Strong small GPT for coding subagents, quick tool use, and high-volume work",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "gpt-4.1": {
+        "id": "gpt-4.1",
+        "name": "GPT-4.1",
+        "description": "Long-lived GPT workhorse for coding, instruction following, and production apps",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14",
+        "last_updated": "2025-04-14",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        }
+      },
+      "gpt-4.1-mini": {
+        "id": "gpt-4.1-mini",
+        "name": "GPT-4.1 mini",
+        "description": "Affordable GPT-4.1 lane for fast coding help and structured extraction",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14",
+        "last_updated": "2025-04-14",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        }
+      },
+      "auto": {
+        "id": "auto",
+        "name": "Auto",
+        "description": "Model Oracle AI decision engine that selects and routes among configured coding-agent models",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-06-29",
+        "last_updated": "2026-07-07",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      }
+    }
+  },
   "openai": {
     "id": "openai",
     "env": [
@@ -35497,6 +37660,69 @@
           "context": 400000,
           "input": 272000,
           "output": 128000
+        }
+      },
+      "gpt-5.6": {
+        "id": "gpt-5.6",
+        "name": "GPT-5.6",
+        "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            },
+            "pro": {
+              "provider": {
+                "body": {
+                  "reasoning": {
+                    "mode": "pro"
+                  }
+                }
+              }
+            }
+          }
         }
       },
       "gpt-5": {
@@ -36211,6 +38437,69 @@
           "output": 1536
         }
       },
+      "gpt-5.6-luna": {
+        "id": "gpt-5.6-luna",
+        "name": "GPT-5.6 Luna",
+        "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            },
+            "pro": {
+              "provider": {
+                "body": {
+                  "reasoning": {
+                    "mode": "pro"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "gpt-5.1-codex-mini": {
         "id": "gpt-5.1-codex-mini",
         "name": "GPT-5.1 Codex mini",
@@ -36248,6 +38537,112 @@
           "context": 400000,
           "input": 272000,
           "output": 128000
+        }
+      },
+      "gpt-realtime-2.1": {
+        "id": "gpt-realtime-2.1",
+        "name": "GPT-Realtime-2.1",
+        "description": "Realtime speech-to-speech model with configurable reasoning, tool use, and robust voice-agent behavior",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": false,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "release_date": "2026-07-06",
+        "last_updated": "2026-07-06",
+        "modalities": {
+          "input": [
+            "text",
+            "audio",
+            "image"
+          ],
+          "output": [
+            "text",
+            "audio"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 128000,
+          "input": 96000,
+          "output": 32000
+        }
+      },
+      "gpt-5.6-terra": {
+        "id": "gpt-5.6-terra",
+        "name": "GPT-5.6 Terra",
+        "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            },
+            "pro": {
+              "provider": {
+                "body": {
+                  "reasoning": {
+                    "mode": "pro"
+                  }
+                }
+              }
+            }
+          }
         }
       },
       "gpt-5.1-chat-latest": {
@@ -36947,6 +39342,69 @@
           "output": 16384
         }
       },
+      "gpt-5.6-sol": {
+        "id": "gpt-5.6-sol",
+        "name": "GPT-5.6 Sol",
+        "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            },
+            "pro": {
+              "provider": {
+                "body": {
+                  "reasoning": {
+                    "mode": "pro"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "gpt-5-codex": {
         "id": "gpt-5-codex",
         "name": "GPT-5-Codex",
@@ -37537,6 +39995,7 @@
         "reasoning_options": [],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -43070,7 +45529,7 @@
         ],
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-01",
         "last_updated": "2025-11-01",
         "modalities": {
@@ -43108,6 +45567,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -46107,7 +48567,7 @@
         "reasoning_options": [],
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-24",
         "last_updated": "2025-11-24",
         "modalities": {
@@ -49998,6 +52458,2856 @@
       }
     }
   },
+  "pioneer": {
+    "id": "pioneer",
+    "env": [
+      "PIONEER_API_KEY"
+    ],
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.pioneer.ai/v1",
+    "name": "Pioneer",
+    "doc": "https://agent.pioneer.ai/llms.txt",
+    "models": {
+      "gemini-3-flash": {
+        "id": "gemini-3-flash",
+        "name": "Gemini 3 Flash Preview",
+        "description": "New Gemini flash lane bringing frontier-style multimodal reasoning to cheaper runs",
+        "family": "gemini-flash",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2025-12-17",
+        "last_updated": "2025-12-17",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65535
+        }
+      },
+      "qwen3.7-plus": {
+        "id": "qwen3.7-plus",
+        "name": "Qwen3.7 Plus",
+        "description": "Multimodal Qwen workhorse for long-context agents, visual inputs, and coding",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2026-06-02",
+        "last_updated": "2026-06-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        }
+      },
+      "claude-opus-4-5": {
+        "id": "claude-opus-4-5",
+        "name": "Claude Opus 4.5 (latest)",
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2025-11-24",
+        "last_updated": "2025-11-24",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        }
+      },
+      "qwen3.7-max": {
+        "id": "qwen3.7-max",
+        "name": "Qwen3.7 Max",
+        "description": "Qwen frontier model tuned for agent frameworks, coding assistants, and long tasks",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2026-05-21",
+        "last_updated": "2026-05-21",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        }
+      },
+      "gpt-4o": {
+        "id": "gpt-4o",
+        "name": "GPT-4o",
+        "description": "Omni-era GPT for multimodal chat, practical coding, and general assistants",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2023-09",
+        "release_date": "2024-05-13",
+        "last_updated": "2024-08-06",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        }
+      },
+      "gemini-3.5-flash": {
+        "id": "gemini-3.5-flash",
+        "name": "Gemini 3.5 Flash",
+        "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+        "family": "gemini-flash",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-05-19",
+        "last_updated": "2026-05-19",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        }
+      },
+      "claude-sonnet-4-5": {
+        "id": "claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5 (latest)",
+        "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2025-07-31",
+        "release_date": "2025-09-29",
+        "last_updated": "2025-09-29",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        }
+      },
+      "claude-opus-4-7": {
+        "id": "claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-04-16",
+        "last_updated": "2026-04-16",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "gpt-5.4-nano": {
+        "id": "gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
+        "description": "Cheapest GPT-5.4 lane for simple routing, extraction, and bulk automation",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1047576,
+          "output": 128000
+        }
+      },
+      "qwen3.6-flash": {
+        "id": "qwen3.6-flash",
+        "name": "Qwen3.6 Flash",
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+        "family": "qwen3.6",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-27",
+        "last_updated": "2026-04-27",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        }
+      },
+      "claude-opus-4-8": {
+        "id": "claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": false,
+        "knowledge": "2026-01",
+        "release_date": "2026-05-28",
+        "last_updated": "2026-05-28",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "mistral-medium-3.5": {
+        "id": "mistral-medium-3.5",
+        "name": "Mistral Medium 3.5",
+        "description": "Balanced Mistral model for enterprise assistants, multilingual work, and tools",
+        "family": "mistral-medium",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-29",
+        "last_updated": "2026-04-29",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 131072
+        }
+      },
+      "gpt-5.3-codex": {
+        "id": "gpt-5.3-codex",
+        "name": "GPT-5.3 Codex",
+        "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
+        "family": "gpt-codex",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-02-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "claude-opus-4-1": {
+        "id": "claude-opus-4-1",
+        "name": "Claude Opus 4.1 (latest)",
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2025-03-31",
+        "release_date": "2025-08-05",
+        "last_updated": "2025-08-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        }
+      },
+      "gpt-4.1-nano": {
+        "id": "gpt-4.1-nano",
+        "name": "GPT-4.1 nano",
+        "description": "Tiny GPT-4.1 option for classification, routing, and very high-volume tasks",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14",
+        "last_updated": "2025-04-14",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        }
+      },
+      "claude-haiku-4-5": {
+        "id": "claude-haiku-4-5",
+        "name": "Claude Haiku 4.5 (latest)",
+        "description": "Fast Claude lane for lightweight agents, office tasks, and responsive chat",
+        "family": "claude-haiku",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2025-02-28",
+        "release_date": "2025-10-15",
+        "last_updated": "2025-10-15",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        }
+      },
+      "gpt-5.4": {
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-05",
+        "last_updated": "2026-03-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "output": 128000
+        }
+      },
+      "gpt-5.4-mini": {
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 mini",
+        "description": "Strong small GPT for coding subagents, quick tool use, and high-volume work",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "gpt-4.1": {
+        "id": "gpt-4.1",
+        "name": "GPT-4.1",
+        "description": "Long-lived GPT workhorse for coding, instruction following, and production apps",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14",
+        "last_updated": "2025-04-14",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        }
+      },
+      "claude-opus-4-6": {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2025-05-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-03-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "gpt-5-mini": {
+        "id": "gpt-5-mini",
+        "name": "GPT-5 Mini",
+        "description": "Small GPT-5 for responsive agents, coding help, and everyday automation",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-05-30",
+        "release_date": "2025-08-07",
+        "last_updated": "2025-08-07",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "gpt-4.1-mini": {
+        "id": "gpt-4.1-mini",
+        "name": "GPT-4.1 mini",
+        "description": "Affordable GPT-4.1 lane for fast coding help and structured extraction",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14",
+        "last_updated": "2025-04-14",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        }
+      },
+      "gpt-5-nano": {
+        "id": "gpt-5-nano",
+        "name": "GPT-5 Nano",
+        "description": "Tiny GPT-5 lane for routing, extraction, classification, and bulk jobs",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-05-30",
+        "release_date": "2025-08-07",
+        "last_updated": "2025-08-07",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "claude-sonnet-4-6": {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-02-17",
+        "last_updated": "2026-03-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "gemini-3.1-pro": {
+        "id": "gemini-3.1-pro",
+        "name": "Gemini 3.1 Pro Preview",
+        "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
+        "family": "gemini-pro",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-02-19",
+        "last_updated": "2026-02-19",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        }
+      },
+      "gpt-4o-mini": {
+        "id": "gpt-4o-mini",
+        "name": "GPT-4o mini",
+        "description": "Small omni GPT for cheap multimodal assistance and production-scale traffic",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2023-09",
+        "release_date": "2024-07-18",
+        "last_updated": "2024-07-18",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        }
+      },
+      "qwen3.6-max-preview": {
+        "id": "qwen3.6-max-preview",
+        "name": "Qwen3.6 Max Preview",
+        "description": "Flagship Qwen model for complex reasoning, coding, and agentic workflows",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2026-04-20",
+        "last_updated": "2026-04-20",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 262144,
+          "output": 65536
+        }
+      },
+      "qwen3.6-plus": {
+        "id": "qwen3.6-plus",
+        "name": "Qwen3.6 Plus",
+        "description": "Earlier Qwen multimodal workhorse for million-token agent and document tasks",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        }
+      },
+      "gpt-5.1": {
+        "id": "gpt-5.1",
+        "name": "GPT-5.1",
+        "description": "Sharper GPT-5 generation for coding, product work, and tool-assisted tasks",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13",
+        "last_updated": "2025-11-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "LiquidAI/LFM2-24B-A2B": {
+        "id": "LiquidAI/LFM2-24B-A2B",
+        "name": "LFM2 24B A2B",
+        "description": "Open-weight instruction model for adaptable chat and self-hosted production workloads",
+        "family": "liquid",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": false,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2026-01-31",
+        "last_updated": "2026-02-25",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        }
+      },
+      "HuggingFaceTB/SmolLM3-3B-Base": {
+        "id": "HuggingFaceTB/SmolLM3-3B-Base",
+        "name": "SmolLM3 3B Base",
+        "description": "Tool-capable chat model for instruction following and agentic application workflows",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2025-06-30",
+        "last_updated": "2025-06-30",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        }
+      },
+      "meta-llama/Llama-3.2-1B-Instruct": {
+        "id": "meta-llama/Llama-3.2-1B-Instruct",
+        "name": "Llama 3.2 1B Instruct",
+        "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
+        "family": "llama",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": false,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2023-12-31",
+        "release_date": "2024-08-31",
+        "last_updated": "2024-09-25",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 60000
+        }
+      },
+      "meta-llama/Llama-3.3-70B-Instruct": {
+        "id": "meta-llama/Llama-3.3-70B-Instruct",
+        "name": "Llama-3.3-70B-Instruct",
+        "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
+        "family": "llama",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2023-12",
+        "release_date": "2024-12-06",
+        "last_updated": "2024-12-06",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 4096
+        }
+      },
+      "meta-llama/Llama-3.1-8B-Instruct": {
+        "id": "meta-llama/Llama-3.1-8B-Instruct",
+        "name": "Llama 3.1 8B Instruct",
+        "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
+        "family": "llama",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2023-12-31",
+        "release_date": "2024-06-30",
+        "last_updated": "2024-07-23",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 16384
+        }
+      },
+      "meta-llama/Llama-3.2-3B-Instruct": {
+        "id": "meta-llama/Llama-3.2-3B-Instruct",
+        "name": "Llama 3.2 3B Instruct",
+        "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
+        "family": "llama",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": false,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2023-12-31",
+        "release_date": "2024-08-31",
+        "last_updated": "2024-09-25",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 80000
+        }
+      },
+      "moonshotai/Kimi-K2.7-Code": {
+        "id": "moonshotai/Kimi-K2.7-Code",
+        "name": "Kimi K2.7 Code",
+        "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+        "family": "kimi-k2",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-01",
+        "release_date": "2026-06-12",
+        "last_updated": "2026-06-12",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        }
+      },
+      "google/gemma-4-31B-it": {
+        "id": "google/gemma-4-31B-it",
+        "name": "Gemma 4 31B IT",
+        "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
+        "family": "gemma",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        }
+      },
+      "google/diffusiongemma-26B-A4B-it": {
+        "id": "google/diffusiongemma-26B-A4B-it",
+        "name": "DiffusionGemma 26B-A4B IT",
+        "description": "Gemini model for general assistance, reasoning, and multimodal workflows",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2026-05-31",
+        "last_updated": "2026-05-31",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 262144,
+          "output": 4096
+        }
+      },
+      "google/gemma-3-4b-pt": {
+        "id": "google/gemma-3-4b-pt",
+        "name": "Gemma 3 4B (Pretrained)",
+        "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2025-02-28",
+        "last_updated": "2025-02-28",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        }
+      },
+      "google/gemma-4-E4B-it": {
+        "id": "google/gemma-4-E4B-it",
+        "name": "Gemma 4 E4B IT",
+        "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
+        "family": "gemma",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        }
+      },
+      "google/gemma-4-E2B-it": {
+        "id": "google/gemma-4-E2B-it",
+        "name": "Gemma 4 E2B IT",
+        "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
+        "family": "gemma",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        }
+      },
+      "google/gemma-4-12B-it": {
+        "id": "google/gemma-4-12B-it",
+        "name": "Gemma 4 12B IT",
+        "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2026-05-31",
+        "last_updated": "2026-05-31",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        }
+      },
+      "Qwen/Qwen3.6-35B-A3B": {
+        "id": "Qwen/Qwen3.6-35B-A3B",
+        "name": "Qwen3.6 35B-A3B",
+        "description": "Open multimodal Qwen MoE for local agents that need vision, audio, and code",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-17",
+        "last_updated": "2026-04-17",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 131072
+        }
+      },
+      "Qwen/Qwen3-4B-Instruct-2507": {
+        "id": "Qwen/Qwen3-4B-Instruct-2507",
+        "name": "Qwen3 4B Instruct",
+        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2025-07-31",
+        "last_updated": "2025-07-31",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 262144,
+          "output": 4096
+        }
+      },
+      "Qwen/Qwen3.6-27B": {
+        "id": "Qwen/Qwen3.6-27B",
+        "name": "Qwen3.6 27B",
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-22",
+        "last_updated": "2026-04-22",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        }
+      },
+      "Qwen/Qwen3-4B-Base": {
+        "id": "Qwen/Qwen3-4B-Base",
+        "name": "Qwen3 4B Base",
+        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2025-03-31",
+        "last_updated": "2025-03-31",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        }
+      },
+      "Qwen/Qwen3-1.7B-Base": {
+        "id": "Qwen/Qwen3-1.7B-Base",
+        "name": "Qwen3 1.7B Base",
+        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2025-03-31",
+        "last_updated": "2025-03-31",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        }
+      },
+      "Qwen/Qwen3-8B": {
+        "id": "Qwen/Qwen3-8B",
+        "name": "Qwen3 8B",
+        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2025-03-31",
+        "release_date": "2025-03-31",
+        "last_updated": "2025-04-28",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 4096
+        }
+      },
+      "Qwen/Qwen3.5-9B": {
+        "id": "Qwen/Qwen3.5-9B",
+        "name": "Qwen3.5 9B",
+        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-23",
+        "last_updated": "2026-02-23",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        }
+      },
+      "Qwen/Qwen3-32B": {
+        "id": "Qwen/Qwen3-32B",
+        "name": "Qwen3 32B",
+        "description": "Dense open Qwen model for self-hosted chat, reasoning, and coding",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2025-04",
+        "last_updated": "2025-04",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 16384
+        }
+      },
+      "openai/gpt-oss-120b": {
+        "id": "openai/gpt-oss-120b",
+        "name": "GPT OSS 120B",
+        "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+        "family": "gpt-oss",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2025-08-05",
+        "last_updated": "2025-08-05",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        }
+      },
+      "openai/gpt-oss-20b": {
+        "id": "openai/gpt-oss-20b",
+        "name": "GPT OSS 20B",
+        "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
+        "family": "gpt-oss",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2025-08-05",
+        "last_updated": "2025-08-05",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 8192
+        }
+      },
+      "XiaomiMiMo/MiMo-V2.5": {
+        "id": "XiaomiMiMo/MiMo-V2.5",
+        "name": "MiMo-V2.5",
+        "description": "Open MiMo model for multimodal coding agents and long-context automation",
+        "family": "mimo",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-04-22",
+        "last_updated": "2026-04-22",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1050000,
+          "output": 131072
+        }
+      },
+      "XiaomiMiMo/MiMo-V2.5-Pro": {
+        "id": "XiaomiMiMo/MiMo-V2.5-Pro",
+        "name": "MiMo-V2.5-Pro",
+        "description": "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution",
+        "family": "mimo",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-04-22",
+        "last_updated": "2026-04-22",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1050000,
+          "output": 131072
+        }
+      },
+      "mistralai/Mistral-Small-4-119B-2603": {
+        "id": "mistralai/Mistral-Small-4-119B-2603",
+        "name": "Mistral Small 4",
+        "description": "Fast Mistral production model for chat, extraction, and cost-sensitive agents",
+        "family": "mistral-small",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2025-06",
+        "release_date": "2026-03-16",
+        "last_updated": "2026-03-16",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 65536
+        }
+      },
+      "mistralai/Mistral-7B-Instruct-v0.3": {
+        "id": "mistralai/Mistral-7B-Instruct-v0.3",
+        "name": "Mistral 7B Instruct v0.3",
+        "description": "Mistral model for multilingual chat, reasoning, and tool-assisted workflows",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2023-04-30",
+        "last_updated": "2023-04-30",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        }
+      },
+      "mistralai/Mistral-Nemo-Instruct-2407": {
+        "id": "mistralai/Mistral-Nemo-Instruct-2407",
+        "name": "Mistral Nemo",
+        "description": "Efficient Mistral-NVIDIA open model for multilingual chat and local deployment",
+        "family": "mistral-nemo",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2024-07",
+        "release_date": "2024-07-01",
+        "last_updated": "2024-07-01",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 128000
+        }
+      },
+      "pioneer/auto": {
+        "id": "pioneer/auto",
+        "name": "Pioneer Auto",
+        "description": "Automatic model router for matching prompts to suitable backends and budgets",
+        "family": "auto",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2024-01-01",
+        "last_updated": "2025-06-29",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 4096
+        }
+      },
+      "sakana/fugu-ultra": {
+        "id": "sakana/fugu-ultra",
+        "name": "Fugu Ultra",
+        "description": "Quality-first multi-agent model for hard research, analysis, and competitions",
+        "family": "fugu",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": false,
+        "release_date": "2026-06-15",
+        "last_updated": "2026-06-15",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      },
+      "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": {
+        "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
+        "name": "Nemotron 3 Ultra 550B A55B",
+        "description": "Largest Nemotron 3 model for maximum open-weight reasoning and agent accuracy",
+        "family": "nemotron",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2026-06-04",
+        "last_updated": "2026-06-04",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 65000
+        }
+      },
+      "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": {
+        "id": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+        "name": "Nemotron 3 Nano 30B A3B",
+        "description": "Small Nemotron 3 MoE for efficient coding, math, and long-context agents",
+        "family": "nemotron",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2025-12-15",
+        "last_updated": "2025-12-15",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 131072
+        }
+      },
+      "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
+        "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
+        "name": "Nemotron 3 Super 120B A12B",
+        "description": "Nemotron middle tier for collaborative agents and high-volume reasoning workloads",
+        "family": "nemotron",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2026-03-11",
+        "last_updated": "2026-03-11",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 32000
+        }
+      },
+      "zai-org/GLM-5.2": {
+        "id": "zai-org/GLM-5.2",
+        "name": "GLM-5.2",
+        "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-06-13",
+        "last_updated": "2026-06-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1048576,
+          "output": 128000
+        }
+      },
+      "deepseek-ai/DeepSeek-V4-Flash": {
+        "id": "deepseek-ai/DeepSeek-V4-Flash",
+        "name": "DeepSeek V4 Flash",
+        "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+        "family": "deepseek-flash",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "id": "deepseek-ai/DeepSeek-V4-Pro",
+        "name": "DeepSeek V4 Pro",
+        "description": "Open MoE flagship with million-token context for coding and long agent runs",
+        "family": "deepseek-thinking",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      },
+      "fastino/gliner2-multi-large-v1": {
+        "id": "fastino/gliner2-multi-large-v1",
+        "name": "GLiNER2 Multi Large",
+        "description": "Flagship model for demanding analysis, coding, and production agent workflows",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2025-11-30",
+        "last_updated": "2025-11-30",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 8192,
+          "output": 4096
+        }
+      },
+      "fastino/gliner2-multi-v1": {
+        "id": "fastino/gliner2-multi-v1",
+        "name": "GLiNER2 Multi",
+        "description": "Tool-capable chat model for instruction following and agentic application workflows",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2025-11-30",
+        "last_updated": "2025-11-30",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 8192,
+          "output": 4096
+        }
+      },
+      "fastino/gliguard-LLMGuardrails-300M": {
+        "id": "fastino/gliguard-LLMGuardrails-300M",
+        "name": "GLiGuard LLM Guardrails 300M",
+        "description": "Tool-capable chat model for instruction following and agentic application workflows",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-04-30",
+        "last_updated": "2026-04-30",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 8192,
+          "output": 4096
+        }
+      },
+      "fastino/gliner2-privacy-filter-PII-multi": {
+        "id": "fastino/gliner2-privacy-filter-PII-multi",
+        "name": "GLiNER2 Privacy Filter PII (Multi)",
+        "description": "Tool-capable chat model for instruction following and agentic application workflows",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-04-30",
+        "last_updated": "2026-04-30",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 8192,
+          "output": 4096
+        }
+      },
+      "fastino/gliner2-base-v1": {
+        "id": "fastino/gliner2-base-v1",
+        "name": "GLiNER2 Base",
+        "description": "Tool-capable chat model for instruction following and agentic application workflows",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2025-06-30",
+        "last_updated": "2025-06-30",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 8192,
+          "output": 4096
+        }
+      },
+      "fastino/gliner2-large-v1": {
+        "id": "fastino/gliner2-large-v1",
+        "name": "GLiNER2 Large",
+        "description": "Flagship model for demanding analysis, coding, and production agent workflows",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2025-06-30",
+        "last_updated": "2025-06-30",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 8192,
+          "output": 4096
+        }
+      },
+      "MiniMaxAI/MiniMax-M3": {
+        "id": "MiniMaxAI/MiniMax-M3",
+        "name": "MiniMax-M3",
+        "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+        "family": "minimax",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2026-06-01",
+        "last_updated": "2026-06-01",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      },
+      "MiniMaxAI/MiniMax-M2.7": {
+        "id": "MiniMaxAI/MiniMax-M2.7",
+        "name": "MiniMax-M2.7",
+        "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "release_date": "2026-03-18",
+        "last_updated": "2026-03-18",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        }
+      }
+    }
+  },
   "llmgateway": {
     "id": "llmgateway",
     "env": [
@@ -51260,6 +56570,48 @@
           "output": 8192
         }
       },
+      "muse-spark-1.1": {
+        "id": "muse-spark-1.1",
+        "name": "Muse Spark 1.1",
+        "description": "Muse Spark is a natively multimodal reasoning model with support for tool-use, visual chain of thought, and multi-agent orchestration.",
+        "family": "muse",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-08",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 32000
+        }
+      },
       "claude-opus-4-1-20250805": {
         "id": "claude-opus-4-1-20250805",
         "name": "Claude Opus 4.1",
@@ -51884,8 +57236,37 @@
         },
         "open_weights": true,
         "limit": {
-          "context": 1000000,
+          "context": 1024000,
           "output": 131072
+        }
+      },
+      "qwen3.6-flash": {
+        "id": "qwen3.6-flash",
+        "name": "Qwen3.6 Flash",
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+        "family": "qwen3.6",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-27",
+        "last_updated": "2026-04-27",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 262144,
+          "output": 65536
         }
       },
       "gpt-5-chat-latest": {
@@ -52053,7 +57434,7 @@
         ],
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-01",
         "last_updated": "2025-11-01",
         "modalities": {
@@ -52158,6 +57539,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -52478,6 +57860,49 @@
           "output": 8192
         }
       },
+      "gpt-5.6-luna": {
+        "id": "gpt-5.6-luna",
+        "name": "GPT-5.6 Luna",
+        "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        }
+      },
       "gpt-5.1-codex-mini": {
         "id": "gpt-5.1-codex-mini",
         "name": "GPT-5.1 Codex mini",
@@ -52553,6 +57978,49 @@
         "limit": {
           "context": 256000,
           "output": 8192
+        }
+      },
+      "gpt-5.6-terra": {
+        "id": "gpt-5.6-terra",
+        "name": "GPT-5.6 Terra",
+        "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
         }
       },
       "gpt-5.2-chat-latest": {
@@ -54351,6 +59819,49 @@
           "output": 16384
         }
       },
+      "gpt-5.6-sol": {
+        "id": "gpt-5.6-sol",
+        "name": "GPT-5.6 Sol",
+        "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        }
+      },
       "deepseek-v3.2": {
         "id": "deepseek-v3.2",
         "name": "DeepSeek V3.2",
@@ -54994,12 +60505,13 @@
       "o3": {
         "id": "o3",
         "name": "o3",
-        "description": "O-series reasoning model for hard analysis, math, coding, and planning",
+        "description": "Deliberate o-series reasoner for hard math, coding, and multi-step analysis",
         "family": "o",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": true,
         "temperature": false,
         "knowledge": "2024-05",
         "release_date": "2025-04-16",
@@ -55019,18 +60531,47 @@
           "output": 100000
         }
       },
+      "gemini-3.1-flash-lite": {
+        "id": "gemini-3.1-flash-lite",
+        "name": "Gemini 3.1 Flash Lite",
+        "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+        "family": "gemini-flash-lite",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-05-07",
+        "last_updated": "2026-05-07",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        }
+      },
       "route-llm": {
         "id": "route-llm",
-        "name": "Route LLM",
-        "description": "Automatic model router for matching prompts to suitable backends and budgets",
+        "name": "RouteLLM",
+        "description": "RouteLLM routes prompts to an appropriate Abacus-backed text-generation model",
         "family": "gpt",
         "attachment": true,
         "reasoning": false,
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2024-10",
         "release_date": "2024-01-01",
-        "last_updated": "2024-01-01",
+        "last_updated": "2026-07-10",
         "modalities": {
           "input": [
             "text",
@@ -55043,7 +60584,7 @@
         "open_weights": false,
         "limit": {
           "context": 128000,
-          "output": 16384
+          "output": 64000
         }
       },
       "grok-code-fast-1": {
@@ -55131,12 +60672,13 @@
       "gpt-5": {
         "id": "gpt-5",
         "name": "GPT-5",
-        "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+        "description": "Original GPT-5 workhorse for reasoning, coding, writing, and tool workflows",
         "family": "gpt",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": true,
         "temperature": false,
         "knowledge": "2024-09-30",
         "release_date": "2025-08-07",
@@ -55153,6 +60695,7 @@
         "open_weights": false,
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         }
       },
@@ -55172,8 +60715,7 @@
         "modalities": {
           "input": [
             "text",
-            "image",
-            "pdf"
+            "image"
           ],
           "output": [
             "text"
@@ -55185,15 +60727,72 @@
           "output": 64000
         }
       },
+      "grok-4.3": {
+        "id": "grok-4.3",
+        "name": "Grok 4.3",
+        "description": "xAI's default Grok for chat, coding, agentic tools, and lower hallucination risk",
+        "family": "grok",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-17",
+        "last_updated": "2026-04-17",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 32768
+        }
+      },
+      "gpt-4o": {
+        "id": "gpt-4o",
+        "name": "GPT-4o",
+        "description": "Omni-era GPT for multimodal chat, practical coding, and general assistants",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2023-09",
+        "release_date": "2024-05-13",
+        "last_updated": "2024-08-06",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        }
+      },
       "o4-mini": {
         "id": "o4-mini",
         "name": "o4-mini",
-        "description": "O-series reasoning model for hard analysis, math, coding, and planning",
+        "description": "Fast o-series model for compact reasoning, coding, and tool use",
         "family": "o-mini",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": true,
         "temperature": false,
         "knowledge": "2024-05",
         "release_date": "2025-04-16",
@@ -55239,15 +60838,46 @@
           "output": 16384
         }
       },
+      "gemini-3.5-flash": {
+        "id": "gemini-3.5-flash",
+        "name": "Gemini 3.5 Flash",
+        "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+        "family": "gemini-flash",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-05-19",
+        "last_updated": "2026-05-19",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        }
+      },
       "o3-pro": {
         "id": "o3-pro",
         "name": "o3-pro",
-        "description": "O-series reasoning model for hard analysis, math, coding, and planning",
+        "description": "High-effort o3 tier for difficult technical reasoning and careful answers",
         "family": "o-pro",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": true,
         "temperature": false,
         "knowledge": "2024-05",
         "release_date": "2025-06-10",
@@ -55265,6 +60895,35 @@
         "limit": {
           "context": 200000,
           "output": 100000
+        }
+      },
+      "muse-spark-1.1": {
+        "id": "muse-spark-1.1",
+        "name": "Muse Spark 1.1",
+        "description": "Muse Spark is a natively multimodal reasoning model with support for tool-use, visual chain of thought, and multi-agent orchestration.",
+        "family": "muse",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-08",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 32000
         }
       },
       "claude-opus-4-1-20250805": {
@@ -55295,6 +60954,92 @@
           "output": 32000
         }
       },
+      "claude-opus-4-7": {
+        "id": "claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-04-16",
+        "last_updated": "2026-04-16",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "claude-sonnet-5": {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-06-30",
+        "last_updated": "2026-06-30",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        }
+      },
+      "gpt-5.4-nano": {
+        "id": "gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
+        "description": "Cheapest GPT-5.4 lane for simple routing, extraction, and bulk automation",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
       "claude-opus-4-5-20251101": {
         "id": "claude-opus-4-5-20251101",
         "name": "Claude Opus 4.5",
@@ -55305,14 +61050,13 @@
         "reasoning_options": [],
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-01",
         "last_updated": "2025-11-01",
         "modalities": {
           "input": [
             "text",
-            "image",
-            "pdf"
+            "image"
           ],
           "output": [
             "text"
@@ -55327,8 +61071,8 @@
       "gpt-5.1-codex": {
         "id": "gpt-5.1-codex",
         "name": "GPT-5.1 Codex",
-        "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
-        "family": "gpt",
+        "description": "Codex GPT for repository edits, code review, and practical software agents",
+        "family": "gpt-codex",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
@@ -55381,6 +61125,34 @@
         "limit": {
           "context": 400000,
           "input": 272000,
+          "output": 128000
+        }
+      },
+      "claude-opus-4-8": {
+        "id": "claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01",
+        "release_date": "2026-05-28",
+        "last_updated": "2026-05-28",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
           "output": 128000
         }
       },
@@ -55439,15 +61211,45 @@
           "output": 128000
         }
       },
+      "gemini-3-pro-image-preview": {
+        "id": "gemini-3-pro-image-preview",
+        "name": "Nano Banana Pro",
+        "description": "Nano Banana Pro for higher-fidelity image generation and design-heavy edits",
+        "family": "gemini-pro",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": false,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2025-11-20",
+        "last_updated": "2025-11-20",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 65536,
+          "output": 32768
+        }
+      },
       "o3-mini": {
         "id": "o3-mini",
         "name": "o3-mini",
-        "description": "O-series reasoning model for hard analysis, math, coding, and planning",
+        "description": "Smaller o-series reasoner for economical coding, math, and planning tasks",
         "family": "o-mini",
         "attachment": false,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": true,
         "temperature": false,
         "knowledge": "2024-05",
         "release_date": "2024-12-20",
@@ -55469,12 +61271,13 @@
       "gpt-5.2": {
         "id": "gpt-5.2",
         "name": "GPT-5.2",
-        "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+        "description": "Reliable GPT generation for broad coding, writing, and tool-assisted product work",
         "family": "gpt",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": true,
         "temperature": false,
         "knowledge": "2025-08-31",
         "release_date": "2025-12-11",
@@ -55491,6 +61294,7 @@
         "open_weights": false,
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         }
       },
@@ -55498,7 +61302,7 @@
         "id": "gpt-5.3-codex",
         "name": "GPT-5.3 Codex",
         "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
-        "family": "gpt",
+        "family": "gpt-codex",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
@@ -55511,8 +61315,7 @@
         "modalities": {
           "input": [
             "text",
-            "image",
-            "pdf"
+            "image"
           ],
           "output": [
             "text"
@@ -55522,6 +61325,35 @@
         "limit": {
           "context": 400000,
           "input": 272000,
+          "output": 128000
+        }
+      },
+      "gpt-5.6-luna": {
+        "id": "gpt-5.6-luna",
+        "name": "GPT-5.6 Luna",
+        "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
           "output": 128000
         }
       },
@@ -55551,6 +61383,35 @@
         "limit": {
           "context": 200000,
           "output": 64000
+        }
+      },
+      "gpt-5.6-terra": {
+        "id": "gpt-5.6-terra",
+        "name": "GPT-5.6 Terra",
+        "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
         }
       },
       "gpt-5.1-chat-latest": {
@@ -55611,12 +61472,13 @@
       },
       "gpt-4.1-nano": {
         "id": "gpt-4.1-nano",
-        "name": "GPT-4.1 Nano",
-        "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-        "family": "gpt",
+        "name": "GPT-4.1 nano",
+        "description": "Tiny GPT-4.1 option for classification, routing, and very high-volume tasks",
+        "family": "gpt-nano",
         "attachment": true,
         "reasoning": false,
         "tool_call": true,
+        "structured_output": true,
         "temperature": true,
         "knowledge": "2024-04",
         "release_date": "2025-04-14",
@@ -55634,6 +61496,34 @@
         "limit": {
           "context": 1047576,
           "output": 32768
+        }
+      },
+      "claude-fable-5": {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+        "family": "claude-fable",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-06-09",
+        "last_updated": "2026-06-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
         }
       },
       "gpt-4o-2024-11-20": {
@@ -55693,10 +61583,39 @@
           "output": 64000
         }
       },
+      "gemini-3.1-flash-image-preview": {
+        "id": "gemini-3.1-flash-image-preview",
+        "name": "Nano Banana 2",
+        "description": "Image model for prompt-driven generation, editing, and visual design workflows",
+        "family": "gemini-flash",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": false,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-02-26",
+        "last_updated": "2026-02-26",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 32768
+        }
+      },
       "gpt-5.4": {
         "id": "gpt-5.4",
         "name": "GPT-5.4",
-        "description": "Frontier GPT model for professional reasoning, coding, and multimodal work",
+        "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
         "family": "gpt",
         "attachment": true,
         "reasoning": true,
@@ -55718,19 +61637,49 @@
         },
         "open_weights": false,
         "limit": {
-          "context": 1050000,
-          "input": 922000,
+          "context": 400000,
+          "output": 128000
+        }
+      },
+      "gpt-5.4-mini": {
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 mini",
+        "description": "Strong small GPT for coding subagents, quick tool use, and high-volume work",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
           "output": 128000
         }
       },
       "gpt-4.1": {
         "id": "gpt-4.1",
         "name": "GPT-4.1",
-        "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+        "description": "Long-lived GPT workhorse for coding, instruction following, and production apps",
         "family": "gpt",
         "attachment": true,
         "reasoning": false,
         "tool_call": true,
+        "structured_output": true,
         "temperature": true,
         "knowledge": "2024-04",
         "release_date": "2025-04-14",
@@ -55753,7 +61702,7 @@
       "gemini-3.1-pro-preview": {
         "id": "gemini-3.1-pro-preview",
         "name": "Gemini 3.1 Pro Preview",
-        "description": "Advanced Gemini model for complex reasoning, coding, and multimodal analysis",
+        "description": "Reasoning-first Gemini preview for agentic coding and complex problem solving",
         "family": "gemini-pro",
         "attachment": true,
         "reasoning": true,
@@ -55768,9 +61717,7 @@
           "input": [
             "text",
             "image",
-            "video",
-            "audio",
-            "pdf"
+            "audio"
           ],
           "output": [
             "text"
@@ -55785,7 +61732,7 @@
       "claude-opus-4-6": {
         "id": "claude-opus-4-6",
         "name": "Claude Opus 4.6",
-        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
+        "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
         "family": "claude-opus",
         "attachment": true,
         "reasoning": true,
@@ -55794,12 +61741,11 @@
         "temperature": true,
         "knowledge": "2025-05-31",
         "release_date": "2026-02-05",
-        "last_updated": "2026-02-05",
+        "last_updated": "2026-03-13",
         "modalities": {
           "input": [
             "text",
-            "image",
-            "pdf"
+            "image"
           ],
           "output": [
             "text"
@@ -55807,7 +61753,7 @@
         },
         "open_weights": false,
         "limit": {
-          "context": 200000,
+          "context": 1000000,
           "output": 128000
         }
       },
@@ -55852,8 +61798,7 @@
         "modalities": {
           "input": [
             "text",
-            "image",
-            "pdf"
+            "image"
           ],
           "output": [
             "text"
@@ -55868,12 +61813,13 @@
       "gpt-5-mini": {
         "id": "gpt-5-mini",
         "name": "GPT-5 Mini",
-        "description": "Compact GPT model for low-latency assistance and high-volume workloads",
+        "description": "Small GPT-5 for responsive agents, coding help, and everyday automation",
         "family": "gpt-mini",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": true,
         "temperature": false,
         "knowledge": "2024-05-30",
         "release_date": "2025-08-07",
@@ -55890,17 +61836,19 @@
         "open_weights": false,
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         }
       },
       "gpt-4.1-mini": {
         "id": "gpt-4.1-mini",
-        "name": "GPT-4.1 Mini",
-        "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-        "family": "gpt",
+        "name": "GPT-4.1 mini",
+        "description": "Affordable GPT-4.1 lane for fast coding help and structured extraction",
+        "family": "gpt-mini",
         "attachment": true,
         "reasoning": false,
         "tool_call": true,
+        "structured_output": true,
         "temperature": true,
         "knowledge": "2024-04",
         "release_date": "2025-04-14",
@@ -55923,12 +61871,13 @@
       "gpt-5-nano": {
         "id": "gpt-5-nano",
         "name": "GPT-5 Nano",
-        "description": "Compact GPT model for low-latency assistance and high-volume workloads",
+        "description": "Tiny GPT-5 lane for routing, extraction, classification, and bulk jobs",
         "family": "gpt-nano",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": true,
         "temperature": false,
         "knowledge": "2024-05-30",
         "release_date": "2025-08-07",
@@ -55945,13 +61894,14 @@
         "open_weights": false,
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         }
       },
       "claude-sonnet-4-6": {
         "id": "claude-sonnet-4-6",
         "name": "Claude Sonnet 4.6",
-        "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
+        "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
         "family": "claude-sonnet",
         "attachment": true,
         "reasoning": true,
@@ -55960,12 +61910,11 @@
         "temperature": true,
         "knowledge": "2025-08-31",
         "release_date": "2026-02-17",
-        "last_updated": "2026-02-17",
+        "last_updated": "2026-03-13",
         "modalities": {
           "input": [
             "text",
-            "image",
-            "pdf"
+            "image"
           ],
           "output": [
             "text"
@@ -55973,19 +61922,20 @@
         },
         "open_weights": false,
         "limit": {
-          "context": 200000,
+          "context": 1000000,
           "output": 64000
         }
       },
       "gemini-3-flash-preview": {
         "id": "gemini-3-flash-preview",
         "name": "Gemini 3 Flash Preview",
-        "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+        "description": "New Gemini flash lane bringing frontier-style multimodal reasoning to cheaper runs",
         "family": "gemini-flash",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": true,
         "temperature": true,
         "knowledge": "2025-01",
         "release_date": "2025-12-17",
@@ -55994,9 +61944,7 @@
           "input": [
             "text",
             "image",
-            "audio",
-            "video",
-            "pdf"
+            "audio"
           ],
           "output": [
             "text"
@@ -56008,16 +61956,44 @@
           "output": 65536
         }
       },
+      "mimo-v2-pro": {
+        "id": "mimo-v2-pro",
+        "name": "MiMo-V2-Pro",
+        "description": "Earlier MiMo Pro model for multimodal agents, reasoning, and code tasks",
+        "family": "mimo",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-03-18",
+        "last_updated": "2026-03-18",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 131072
+        }
+      },
       "gpt-4o-mini": {
         "id": "gpt-4o-mini",
-        "name": "GPT-4o Mini",
-        "description": "Compact GPT model for low-latency assistance and high-volume workloads",
-        "family": "gpt",
+        "name": "GPT-4o mini",
+        "description": "Small omni GPT for cheap multimodal assistance and production-scale traffic",
+        "family": "gpt-mini",
         "attachment": true,
         "reasoning": false,
         "tool_call": true,
+        "structured_output": true,
         "temperature": true,
-        "knowledge": "2024-04",
+        "knowledge": "2023-09",
         "release_date": "2024-07-18",
         "last_updated": "2024-07-18",
         "modalities": {
@@ -56035,11 +62011,40 @@
           "output": 16384
         }
       },
+      "gpt-5.6-sol": {
+        "id": "gpt-5.6-sol",
+        "name": "GPT-5.6 Sol",
+        "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
       "gpt-5-codex": {
         "id": "gpt-5-codex",
-        "name": "GPT-5 Codex",
+        "name": "GPT-5-Codex",
         "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
-        "family": "gpt",
+        "family": "gpt-codex",
         "attachment": false,
         "reasoning": true,
         "reasoning_options": [],
@@ -56099,8 +62104,8 @@
       "gpt-5.2-codex": {
         "id": "gpt-5.2-codex",
         "name": "GPT-5.2 Codex",
-        "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
-        "family": "gpt",
+        "description": "Code-specialist GPT for repository edits, reviews, and long-running software agents",
+        "family": "gpt-codex",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
@@ -56113,8 +62118,7 @@
         "modalities": {
           "input": [
             "text",
-            "image",
-            "pdf"
+            "image"
           ],
           "output": [
             "text"
@@ -56130,12 +62134,13 @@
       "gpt-5.1": {
         "id": "gpt-5.1",
         "name": "GPT-5.1",
-        "description": "GPT model for general reasoning, writing, coding, and tool-assisted tasks",
+        "description": "Sharper GPT-5 generation for coding, product work, and tool-assisted tasks",
         "family": "gpt",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": true,
         "temperature": false,
         "knowledge": "2024-09-30",
         "release_date": "2025-11-13",
@@ -56152,13 +62157,40 @@
         "open_weights": false,
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
+        }
+      },
+      "meta-llama/Meta-Llama-3.3-70B-Instruct": {
+        "id": "meta-llama/Meta-Llama-3.3-70B-Instruct",
+        "name": "Llama-3.3-70B-Instruct",
+        "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
+        "family": "llama",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2023-12",
+        "release_date": "2024-12-06",
+        "last_updated": "2024-12-06",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 8192
         }
       },
       "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
         "id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
-        "name": "Llama 4 Maverick 17B 128E Instruct FP8",
-        "description": "Open multimodal Llama model for strong reasoning and fast responses",
+        "name": "Llama 4 Maverick 17B Instruct",
+        "description": "Open multimodal Llama for strong reasoning with efficient everyday serving",
         "family": "llama",
         "attachment": true,
         "reasoning": false,
@@ -56178,8 +62210,8 @@
         },
         "open_weights": true,
         "limit": {
-          "context": 1000000,
-          "output": 32768
+          "context": 1048576,
+          "output": 8192
         }
       },
       "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo": {
@@ -56232,18 +62264,47 @@
           "output": 4096
         }
       },
-      "Qwen/qwen3-coder-480b-a35b-instruct": {
-        "id": "Qwen/qwen3-coder-480b-a35b-instruct",
-        "name": "Qwen3 Coder 480B A35B Instruct",
-        "description": "Qwen coding model for software agents, repository edits, and code reasoning",
-        "family": "qwen",
-        "attachment": false,
+      "google/gemma-4-31b-it": {
+        "id": "google/gemma-4-31b-it",
+        "name": "Gemma 4 31B IT",
+        "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
+        "family": "gemma",
+        "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": true,
         "temperature": true,
-        "release_date": "2025-07-22",
-        "last_updated": "2025-07-22",
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 131072
+        }
+      },
+      "Qwen/Qwen3.6-27B": {
+        "id": "Qwen/Qwen3.6-27B",
+        "name": "Qwen3.6 27B",
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-22",
+        "last_updated": "2026-04-22",
         "modalities": {
           "input": [
             "text"
@@ -56255,7 +62316,33 @@
         "open_weights": true,
         "limit": {
           "context": 262144,
-          "output": 65536
+          "output": 8192
+        }
+      },
+      "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+        "id": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+        "name": "Qwen3-Coder 480B-A35B Instruct",
+        "description": "Open Qwen coding heavyweight for repository reasoning and agentic engineering",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2025-04",
+        "last_updated": "2025-04",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 16384
         }
       },
       "Qwen/QwQ-32B": {
@@ -56313,15 +62400,16 @@
       "Qwen/Qwen3-32B": {
         "id": "Qwen/Qwen3-32B",
         "name": "Qwen3 32B",
-        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+        "description": "Dense open Qwen model for self-hosted chat, reasoning, and coding",
         "family": "qwen",
         "attachment": false,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
         "temperature": true,
-        "release_date": "2025-04-29",
-        "last_updated": "2025-04-29",
+        "knowledge": "2025-04",
+        "release_date": "2025-04",
+        "last_updated": "2025-04",
         "modalities": {
           "input": [
             "text"
@@ -56332,7 +62420,7 @@
         },
         "open_weights": true,
         "limit": {
-          "context": 128000,
+          "context": 131072,
           "output": 8192
         }
       },
@@ -56363,29 +62451,20 @@
       },
       "openai/gpt-oss-120b": {
         "id": "openai/gpt-oss-120b",
-        "name": "GPT-OSS 120B",
-        "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
+        "name": "GPT OSS 120B",
+        "description": "Open GPT reasoning model for self-hosted agents and controllable deployments",
         "family": "gpt-oss",
-        "attachment": true,
+        "attachment": false,
         "reasoning": true,
-        "reasoning_options": [
-          {
-            "type": "effort",
-            "values": [
-              "low",
-              "medium",
-              "high"
-            ]
-          }
-        ],
+        "reasoning_options": [],
         "tool_call": true,
+        "structured_output": true,
         "temperature": true,
         "release_date": "2025-08-05",
         "last_updated": "2025-08-05",
         "modalities": {
           "input": [
-            "text",
-            "image"
+            "text"
           ],
           "output": [
             "text"
@@ -56394,21 +62473,21 @@
         "open_weights": true,
         "limit": {
           "context": 128000,
-          "output": 32768
+          "output": 16384
         }
       },
-      "zai-org/glm-5": {
-        "id": "zai-org/glm-5",
+      "zai-org/GLM-5": {
+        "id": "zai-org/GLM-5",
         "name": "GLM-5",
-        "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
+        "description": "General GLM flagship for coding, analysis, and tool-heavy engineering workflows",
         "family": "glm",
         "attachment": false,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
         "temperature": true,
-        "release_date": "2026-02-11",
-        "last_updated": "2026-02-11",
+        "release_date": "2026-02-12",
+        "last_updated": "2026-02-12",
         "modalities": {
           "input": [
             "text"
@@ -56420,6 +62499,33 @@
         "open_weights": true,
         "limit": {
           "context": 204800,
+          "output": 131072
+        }
+      },
+      "zai-org/GLM-5.2": {
+        "id": "zai-org/GLM-5.2",
+        "name": "GLM-5.2",
+        "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-06-13",
+        "last_updated": "2026-06-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1048576,
           "output": 131072
         }
       },
@@ -56475,6 +62581,62 @@
           "output": 8192
         }
       },
+      "deepseek-ai/DeepSeek-V4-Flash": {
+        "id": "deepseek-ai/DeepSeek-V4-Flash",
+        "name": "DeepSeek V4 Flash",
+        "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+        "family": "deepseek-flash",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 32768
+        }
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "id": "deepseek-ai/DeepSeek-V4-Pro",
+        "name": "DeepSeek V4 Pro",
+        "description": "Open MoE flagship with million-token context for coding and long agent runs",
+        "family": "deepseek-thinking",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 32768
+        }
+      },
       "deepseek-ai/DeepSeek-V3.2": {
         "id": "deepseek-ai/DeepSeek-V3.2",
         "name": "DeepSeek V3.2",
@@ -56499,6 +62661,60 @@
         "limit": {
           "context": 128000,
           "output": 8192
+        }
+      },
+      "MiniMaxAI/MiniMax-M3": {
+        "id": "MiniMaxAI/MiniMax-M3",
+        "name": "MiniMax-M3",
+        "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+        "family": "minimax",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-06-01",
+        "last_updated": "2026-06-01",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      },
+      "MiniMaxAI/MiniMax-M2.7": {
+        "id": "MiniMaxAI/MiniMax-M2.7",
+        "name": "MiniMax-M2.7",
+        "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-03-18",
+        "last_updated": "2026-03-18",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 204800,
+          "output": 131072
         }
       },
       "deepseek/deepseek-v3.1": {
@@ -59637,6 +65853,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -61407,7 +67624,7 @@
         ],
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-01",
         "last_updated": "2025-11-01",
         "modalities": {
@@ -61671,6 +67888,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -64980,7 +71198,7 @@
         "tool_call": true,
         "structured_output": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-24",
         "last_updated": "2025-11-24",
         "modalities": {
@@ -65237,7 +71455,7 @@
         "tool_call": true,
         "structured_output": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-24",
         "last_updated": "2025-11-01",
         "modalities": {
@@ -65278,6 +71496,7 @@
         "tool_call": true,
         "structured_output": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -65887,6 +72106,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -66179,6 +72399,89 @@
     "name": "SAP AI Core",
     "doc": "https://help.sap.com/docs/sap-ai-core",
     "models": {
+      "anthropic--claude-4.8-opus": {
+        "id": "anthropic--claude-4.8-opus",
+        "name": "anthropic--claude-4.8-opus",
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-01",
+        "release_date": "2026-05-28",
+        "last_updated": "2026-05-28",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "gemini-3.1-flash-lite": {
+        "id": "gemini-3.1-flash-lite",
+        "name": "gemini-3.1-flash-lite",
+        "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+        "family": "gemini-flash-lite",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-05-07",
+        "last_updated": "2026-05-07",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        }
+      },
       "anthropic--claude-4.6-sonnet": {
         "id": "anthropic--claude-4.6-sonnet",
         "name": "anthropic--claude-4.6-sonnet",
@@ -66192,7 +72495,8 @@
             "values": [
               "low",
               "medium",
-              "high"
+              "high",
+              "max"
             ]
           },
           {
@@ -66321,6 +72625,48 @@
           "context": 400000,
           "input": 272000,
           "output": 128000
+        }
+      },
+      "gemini-3.5-flash": {
+        "id": "gemini-3.5-flash",
+        "name": "gemini-3.5-flash",
+        "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+        "family": "gemini-flash",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-05-19",
+        "last_updated": "2026-05-19",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
         }
       },
       "anthropic--claude-4.5-haiku": {
@@ -66865,6 +73211,14 @@
         "reasoning": true,
         "reasoning_options": [
           {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          {
             "type": "budget_tokens",
             "min": 1024
           }
@@ -66903,7 +73257,9 @@
             "values": [
               "low",
               "medium",
-              "high"
+              "high",
+              "xhigh",
+              "max"
             ]
           }
         ],
@@ -68022,6 +74378,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -68327,6 +74684,52 @@
         },
         "status": "deprecated"
       },
+      "gpt-5.6-luna": {
+        "id": "gpt-5.6-luna",
+        "name": "GPT-5.6 Luna",
+        "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai"
+        }
+      },
       "claude-opus-4-1": {
         "id": "claude-opus-4-1",
         "name": "Claude Opus 4.1",
@@ -68406,6 +74809,52 @@
           "npm": "@ai-sdk/openai"
         }
       },
+      "gpt-5.6-terra": {
+        "id": "gpt-5.6-terra",
+        "name": "GPT-5.6 Terra",
+        "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai"
+        }
+      },
       "claude-fable-5": {
         "id": "claude-fable-5",
         "name": "Claude Fable 5",
@@ -68471,7 +74920,7 @@
         },
         "open_weights": true,
         "limit": {
-          "context": 256000,
+          "context": 190000,
           "output": 64000
         }
       },
@@ -69085,6 +75534,52 @@
           "output": 64000
         },
         "status": "deprecated"
+      },
+      "gpt-5.6-sol": {
+        "id": "gpt-5.6-sol",
+        "name": "GPT-5.6 Sol",
+        "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai"
+        }
       },
       "gpt-5-codex": {
         "id": "gpt-5-codex",
@@ -71063,6 +77558,559 @@
         "limit": {
           "context": 204800,
           "output": 131072
+        }
+      }
+    }
+  },
+  "unorouter": {
+    "id": "unorouter",
+    "env": [
+      "UNOROUTER_API_KEY"
+    ],
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.unorouter.com/v1",
+    "name": "UnoRouter",
+    "doc": "https://unorouter.com/models",
+    "models": {
+      "deepseek-v4-flash": {
+        "id": "deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash",
+        "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+        "family": "deepseek-flash",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        }
+      },
+      "gpt-5.4:free": {
+        "id": "gpt-5.4:free",
+        "name": "GPT-5.4",
+        "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-05",
+        "last_updated": "2026-03-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        }
+      },
+      "minimax-m2.7:free": {
+        "id": "minimax-m2.7:free",
+        "name": "MiniMax-M2.7",
+        "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-03-18",
+        "last_updated": "2026-03-18",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        }
+      },
+      "step-3.7-flash:free": {
+        "id": "step-3.7-flash:free",
+        "name": "Step 3.7 Flash",
+        "description": "Newer StepFun flash model for faster agents, coding, and multimodal prompts",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2026-01-01",
+        "release_date": "2026-05-29",
+        "last_updated": "2026-05-29",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 256000
+        }
+      },
+      "claude-haiku-4-5-20251001": {
+        "id": "claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4.5",
+        "description": "Fast Claude model for responsive assistance, classification, and lightweight agents",
+        "family": "claude-haiku",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-02-28",
+        "release_date": "2025-10-15",
+        "last_updated": "2025-10-15",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        }
+      },
+      "qwen3.5-397b-a17b:free": {
+        "id": "qwen3.5-397b-a17b:free",
+        "name": "Qwen3.5 397B-A17B",
+        "description": "Large open Qwen multimodal MoE for visual agents and long technical tasks",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-15",
+        "last_updated": "2026-02-15",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 65536
+        }
+      },
+      "nemotron-3-ultra-550b-a55b:free": {
+        "id": "nemotron-3-ultra-550b-a55b:free",
+        "name": "Nemotron 3 Ultra 550B A55B",
+        "description": "Largest Nemotron 3 model for maximum open-weight reasoning and agent accuracy",
+        "family": "nemotron",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-06-04",
+        "last_updated": "2026-06-04",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "gemini-3.5-flash": {
+        "id": "gemini-3.5-flash",
+        "name": "Gemini 3.5 Flash",
+        "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+        "family": "gemini-flash",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-05-19",
+        "last_updated": "2026-05-19",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        }
+      },
+      "deepseek-v4-pro": {
+        "id": "deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro",
+        "description": "Open MoE flagship with million-token context for coding and long agent runs",
+        "family": "deepseek-thinking",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        }
+      },
+      "deepseek-v4-flash:free": {
+        "id": "deepseek-v4-flash:free",
+        "name": "DeepSeek V4 Flash",
+        "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+        "family": "deepseek-flash",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        }
+      },
+      "claude-sonnet-5": {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-06-30",
+        "last_updated": "2026-06-30",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "glm-5.2": {
+        "id": "glm-5.2",
+        "name": "GLM-5.2",
+        "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-06-13",
+        "last_updated": "2026-06-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      },
+      "claude-opus-4-8": {
+        "id": "claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01",
+        "release_date": "2026-05-28",
+        "last_updated": "2026-05-28",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "gpt-5.2": {
+        "id": "gpt-5.2",
+        "name": "GPT-5.2",
+        "description": "Reliable GPT generation for broad coding, writing, and tool-assisted product work",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2025-12-11",
+        "last_updated": "2025-12-11",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        }
+      },
+      "minimax-m2.7": {
+        "id": "minimax-m2.7",
+        "name": "MiniMax-M2.7",
+        "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-03-18",
+        "last_updated": "2026-03-18",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        }
+      },
+      "gpt-5.4": {
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-05",
+        "last_updated": "2026-03-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        }
+      },
+      "glm-5.2:free": {
+        "id": "glm-5.2:free",
+        "name": "GLM-5.2",
+        "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-06-13",
+        "last_updated": "2026-06-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      },
+      "gemma-4-31b-it:free": {
+        "id": "gemma-4-31b-it:free",
+        "name": "Gemma 4 31B IT",
+        "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
+        "family": "gemma",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        }
+      },
+      "deepseek-v4-pro:free": {
+        "id": "deepseek-v4-pro:free",
+        "name": "DeepSeek V4 Pro",
+        "description": "Open MoE flagship with million-token context for coding and long agent runs",
+        "family": "deepseek-thinking",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 384000
         }
       }
     }
@@ -74248,6 +81296,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -77397,6 +84446,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -78406,6 +85456,1181 @@
       }
     }
   },
+  "empiriolabs": {
+    "id": "empiriolabs",
+    "env": [
+      "EMPIRIOLABS_API_KEY"
+    ],
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.empiriolabs.ai/v1",
+    "name": "EmpirioLabs AI",
+    "doc": "https://docs.empiriolabs.ai",
+    "models": {
+      "qwen3-5-plus": {
+        "id": "qwen3-5-plus",
+        "name": "Qwen3.5 Plus",
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2026-02-16",
+        "last_updated": "2026-02-16",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        }
+      },
+      "deepseek-v4-flash": {
+        "id": "deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash",
+        "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+        "family": "deepseek-flash",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1,
+            "max": 393216
+          }
+        ],
+        "tool_call": false,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-06-12",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 393216
+        }
+      },
+      "qwen3-5-27b": {
+        "id": "qwen3-5-27b",
+        "name": "Qwen3.5 27B",
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1,
+            "max": 80000
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-23",
+        "last_updated": "2026-02-23",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 256000,
+          "output": 64000
+        }
+      },
+      "step-3-7-flash": {
+        "id": "step-3-7-flash",
+        "name": "Step 3.7 Flash",
+        "description": "Newer StepFun flash model for faster agents, coding, and multimodal prompts",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2026-01-01",
+        "release_date": "2026-05-29",
+        "last_updated": "2026-05-29",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 131072
+        }
+      },
+      "qwen3-5-397b-a17b": {
+        "id": "qwen3-5-397b-a17b",
+        "name": "Qwen3.5 397B-A17B",
+        "description": "Large open Qwen multimodal MoE for visual agents and long technical tasks",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1,
+            "max": 80000
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-15",
+        "last_updated": "2026-02-15",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 256000,
+          "output": 64000
+        }
+      },
+      "qwen3-5-35b-a3b": {
+        "id": "qwen3-5-35b-a3b",
+        "name": "Qwen3.5 35B-A3B",
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1,
+            "max": 80000
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-23",
+        "last_updated": "2026-02-23",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 256000,
+          "output": 64000
+        }
+      },
+      "qwen3-max": {
+        "id": "qwen3-max",
+        "name": "Qwen3 Max",
+        "description": "Flagship Qwen3 model for coding agents, complex reasoning, and tool use",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": false,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2025-09-23",
+        "last_updated": "2025-09-23",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 256000,
+          "output": 65536
+        }
+      },
+      "qwen3-7-plus": {
+        "id": "qwen3-7-plus",
+        "name": "Qwen3.7 Plus",
+        "description": "Multimodal Qwen workhorse for long-context agents, visual inputs, and coding",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1,
+            "max": 256000
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2026-06-02",
+        "last_updated": "2026-06-12",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        }
+      },
+      "kimi-k2-7-code": {
+        "id": "kimi-k2-7-code",
+        "name": "Kimi K2.7 Code",
+        "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+        "family": "kimi-k2",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-01",
+        "release_date": "2026-06-12",
+        "last_updated": "2026-06-12",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 256000,
+          "output": 131072
+        }
+      },
+      "deepseek-v4-pro": {
+        "id": "deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro",
+        "description": "Open MoE flagship with million-token context for coding and long agent runs",
+        "family": "deepseek-thinking",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1,
+            "max": 393216
+          }
+        ],
+        "tool_call": false,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-06-12",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 393216
+        }
+      },
+      "qwen3-6-flash": {
+        "id": "qwen3-6-flash",
+        "name": "Qwen3.6 Flash",
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+        "family": "qwen3.6",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1,
+            "max": 64000
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-27",
+        "last_updated": "2026-04-27",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        }
+      },
+      "minimax-m2-7-highspeed": {
+        "id": "minimax-m2-7-highspeed",
+        "name": "MiniMax M2.7 Highspeed",
+        "description": "Low-latency M2.7 variant for interactive coding plans and agent loops",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": false,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-03-18",
+        "last_updated": "2026-03-18",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 200000,
+          "output": 32768
+        }
+      },
+      "minimax-m2-7": {
+        "id": "minimax-m2-7",
+        "name": "MiniMax M2.7",
+        "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-03-18",
+        "last_updated": "2026-03-18",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 200000,
+          "output": 32768
+        }
+      },
+      "minimax-m3": {
+        "id": "minimax-m3",
+        "name": "MiniMax M3",
+        "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+        "family": "minimax",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-06-01",
+        "last_updated": "2026-06-12",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 524288
+        }
+      },
+      "mimo-v2-5": {
+        "id": "mimo-v2-5",
+        "name": "MiMo V2.5",
+        "description": "Open MiMo model for multimodal coding agents and long-context automation",
+        "family": "mimo",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": false,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-04-22",
+        "last_updated": "2026-04-22",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "qwen3-6-plus": {
+        "id": "qwen3-6-plus",
+        "name": "Qwen3.6 Plus",
+        "description": "Earlier Qwen multimodal workhorse for million-token agent and document tasks",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        }
+      },
+      "step-3-5-flash": {
+        "id": "step-3-5-flash",
+        "name": "Step 3.5 Flash",
+        "description": "StepFun flash lane for quick multimodal reasoning and coding assistance",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-01-29",
+        "last_updated": "2026-02-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 131072
+        }
+      },
+      "qwen3-6-27b": {
+        "id": "qwen3-6-27b",
+        "name": "Qwen3.6 27B",
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1,
+            "max": 80000
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-22",
+        "last_updated": "2026-04-22",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 256000,
+          "output": 64000
+        }
+      },
+      "glm-5-2": {
+        "id": "glm-5-2",
+        "name": "GLM 5.2",
+        "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-06-13",
+        "last_updated": "2026-06-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      },
+      "step-3-5-flash-2603": {
+        "id": "step-3-5-flash-2603",
+        "name": "Step 3.5 Flash 2603",
+        "description": "StepFun flash model for efficient multimodal reasoning, coding, and tool use",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-02",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 256000,
+          "input": 256000,
+          "output": 131072
+        }
+      },
+      "qwen3-5-4b": {
+        "id": "qwen3-5-4b",
+        "name": "Qwen3.5 4B",
+        "description": "Qwen3.5 4B is a low-cost multimodal reasoning model with 256K context, image and video input, function tools, and structured output.",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1024,
+            "max": 32768
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-03-02",
+        "last_updated": "2026-03-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        }
+      },
+      "gemma-4-26b-a4b": {
+        "id": "gemma-4-26b-a4b",
+        "name": "Gemma 4 26B-A4B",
+        "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
+        "family": "gemma",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 128,
+            "max": 32768
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-02",
+        "last_updated": "2026-06-12",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        }
+      },
+      "qwen3-5-9b": {
+        "id": "qwen3-5-9b",
+        "name": "Qwen3.5 9B",
+        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1024,
+            "max": 32768
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-23",
+        "last_updated": "2026-02-23",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        }
+      },
+      "qwen3-7-max": {
+        "id": "qwen3-7-max",
+        "name": "Qwen3.7 Max",
+        "description": "Qwen frontier model tuned for agent frameworks, coding assistants, and long tasks",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1,
+            "max": 64000
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-05-21",
+        "last_updated": "2026-06-12",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        }
+      },
+      "qwen3-6-max-preview": {
+        "id": "qwen3-6-max-preview",
+        "name": "Qwen3.6 Max Preview",
+        "description": "Flagship Qwen model for complex reasoning, coding, and agentic workflows",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1,
+            "max": 393216
+          }
+        ],
+        "tool_call": false,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2026-04-20",
+        "last_updated": "2026-04-20",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 256000,
+          "output": 65536
+        }
+      },
+      "mimo-v2-5-pro": {
+        "id": "mimo-v2-5-pro",
+        "name": "MiMo V2.5 Pro",
+        "description": "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution",
+        "family": "mimo",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": false,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-04-22",
+        "last_updated": "2026-04-22",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "qwen3-5-122b-a10b": {
+        "id": "qwen3-5-122b-a10b",
+        "name": "Qwen3.5 122B-A10B",
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+        "family": "qwen",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "type": "budget_tokens",
+            "min": 1,
+            "max": 80000
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-23",
+        "last_updated": "2026-02-23",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 256000,
+          "output": 64000
+        }
+      },
+      "fugu-ultra": {
+        "id": "fugu-ultra",
+        "name": "Fugu Ultra",
+        "description": "Quality-first multi-agent model for hard research, analysis, and competitions",
+        "family": "fugu",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "release_date": "2026-06-15",
+        "last_updated": "2026-06-15",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      },
+      "muse-spark-1-1": {
+        "id": "muse-spark-1-1",
+        "name": "Muse Spark 1.1",
+        "description": "Muse Spark is a natively multimodal reasoning model with support for tool-use, visual chain of thought, and multi-agent orchestration.",
+        "family": "muse",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-08",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      }
+    }
+  },
   "ovhcloud": {
     "id": "ovhcloud",
     "env": [
@@ -79100,23 +87325,21 @@
     "name": "Weights & Biases",
     "doc": "https://docs.wandb.ai/guides/integrations/inference/",
     "models": {
-      "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
-        "id": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
-        "name": "Llama 4 Scout 17B 16E Instruct",
-        "description": "Open multimodal Llama model for long-context analysis and efficient agents",
-        "family": "llama",
+      "ibm-granite/granite-4.1-8b": {
+        "id": "ibm-granite/granite-4.1-8b",
+        "name": "Granite 4.1 8B",
+        "description": "Granite 4.1 8B is a long-context instruct model capable of enhanced tool calling, instruction following, and chat capabilities.",
+        "family": "granite",
         "attachment": false,
         "reasoning": false,
         "tool_call": true,
         "structured_output": true,
         "temperature": true,
-        "knowledge": "2024-12",
-        "release_date": "2025-01-31",
-        "last_updated": "2026-03-12",
+        "release_date": "2026-04-29",
+        "last_updated": "2026-04-29",
         "modalities": {
           "input": [
-            "text",
-            "image"
+            "text"
           ],
           "output": [
             "text"
@@ -79124,14 +87347,14 @@
         },
         "open_weights": true,
         "limit": {
-          "context": 64000,
-          "output": 64000
+          "context": 131072,
+          "output": 131072
         }
       },
       "meta-llama/Llama-3.3-70B-Instruct": {
         "id": "meta-llama/Llama-3.3-70B-Instruct",
-        "name": "Llama-3.3-70B-Instruct",
-        "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
+        "name": "Llama 3.3 70B",
+        "description": "Multilingual model excelling in conversational tasks, detailed instruction-following, and coding.",
         "family": "llama",
         "attachment": false,
         "reasoning": false,
@@ -79139,8 +87362,8 @@
         "structured_output": true,
         "temperature": true,
         "knowledge": "2023-12",
-        "release_date": "2024-12-06",
-        "last_updated": "2026-03-12",
+        "release_date": "2024-12-01",
+        "last_updated": "2024-12-01",
         "modalities": {
           "input": [
             "text"
@@ -79158,7 +87381,7 @@
       "meta-llama/Llama-3.1-70B-Instruct": {
         "id": "meta-llama/Llama-3.1-70B-Instruct",
         "name": "Llama 3.1 70B",
-        "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
+        "description": "Efficient conversational model optimized for responsive multilingual chatbot interactions.",
         "family": "llama",
         "attachment": false,
         "reasoning": false,
@@ -79166,7 +87389,7 @@
         "structured_output": true,
         "temperature": true,
         "release_date": "2024-07-23",
-        "last_updated": "2026-03-12",
+        "last_updated": "2024-07-23",
         "modalities": {
           "input": [
             "text"
@@ -79183,8 +87406,8 @@
       },
       "meta-llama/Llama-3.1-8B-Instruct": {
         "id": "meta-llama/Llama-3.1-8B-Instruct",
-        "name": "Meta-Llama-3.1-8B-Instruct",
-        "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
+        "name": "Llama 3.1 8B",
+        "description": "Efficient conversational model optimized for responsive multilingual chatbot interactions.",
         "family": "llama",
         "attachment": false,
         "reasoning": false,
@@ -79193,7 +87416,7 @@
         "temperature": true,
         "knowledge": "2023-12",
         "release_date": "2024-07-23",
-        "last_updated": "2026-03-12",
+        "last_updated": "2024-07-23",
         "modalities": {
           "input": [
             "text"
@@ -79208,10 +87431,71 @@
           "output": 128000
         }
       },
+      "moonshotai/Kimi-K2.7-Code": {
+        "id": "moonshotai/Kimi-K2.7-Code",
+        "name": "Kimi K2.7 Code",
+        "description": "Kimi K2.7 Code is a 1T-parameter MoE model with 32B active parameters purpose-built for long-horizon agentic coding and software engineering.",
+        "family": "kimi-k2",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-06-12",
+        "last_updated": "2026-06-12",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        }
+      },
+      "google/gemma-4-31B-it": {
+        "id": "google/gemma-4-31B-it",
+        "name": "Gemma 4 31B",
+        "description": "Gemma 4 31B Dense is designed for advanced reasoning, agentic workflows, and longer context and is natively trained on 140+ languages.",
+        "family": "gemma",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        }
+      },
       "microsoft/Phi-4-mini-instruct": {
         "id": "microsoft/Phi-4-mini-instruct",
-        "name": "Phi-4-mini-instruct",
-        "description": "Efficient model for low-latency assistance, extraction, and routine automation",
+        "name": "Phi 4 Mini 3.8B",
+        "description": "Compact, efficient model ideal for fast responses in resource-constrained environments.",
         "family": "phi",
         "attachment": false,
         "reasoning": false,
@@ -79219,8 +87503,8 @@
         "structured_output": true,
         "temperature": true,
         "knowledge": "2023-10",
-        "release_date": "2024-12-11",
-        "last_updated": "2026-03-12",
+        "release_date": "2025-02-01",
+        "last_updated": "2025-02-01",
         "modalities": {
           "input": [
             "text"
@@ -79233,12 +87517,77 @@
         "limit": {
           "context": 128000,
           "output": 128000
+        },
+        "status": "deprecated"
+      },
+      "Qwen/Qwen3.6-35B-A3B": {
+        "id": "Qwen/Qwen3.6-35B-A3B",
+        "name": "Qwen3.6 35B A3B",
+        "description": "Qwen3.6-35B-A3B is an MoE multimodal model with 262K context optimized for agentic coding workflows.",
+        "family": "qwen3.6",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-15",
+        "last_updated": "2026-04-15",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        }
+      },
+      "Qwen/Qwen3.6-27B": {
+        "id": "Qwen/Qwen3.6-27B",
+        "name": "Qwen3.6 27B",
+        "description": "Qwen3.6-27B is a 27B dense multimodal model with 262K context built for flagship-level agentic coding.",
+        "family": "qwen3.6",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-22",
+        "last_updated": "2026-04-22",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 262144
         }
       },
       "Qwen/Qwen3-235B-A22B-Thinking-2507": {
         "id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-        "name": "Qwen3-235B-A22B-Thinking-2507",
-        "description": "Qwen reasoning model for deliberate problem solving, math, and coding",
+        "name": "Qwen3 235B A22B Thinking-2507",
+        "description": "High-performance Mixture-of-Experts model optimized for structured reasoning, math, and long-form generation.",
         "family": "qwen",
         "attachment": false,
         "reasoning": true,
@@ -79248,7 +87597,7 @@
         "temperature": true,
         "knowledge": "2025-04",
         "release_date": "2025-07-25",
-        "last_updated": "2026-03-12",
+        "last_updated": "2025-07-25",
         "modalities": {
           "input": [
             "text"
@@ -79261,12 +87610,13 @@
         "limit": {
           "context": 262144,
           "output": 262144
-        }
+        },
+        "status": "deprecated"
       },
       "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
         "id": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
-        "name": "Qwen3-Coder-480B-A35B-Instruct",
-        "description": "Qwen coding model for software agents, repository edits, and code reasoning",
+        "name": "Qwen3 Coder 480B A35B",
+        "description": "Mixture-of-Experts model optimized for agentic coding tasks such as function calling, tool use, and long-context reasoning.",
         "family": "qwen",
         "attachment": false,
         "reasoning": false,
@@ -79274,8 +87624,8 @@
         "structured_output": true,
         "temperature": true,
         "knowledge": "2025-04",
-        "release_date": "2025-07-23",
-        "last_updated": "2026-03-12",
+        "release_date": "2025-07-22",
+        "last_updated": "2025-07-22",
         "modalities": {
           "input": [
             "text"
@@ -79290,10 +87640,43 @@
           "output": 262144
         }
       },
+      "Qwen/Qwen3.5-27B": {
+        "id": "Qwen/Qwen3.5-27B",
+        "name": "Qwen3.5-27B",
+        "description": "Qwen3.5-27B is a dense model from the Qwen3.5 family built for high performance across a large range of benchmarks.",
+        "family": "qwen3.5",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-24",
+        "last_updated": "2026-02-24",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "status": "deprecated"
+      },
       "Qwen/Qwen3-30B-A3B-Instruct-2507": {
         "id": "Qwen/Qwen3-30B-A3B-Instruct-2507",
         "name": "Qwen3 30B A3B Instruct 2507",
-        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+        "description": "Qwen3-30B-A3B-Instruct-2507 is a 30.5B MoE instruction-tuned model with enhanced reasoning, coding, and long-context understanding.",
         "family": "qwen",
         "attachment": false,
         "reasoning": false,
@@ -79301,7 +87684,7 @@
         "structured_output": true,
         "temperature": true,
         "release_date": "2025-07-29",
-        "last_updated": "2026-03-12",
+        "last_updated": "2025-07-29",
         "modalities": {
           "input": [
             "text"
@@ -79318,8 +87701,8 @@
       },
       "Qwen/Qwen3-235B-A22B-Instruct-2507": {
         "id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-        "name": "Qwen3 235B A22B Instruct 2507",
-        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+        "name": "Qwen3 235B A22B-2507",
+        "description": "Efficient multilingual, Mixture-of-Experts, instruction-tuned model, optimized for logical reasoning.",
         "family": "qwen",
         "attachment": false,
         "reasoning": false,
@@ -79327,11 +87710,44 @@
         "structured_output": true,
         "temperature": true,
         "knowledge": "2025-04",
-        "release_date": "2025-04-28",
-        "last_updated": "2026-03-12",
+        "release_date": "2025-07-22",
+        "last_updated": "2025-07-22",
         "modalities": {
           "input": [
             "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "status": "deprecated"
+      },
+      "Qwen/Qwen3.5-35B-A3B": {
+        "id": "Qwen/Qwen3.5-35B-A3B",
+        "name": "Qwen3.5-35B-A3B",
+        "description": "Qwen3.5-35B-A3B is an open-weights multimodal MoE model built for efficient, high-throughput inference across chat, reasoning, and agentic tasks.",
+        "family": "qwen3.5",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-24",
+        "last_updated": "2026-02-24",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
           ],
           "output": [
             "text"
@@ -79346,7 +87762,7 @@
       "openai/gpt-oss-120b": {
         "id": "openai/gpt-oss-120b",
         "name": "gpt-oss-120b",
-        "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
+        "description": "Efficient Mixture-of-Experts model designed for high-reasoning, agentic and general-purpose use cases.",
         "family": "gpt-oss",
         "attachment": false,
         "reasoning": true,
@@ -79355,7 +87771,7 @@
         "structured_output": true,
         "temperature": true,
         "release_date": "2025-08-05",
-        "last_updated": "2026-03-12",
+        "last_updated": "2025-08-05",
         "modalities": {
           "input": [
             "text"
@@ -79364,7 +87780,7 @@
             "text"
           ]
         },
-        "open_weights": false,
+        "open_weights": true,
         "limit": {
           "context": 131072,
           "output": 131072
@@ -79373,7 +87789,7 @@
       "openai/gpt-oss-20b": {
         "id": "openai/gpt-oss-20b",
         "name": "gpt-oss-20b",
-        "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
+        "description": "Lower latency Mixture-of-Experts model trained on OpenAI's Harmony response format with reasoning capabilities.",
         "family": "gpt-oss",
         "attachment": false,
         "reasoning": true,
@@ -79382,7 +87798,7 @@
         "structured_output": true,
         "temperature": true,
         "release_date": "2025-08-05",
-        "last_updated": "2026-03-12",
+        "last_updated": "2025-08-05",
         "modalities": {
           "input": [
             "text"
@@ -79391,16 +87807,16 @@
             "text"
           ]
         },
-        "open_weights": false,
+        "open_weights": true,
         "limit": {
           "context": 131072,
           "output": 131072
         }
       },
-      "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
-        "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
-        "name": "NVIDIA Nemotron 3 Super 120B",
-        "description": "Nemotron middle tier for collaborative agents and high-volume reasoning workloads",
+      "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
+        "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+        "name": "Nemotron 3 Ultra",
+        "description": "Nemotron 3 Ultra is a powerful MoE model designed for long-running agents across coding, deep research, and enterprise automation.",
         "family": "nemotron",
         "attachment": false,
         "reasoning": true,
@@ -79412,8 +87828,8 @@
         "tool_call": true,
         "structured_output": true,
         "temperature": true,
-        "release_date": "2026-03-11",
-        "last_updated": "2026-03-12",
+        "release_date": "2026-06-04",
+        "last_updated": "2026-06-04",
         "modalities": {
           "input": [
             "text"
@@ -79428,10 +87844,66 @@
           "output": 262144
         }
       },
+      "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
+        "id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
+        "name": "Nemotron 3 Super",
+        "description": "Nemotron 3 is a LatentMoE model designed to deliver strong agentic, reasoning, and conversational capabilities.",
+        "family": "nemotron",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-03-11",
+        "last_updated": "2026-03-11",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        }
+      },
+      "JetBrains/Mellum2-12B-A2.5B-Instruct": {
+        "id": "JetBrains/Mellum2-12B-A2.5B-Instruct",
+        "name": "Mellum2 12B A2.5B",
+        "description": "Mellum2-12B-A2.5B-Instruct is a fast MoE model with 131K context built for coding, tool use, and low-latency AI workflows.",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-06-01",
+        "last_updated": "2026-06-01",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        }
+      },
       "OpenPipe/Qwen3-14B-Instruct": {
         "id": "OpenPipe/Qwen3-14B-Instruct",
-        "name": "OpenPipe Qwen3 14B Instruct",
-        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+        "name": "Qwen3 14B Instruct",
+        "description": "An efficient multilingual, dense, instruction-tuned model, optimized by OpenPipe for building agents with finetuning.",
         "family": "qwen",
         "attachment": false,
         "reasoning": false,
@@ -79439,7 +87911,7 @@
         "structured_output": true,
         "temperature": true,
         "release_date": "2025-04-29",
-        "last_updated": "2026-03-12",
+        "last_updated": "2025-04-29",
         "modalities": {
           "input": [
             "text"
@@ -79454,18 +87926,23 @@
           "output": 32768
         }
       },
-      "zai-org/GLM-5-FP8": {
-        "id": "zai-org/GLM-5-FP8",
-        "name": "GLM 5",
-        "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
+      "zai-org/GLM-5.2": {
+        "id": "zai-org/GLM-5.2",
+        "name": "GLM 5.2",
+        "description": "GLM-5.2 is a Mixture-of-Experts language model featuring 40 billion activated parameters and a total of 744 billion parameters.",
         "family": "glm",
         "attachment": false,
-        "reasoning": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
         "tool_call": true,
         "structured_output": true,
         "temperature": true,
-        "release_date": "2026-02-11",
-        "last_updated": "2026-03-12",
+        "release_date": "2026-06-16",
+        "last_updated": "2026-06-16",
         "modalities": {
           "input": [
             "text"
@@ -79476,14 +87953,14 @@
         },
         "open_weights": true,
         "limit": {
-          "context": 200000,
-          "output": 200000
+          "context": 262144,
+          "output": 262144
         }
       },
       "deepseek-ai/DeepSeek-V3.1": {
         "id": "deepseek-ai/DeepSeek-V3.1",
         "name": "DeepSeek V3.1",
-        "description": "DeepSeek chat model for instruction following, coding, and analysis",
+        "description": "A large hybrid model that supports both thinking and non-thinking modes via prompt templates.",
         "family": "deepseek",
         "attachment": false,
         "reasoning": false,
@@ -79491,7 +87968,7 @@
         "structured_output": true,
         "temperature": true,
         "release_date": "2025-08-21",
-        "last_updated": "2026-03-12",
+        "last_updated": "2025-08-21",
         "modalities": {
           "input": [
             "text"
@@ -79506,11 +87983,75 @@
           "output": 161000
         }
       },
+      "deepseek-ai/DeepSeek-V4-Flash": {
+        "id": "deepseek-ai/DeepSeek-V4-Flash",
+        "name": "DeepSeek V4 Flash",
+        "description": "DeepSeek V4-Flash is an MoE model with 1M context length great for coding, reasoning, and agentic workloads.",
+        "family": "deepseek",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1048576,
+          "output": 1048576
+        }
+      },
+      "deepseek-ai/DeepSeek-V4-Pro": {
+        "id": "deepseek-ai/DeepSeek-V4-Pro",
+        "name": "DeepSeek V4 Pro",
+        "description": "DeepSeek V4-Pro is a 1.6T-parameter MoE model with 49B active parameters excelling at advanced reasoning, coding, and complex agentic workloads.",
+        "family": "deepseek",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1048576,
+          "output": 1048576
+        }
+      },
       "MiniMaxAI/MiniMax-M2.5": {
         "id": "MiniMaxAI/MiniMax-M2.5",
         "name": "MiniMax M2.5",
-        "description": "MiniMax model for chat, coding, office work, and agentic tasks",
-        "family": "minimax",
+        "description": "MoE model with a highly sparse architecture designed for high-throughput and low latency with strong coding capabilities.",
+        "family": "minimax-m2.5",
         "attachment": false,
         "reasoning": true,
         "reasoning_options": [],
@@ -79518,7 +88059,7 @@
         "structured_output": true,
         "temperature": true,
         "release_date": "2026-02-12",
-        "last_updated": "2026-03-12",
+        "last_updated": "2026-02-12",
         "modalities": {
           "input": [
             "text"
@@ -81778,10 +90319,12 @@
         "id": "poolside/laguna-xs.2:free",
         "name": "Poolside: Laguna XS.2 (free)",
         "description": "Free provider route for experiments, demos, and cost-sensitive chat workloads",
+        "family": "laguna",
         "attachment": false,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": false,
         "temperature": true,
         "release_date": "2026-04-28",
         "last_updated": "2026-06-13",
@@ -81793,7 +90336,7 @@
             "text"
           ]
         },
-        "open_weights": false,
+        "open_weights": true,
         "limit": {
           "context": 262144,
           "output": 32768
@@ -81803,10 +90346,12 @@
         "id": "poolside/laguna-m.1:free",
         "name": "Poolside: Laguna M.1 (free)",
         "description": "Free provider route for experiments, demos, and cost-sensitive chat workloads",
+        "family": "laguna",
         "attachment": false,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
+        "structured_output": false,
         "temperature": true,
         "release_date": "2026-04-28",
         "last_updated": "2026-06-13",
@@ -81818,7 +90363,7 @@
             "text"
           ]
         },
-        "open_weights": false,
+        "open_weights": true,
         "limit": {
           "context": 262144,
           "output": 32768
@@ -90928,6 +99473,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -91748,6 +100294,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -92132,6 +100679,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -92367,6 +100915,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -92406,6 +100955,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -92656,6 +101206,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -96597,7 +105148,7 @@
         ],
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-24",
         "last_updated": "2025-11-24",
         "modalities": {
@@ -96809,6 +105360,42 @@
         "limit": {
           "context": 200000,
           "output": 64000
+        }
+      },
+      "databricks-glm-5-2": {
+        "id": "databricks-glm-5-2",
+        "name": "GLM-5.2",
+        "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-06-13",
+        "last_updated": "2026-06-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
         }
       },
       "databricks-claude-haiku-4-5": {
@@ -97115,6 +105702,45 @@
         "limit": {
           "context": 1048576,
           "output": 65536
+        }
+      },
+      "databricks-kimi-k2-7-code": {
+        "id": "databricks-kimi-k2-7-code",
+        "name": "Kimi K2.7 Code",
+        "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+        "family": "kimi-k2",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-01",
+        "release_date": "2026-06-12",
+        "last_updated": "2026-06-12",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 262144
         }
       },
       "databricks-claude-sonnet-4-6": {
@@ -98841,6 +107467,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -99762,18 +108389,72 @@
       }
     }
   },
+  "meta": {
+    "id": "meta",
+    "env": [
+      "META_MODEL_API_KEY"
+    ],
+    "npm": "@ai-sdk/openai",
+    "api": "https://api.meta.ai/v1",
+    "name": "Meta",
+    "doc": "https://dev.meta.ai/docs",
+    "models": {
+      "muse-spark-1.1": {
+        "id": "muse-spark-1.1",
+        "name": "Muse Spark 1.1",
+        "description": "Muse Spark is a natively multimodal reasoning model with support for tool-use, visual chain of thought, and multi-agent orchestration.",
+        "family": "muse",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-08",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 32000
+        }
+      }
+    }
+  },
   "routing-run": {
     "id": "routing-run",
     "env": [
       "ROUTING_RUN_API_KEY"
     ],
     "npm": "@ai-sdk/openai-compatible",
-    "api": "https://ai.routing.sh/v1",
+    "api": "https://api.routing.run/v1",
     "name": "routing.run",
     "doc": "https://docs.routing.run/api-reference/models",
     "models": {
-      "route/deepseek-v4-flash": {
-        "id": "route/deepseek-v4-flash",
+      "deepseek-v4-flash": {
+        "id": "deepseek-v4-flash",
         "name": "DeepSeek V4 Flash",
         "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
         "family": "deepseek-flash",
@@ -99800,15 +108481,15 @@
         "open_weights": true,
         "limit": {
           "context": 1000000,
-          "output": 131072
+          "output": 64000
         }
       },
-      "route/deepseek-v4-flash-6bit": {
-        "id": "route/deepseek-v4-flash-6bit",
-        "name": "DeepSeek V4 Flash 6bit",
-        "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
-        "family": "deepseek-flash",
-        "attachment": false,
+      "kimi-k2.7-code": {
+        "id": "kimi-k2.7-code",
+        "name": "Kimi K2.7 Code",
+        "description": "Coding-focused Kimi model, stronger on long-horizon repo work with less overthinking",
+        "family": "kimi-k2",
+        "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
         "tool_call": true,
@@ -99816,152 +108497,15 @@
           "field": "reasoning_content"
         },
         "structured_output": true,
-        "temperature": true,
-        "knowledge": "2025-05",
-        "release_date": "2026-04-24",
-        "last_updated": "2026-04-24",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 1000000,
-          "output": 131072
-        }
-      },
-      "route/minimax-m2.7-highspeed": {
-        "id": "route/minimax-m2.7-highspeed",
-        "name": "MiniMax M2.7 Highspeed",
-        "description": "Low-latency M2.7 variant for interactive coding plans and agent loops",
-        "family": "minimax",
-        "attachment": false,
-        "reasoning": true,
-        "reasoning_options": [],
-        "tool_call": true,
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "temperature": true,
-        "release_date": "2026-03-18",
-        "last_updated": "2026-03-18",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 100000,
-          "output": 131072
-        }
-      },
-      "route/minimax-m2.5": {
-        "id": "route/minimax-m2.5",
-        "name": "MiniMax M2.5",
-        "description": "Prior MiniMax coding model for agent workflows, office edits, and automation",
-        "family": "minimax",
-        "attachment": false,
-        "reasoning": false,
-        "tool_call": true,
-        "temperature": true,
-        "release_date": "2026-02-12",
-        "last_updated": "2026-02-12",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 100000,
-          "output": 131072
-        }
-      },
-      "route/mistral-small-2503": {
-        "id": "route/mistral-small-2503",
-        "name": "Mistral Small 2503",
-        "description": "Fast Mistral production model for chat, extraction, and cost-sensitive agents",
-        "family": "mistral-small",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2025-06",
-        "release_date": "2026-03-16",
-        "last_updated": "2026-03-16",
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "video"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 128000,
-          "output": 32768
-        }
-      },
-      "route/gemma-4-31b-it": {
-        "id": "route/gemma-4-31b-it",
-        "name": "Gemma 4 31B IT",
-        "description": "Largest Gemma 4 instruction model for open, self-hosted chat and reasoning",
-        "family": "gemma",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": true,
-        "release_date": "2026-04-02",
-        "last_updated": "2026-04-02",
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "video"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 131072,
-          "output": 65536
-        }
-      },
-      "route/step-3.5-flash-2603": {
-        "id": "route/step-3.5-flash-2603",
-        "name": "Step 3.5 Flash 2603",
-        "description": "StepFun flash model for efficient multimodal reasoning, coding, and tool use",
-        "attachment": false,
-        "reasoning": true,
-        "reasoning_options": [],
-        "tool_call": true,
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "temperature": true,
+        "temperature": false,
         "knowledge": "2025-01",
-        "release_date": "2026-04-02",
-        "last_updated": "2026-04-02",
+        "release_date": "2026-06-12",
+        "last_updated": "2026-06-12",
         "modalities": {
           "input": [
-            "text"
+            "text",
+            "image",
+            "video"
           ],
           "output": [
             "text"
@@ -99969,13 +108513,12 @@
         },
         "open_weights": true,
         "limit": {
-          "context": 262144,
-          "input": 256000,
-          "output": 65536
+          "context": 200000,
+          "output": 32000
         }
       },
-      "route/deepseek-v4-pro": {
-        "id": "route/deepseek-v4-pro",
+      "deepseek-v4-pro": {
+        "id": "deepseek-v4-pro",
         "name": "DeepSeek V4 Pro",
         "description": "Open MoE flagship with million-token context for coding and long agent runs",
         "family": "deepseek-thinking",
@@ -100002,40 +108545,14 @@
         "open_weights": true,
         "limit": {
           "context": 1000000,
-          "output": 131072
+          "output": 64000
         }
       },
-      "route/mistral-large-3": {
-        "id": "route/mistral-large-3",
-        "name": "Mistral Large 3",
-        "description": "Mistral's largest general model for enterprise agents, coding, and multilingual reasoning",
-        "family": "mistral-large",
-        "attachment": false,
-        "reasoning": false,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2024-11",
-        "release_date": "2024-11-01",
-        "last_updated": "2025-12-02",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 128000,
-          "output": 32768
-        }
-      },
-      "route/deepseek-v4-pro-6bit": {
-        "id": "route/deepseek-v4-pro-6bit",
-        "name": "DeepSeek V4 Pro 6bit",
-        "description": "Open MoE flagship with million-token context for coding and long agent runs",
-        "family": "deepseek-thinking",
+      "glm-5.2": {
+        "id": "glm-5.2",
+        "name": "GLM-5.2",
+        "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+        "family": "glm",
         "attachment": false,
         "reasoning": true,
         "reasoning_options": [],
@@ -100045,9 +108562,8 @@
         },
         "structured_output": true,
         "temperature": true,
-        "knowledge": "2025-05",
-        "release_date": "2026-04-24",
-        "last_updated": "2026-04-24",
+        "release_date": "2026-06-13",
+        "last_updated": "2026-06-13",
         "modalities": {
           "input": [
             "text"
@@ -100058,27 +108574,31 @@
         },
         "open_weights": true,
         "limit": {
-          "context": 1000000,
-          "output": 131072
+          "context": 200000,
+          "output": 32000
         }
       },
-      "route/mistral-medium-2505": {
-        "id": "route/mistral-medium-2505",
-        "name": "Mistral Medium 2505",
-        "description": "Mistral model for multilingual chat, reasoning, and tool-assisted workflows",
-        "family": "mistral-medium",
+      "claude-opus-4-8": {
+        "id": "claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+        "family": "claude-opus",
         "attachment": true,
-        "reasoning": false,
+        "reasoning": true,
+        "reasoning_options": [],
         "tool_call": true,
-        "temperature": true,
-        "knowledge": "2025-05",
-        "release_date": "2025-05-07",
-        "last_updated": "2025-05-07",
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": false,
+        "knowledge": "2026-01",
+        "release_date": "2026-05-28",
+        "last_updated": "2026-05-28",
         "modalities": {
           "input": [
             "text",
             "image",
-            "video"
+            "pdf"
           ],
           "output": [
             "text"
@@ -100086,95 +108606,15 @@
         },
         "open_weights": false,
         "limit": {
-          "context": 128000,
-          "output": 32768
+          "context": 1000000,
+          "output": 32000
         }
       },
-      "route/minimax-m2.7": {
-        "id": "route/minimax-m2.7",
-        "name": "MiniMax M2.7",
-        "description": "Open MiniMax flagship for coding agents, office automation, and complex environments",
-        "family": "minimax",
-        "attachment": false,
-        "reasoning": true,
-        "reasoning_options": [],
-        "tool_call": true,
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "temperature": true,
-        "release_date": "2026-03-18",
-        "last_updated": "2026-03-18",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 100000,
-          "output": 131072
-        }
-      },
-      "route/qwen3.6-27b-202k": {
-        "id": "route/qwen3.6-27b-202k",
-        "name": "Qwen3.6 27B 202K",
-        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
-        "family": "qwen",
-        "attachment": false,
-        "reasoning": false,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": true,
-        "release_date": "2026-04-22",
-        "last_updated": "2026-04-22",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 202000,
-          "output": 32768
-        }
-      },
-      "route/minimax-m2.5-highspeed": {
-        "id": "route/minimax-m2.5-highspeed",
-        "name": "MiniMax M2.5 Highspeed",
-        "description": "High-speed MiniMax model for low-latency coding and agent workflows",
-        "family": "minimax",
-        "attachment": false,
-        "reasoning": false,
-        "tool_call": true,
-        "temperature": true,
-        "release_date": "2026-02-13",
-        "last_updated": "2026-02-13",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 100000,
-          "output": 131072
-        }
-      },
-      "route/mimo-v2.5": {
-        "id": "route/mimo-v2.5",
-        "name": "MiMo V2.5",
-        "description": "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution",
-        "family": "mimo",
+      "gpt-5.6-luna": {
+        "id": "gpt-5.6-luna",
+        "name": "GPT-5.6 Luna",
+        "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+        "family": "gpt-nano",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
@@ -100182,57 +108622,33 @@
         "interleaved": {
           "field": "reasoning_content"
         },
-        "temperature": true,
-        "knowledge": "2024-12",
-        "release_date": "2026-04-22",
-        "last_updated": "2026-04-22",
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
         "modalities": {
           "input": [
             "text",
             "image",
-            "video"
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "open_weights": true,
+        "open_weights": false,
         "limit": {
           "context": 1000000,
-          "output": 262144
+          "input": 922000,
+          "output": 128000
         }
       },
-      "route/qwen3.6-27b": {
-        "id": "route/qwen3.6-27b",
-        "name": "Qwen3.6 27B",
-        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
-        "family": "qwen",
-        "attachment": false,
-        "reasoning": false,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": true,
-        "release_date": "2026-04-22",
-        "last_updated": "2026-04-22",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 202000,
-          "output": 32768
-        }
-      },
-      "route/mimo-v2.5-pro-6bit": {
-        "id": "route/mimo-v2.5-pro-6bit",
-        "name": "MiMo V2.5 Pro 6bit",
-        "description": "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution",
-        "family": "mimo",
+      "gpt-5.6-terra": {
+        "id": "gpt-5.6-terra",
+        "name": "GPT-5.6 Terra",
+        "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+        "family": "gpt-mini",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
@@ -100240,30 +108656,33 @@
         "interleaved": {
           "field": "reasoning_content"
         },
-        "temperature": true,
-        "knowledge": "2024-12",
-        "release_date": "2026-04-22",
-        "last_updated": "2026-04-22",
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
         "modalities": {
           "input": [
             "text",
             "image",
-            "video"
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "open_weights": true,
+        "open_weights": false,
         "limit": {
           "context": 1000000,
-          "output": 262144
+          "input": 922000,
+          "output": 128000
         }
       },
-      "route/stepfun-3.5-flash": {
-        "id": "route/stepfun-3.5-flash",
-        "name": "StepFun 3.5 Flash",
-        "description": "StepFun flash lane for quick multimodal reasoning and coding assistance",
+      "glm-5.2-nitro": {
+        "id": "glm-5.2-nitro",
+        "name": "GLM 5.2 Nitro",
+        "description": "Open flagship GLM for long-horizon coding agents and million-token context work",
+        "family": "glm",
         "attachment": false,
         "reasoning": true,
         "reasoning_options": [],
@@ -100271,10 +108690,40 @@
         "interleaved": {
           "field": "reasoning_content"
         },
+        "structured_output": true,
         "temperature": true,
-        "knowledge": "2025-01",
-        "release_date": "2026-01-29",
-        "last_updated": "2026-02-13",
+        "release_date": "2026-06-13",
+        "last_updated": "2026-06-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        }
+      },
+      "qwen3.5-9b": {
+        "id": "qwen3.5-9b",
+        "name": "Qwen3.5 9B",
+        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-23",
+        "last_updated": "2026-02-23",
         "modalities": {
           "input": [
             "text"
@@ -100286,15 +108735,14 @@
         "open_weights": true,
         "limit": {
           "context": 262144,
-          "input": 256000,
-          "output": 65536
+          "output": 32000
         }
       },
-      "route/mimo-v2.5-pro": {
-        "id": "route/mimo-v2.5-pro",
-        "name": "MiMo V2.5 Pro",
-        "description": "Stronger MiMo Pro tier for multimodal reasoning and coding-agent execution",
-        "family": "mimo",
+      "claude-sonnet-4-6": {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
+        "family": "claude-sonnet",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
@@ -100303,29 +108751,30 @@
           "field": "reasoning_content"
         },
         "temperature": true,
-        "knowledge": "2024-12",
-        "release_date": "2026-04-22",
-        "last_updated": "2026-04-22",
+        "knowledge": "2025-08-31",
+        "release_date": "2026-02-17",
+        "last_updated": "2026-03-13",
         "modalities": {
           "input": [
             "text",
             "image",
-            "video"
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "open_weights": true,
+        "open_weights": false,
         "limit": {
           "context": 1000000,
-          "output": 262144
+          "output": 64000
         }
       },
-      "route/step-3.5-flash": {
-        "id": "route/step-3.5-flash",
-        "name": "Step 3.5 Flash",
-        "description": "StepFun flash lane for quick multimodal reasoning and coding assistance",
+      "nemotron-3-ultra": {
+        "id": "nemotron-3-ultra",
+        "name": "Nemotron 3 Ultra 550B A55B",
+        "description": "Largest Nemotron 3 model for maximum open-weight reasoning and agent accuracy",
+        "family": "nemotron",
         "attachment": false,
         "reasoning": true,
         "reasoning_options": [],
@@ -100334,9 +108783,8 @@
           "field": "reasoning_content"
         },
         "temperature": true,
-        "knowledge": "2025-01",
-        "release_date": "2026-01-29",
-        "last_updated": "2026-02-13",
+        "release_date": "2026-06-04",
+        "last_updated": "2026-06-04",
         "modalities": {
           "input": [
             "text"
@@ -100347,16 +108795,15 @@
         },
         "open_weights": true,
         "limit": {
-          "context": 262144,
-          "input": 256000,
-          "output": 65536
+          "context": 131072,
+          "output": 32000
         }
       },
-      "route/deepseek-v3.2": {
-        "id": "route/deepseek-v3.2",
-        "name": "DeepSeek V3.2",
-        "description": "Automatic model router for matching prompts to suitable backends and budgets",
-        "family": "deepseek",
+      "gpt-5.6-sol": {
+        "id": "gpt-5.6-sol",
+        "name": "GPT-5.6 Sol",
+        "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+        "family": "gpt",
         "attachment": true,
         "reasoning": true,
         "reasoning_options": [],
@@ -100365,24 +108812,25 @@
           "field": "reasoning_content"
         },
         "structured_output": true,
-        "temperature": true,
-        "knowledge": "2024-07",
-        "release_date": "2025-12-01",
-        "last_updated": "2025-12-01",
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
         "modalities": {
           "input": [
             "text",
             "image",
-            "video"
+            "pdf"
           ],
           "output": [
             "text"
           ]
         },
-        "open_weights": true,
+        "open_weights": false,
         "limit": {
-          "context": 163840,
-          "output": 163840
+          "context": 1000000,
+          "input": 922000,
+          "output": 128000
         }
       }
     }
@@ -101237,6 +109685,7 @@
         "tool_call": true,
         "interleaved": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -101992,6 +110441,7 @@
           "field": "reasoning_content"
         },
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -102456,7 +110906,7 @@
         ],
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-01",
         "last_updated": "2025-11-01",
         "modalities": {
@@ -102947,6 +111397,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -111145,13 +119596,16 @@
       "poolside/laguna-xs.2": {
         "id": "poolside/laguna-xs.2",
         "name": "Laguna XS.2",
-        "description": "General-purpose chat model for instruction following, writing, and analysis",
+        "description": "Agentic coding model from Poolside in the XS size class for local deployment",
+        "family": "laguna",
         "attachment": false,
-        "reasoning": false,
-        "tool_call": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
         "structured_output": false,
-        "release_date": "2026-04-29",
-        "last_updated": "2026-04-29",
+        "temperature": true,
+        "release_date": "2026-04-28",
+        "last_updated": "2026-06-13",
         "modalities": {
           "input": [
             "text"
@@ -111160,23 +119614,25 @@
             "text"
           ]
         },
-        "open_weights": false,
+        "open_weights": true,
         "limit": {
-          "context": 128000,
-          "input": 128000,
+          "context": 262144,
           "output": 32768
         }
       },
       "poolside/laguna-m.1": {
         "id": "poolside/laguna-m.1",
         "name": "Laguna M.1",
-        "description": "General-purpose chat model for instruction following, writing, and analysis",
+        "description": "Poolside's flagship agentic coding model for long-horizon work",
+        "family": "laguna",
         "attachment": false,
-        "reasoning": false,
-        "tool_call": false,
+        "reasoning": true,
+        "reasoning_options": [],
+        "tool_call": true,
         "structured_output": false,
-        "release_date": "2026-04-29",
-        "last_updated": "2026-04-29",
+        "temperature": true,
+        "release_date": "2026-04-28",
+        "last_updated": "2026-06-13",
         "modalities": {
           "input": [
             "text"
@@ -111185,10 +119641,9 @@
             "text"
           ]
         },
-        "open_weights": false,
+        "open_weights": true,
         "limit": {
-          "context": 128000,
-          "input": 128000,
+          "context": 262144,
           "output": 32768
         }
       },
@@ -118582,6 +127037,59 @@
           "output": 64000
         }
       },
+      "qwen3-next-80b-a3b-instruct": {
+        "id": "qwen3-next-80b-a3b-instruct",
+        "name": "Qwen3-Next 80B-A3B Instruct",
+        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2025-09",
+        "last_updated": "2025-09",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        }
+      },
+      "llama-4-maverick": {
+        "id": "llama-4-maverick",
+        "name": "Llama 4 Maverick 17B Instruct",
+        "description": "Open multimodal Llama for strong reasoning with efficient everyday serving",
+        "family": "llama",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2024-08",
+        "release_date": "2025-04-05",
+        "last_updated": "2025-04-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 16384
+        }
+      },
       "claude-opus-4-5": {
         "id": "claude-opus-4-5",
         "name": "Claude Opus 4.5 (latest)",
@@ -118601,7 +127109,7 @@
         ],
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-24",
         "last_updated": "2025-11-24",
         "modalities": {
@@ -118650,7 +127158,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "open_weights": false,
@@ -118658,6 +127167,84 @@
           "context": 400000,
           "input": 272000,
           "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai",
+          "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1",
+          "shape": "responses"
+        }
+      },
+      "gemma-3-12b": {
+        "id": "gemma-3-12b",
+        "name": "Gemma 3 12B",
+        "description": "Google's open-weight Gemma 3 vision-language model for text and image understanding",
+        "family": "gemma",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2024-08-31",
+        "release_date": "2025-03-13",
+        "last_updated": "2025-03-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 16384
+        }
+      },
+      "gpt-5-1-codex-mini": {
+        "id": "gpt-5-1-codex-mini",
+        "name": "GPT-5.1 Codex mini",
+        "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
+        "family": "gpt-codex",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13",
+        "last_updated": "2025-11-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai",
+          "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1",
+          "shape": "responses"
         }
       },
       "gpt-5-1": {
@@ -118690,7 +127277,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "open_weights": false,
@@ -118698,6 +127286,37 @@
           "context": 400000,
           "input": 272000,
           "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai",
+          "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1",
+          "shape": "responses"
+        }
+      },
+      "meta-llama-3-3-70b-instruct": {
+        "id": "meta-llama-3-3-70b-instruct",
+        "name": "Llama-3.3-70B-Instruct",
+        "description": "Popular open Llama workhorse for multilingual chat, coding, and self-hosting",
+        "family": "llama",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2023-12",
+        "release_date": "2024-12-06",
+        "last_updated": "2024-12-06",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 128000,
+          "output": 4096
         }
       },
       "gemini-3-pro": {
@@ -118772,7 +127391,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "open_weights": false,
@@ -118780,6 +127400,11 @@
           "context": 400000,
           "input": 272000,
           "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai",
+          "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1",
+          "shape": "responses"
         }
       },
       "gemini-3-1-flash-lite": {
@@ -118873,9 +127498,14 @@
             "type": "toggle"
           },
           {
-            "type": "budget_tokens",
-            "min": 1024,
-            "max": 127999
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           }
         ],
         "tool_call": true,
@@ -118897,20 +127527,97 @@
         "limit": {
           "context": 1000000,
           "output": 128000
-        },
-        "experimental": {
-          "modes": {
-            "fast": {
-              "provider": {
-                "body": {
-                  "speed": "fast"
-                },
-                "headers": {
-                  "anthropic-beta": "fast-mode-2026-02-01"
-                }
-              }
-            }
+        }
+      },
+      "claude-opus-4-8": {
+        "id": "claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
           }
+        ],
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01",
+        "release_date": "2026-05-28",
+        "last_updated": "2026-05-28",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        }
+      },
+      "gpt-5-3-codex": {
+        "id": "gpt-5-3-codex",
+        "name": "GPT-5.3 Codex",
+        "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
+        "family": "gpt-codex",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-02-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai",
+          "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1",
+          "shape": "responses"
         }
       },
       "gpt-5-4-nano": {
@@ -118944,7 +127651,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "open_weights": false,
@@ -118952,6 +127660,11 @@
           "context": 400000,
           "input": 272000,
           "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai",
+          "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1",
+          "shape": "responses"
         }
       },
       "claude-opus-4-1": {
@@ -119023,7 +127736,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "open_weights": false,
@@ -119032,16 +127746,57 @@
           "input": 272000,
           "output": 128000
         },
-        "experimental": {
-          "modes": {
-            "fast": {
-              "provider": {
-                "body": {
-                  "service_tier": "priority"
-                }
-              }
-            }
+        "provider": {
+          "npm": "@ai-sdk/openai",
+          "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1",
+          "shape": "responses"
+        }
+      },
+      "gpt-5-2-codex": {
+        "id": "gpt-5-2-codex",
+        "name": "GPT-5.2 Codex",
+        "description": "Code-specialist GPT for repository edits, reviews, and long-running software agents",
+        "family": "gpt-codex",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2025-12-11",
+        "last_updated": "2025-12-11",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai",
+          "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1",
+          "shape": "responses"
         }
       },
       "gpt-oss-120b": {
@@ -119078,6 +127833,48 @@
         "limit": {
           "context": 131072,
           "output": 32768
+        }
+      },
+      "gemini-3-5-flash": {
+        "id": "gemini-3-5-flash",
+        "name": "Gemini 3.5 Flash",
+        "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+        "family": "gemini-flash",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-05-19",
+        "last_updated": "2026-05-19",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
         }
       },
       "gemini-3-1-pro": {
@@ -119195,20 +127992,70 @@
         "limit": {
           "context": 1000000,
           "output": 128000
-        },
-        "experimental": {
-          "modes": {
-            "fast": {
-              "provider": {
-                "body": {
-                  "speed": "fast"
-                },
-                "headers": {
-                  "anthropic-beta": "fast-mode-2026-02-01"
-                }
-              }
-            }
+        }
+      },
+      "qwen35-122b-a10b": {
+        "id": "qwen35-122b-a10b",
+        "name": "Qwen3.5 122B-A10B",
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
           }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-23",
+        "last_updated": "2026-02-23",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 8000
+        }
+      },
+      "meta-llama-3-1-8b-instruct": {
+        "id": "meta-llama-3-1-8b-instruct",
+        "name": "Llama 3.1 8B Instruct",
+        "description": "Meta's compact open-weight Llama 3.1 model for fast, low-cost text generation",
+        "family": "llama",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2023-12-31",
+        "release_date": "2024-07-23",
+        "last_updated": "2024-07-23",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 131072,
+          "output": 16384
         }
       },
       "gpt-5-mini": {
@@ -119241,7 +128088,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "open_weights": false,
@@ -119249,6 +128097,11 @@
           "context": 400000,
           "input": 272000,
           "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai",
+          "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1",
+          "shape": "responses"
         }
       },
       "gpt-5-nano": {
@@ -119281,7 +128134,8 @@
             "image"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "open_weights": false,
@@ -119289,6 +128143,11 @@
           "context": 400000,
           "input": 272000,
           "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai",
+          "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1",
+          "shape": "responses"
         }
       },
       "claude-sonnet-4-6": {
@@ -119361,7 +128220,8 @@
             "pdf"
           ],
           "output": [
-            "text"
+            "text",
+            "image"
           ]
         },
         "open_weights": false,
@@ -119370,16 +128230,56 @@
           "input": 922000,
           "output": 128000
         },
-        "experimental": {
-          "modes": {
-            "fast": {
-              "provider": {
-                "body": {
-                  "service_tier": "priority"
-                }
-              }
-            }
+        "provider": {
+          "npm": "@ai-sdk/openai",
+          "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1",
+          "shape": "responses"
+        }
+      },
+      "gpt-5-1-codex-max": {
+        "id": "gpt-5-1-codex-max",
+        "name": "GPT-5.1 Codex Max",
+        "description": "Coding-optimized GPT model for repository edits, reviews, and agentic software work",
+        "family": "gpt-codex",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
           }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13",
+        "last_updated": "2025-11-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text",
+            "image"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "provider": {
+          "npm": "@ai-sdk/openai",
+          "api": "${NEON_AI_GATEWAY_BASE_URL}/ai-gateway/openai/v1",
+          "shape": "responses"
         }
       },
       "gpt-oss-20b": {
@@ -121133,6 +130033,92 @@
           "output": 128000
         }
       },
+      "gpt-5.6-luna": {
+        "id": "gpt-5.6-luna",
+        "name": "GPT-5.6 Luna",
+        "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+        "family": "gpt-nano",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        }
+      },
+      "gpt-5.6-terra": {
+        "id": "gpt-5.6-terra",
+        "name": "GPT-5.6 Terra",
+        "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+        "family": "gpt-mini",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        }
+      },
       "claude-opus-4.8": {
         "id": "claude-opus-4.8",
         "name": "Claude Opus 4.8",
@@ -121154,6 +130140,7 @@
         ],
         "tool_call": true,
         "temperature": false,
+        "knowledge": "2026-01",
         "release_date": "2026-05-28",
         "last_updated": "2026-05-28",
         "modalities": {
@@ -121243,7 +130230,7 @@
         ],
         "tool_call": true,
         "temperature": true,
-        "knowledge": "2025-03-31",
+        "knowledge": "2025-05",
         "release_date": "2025-11-24",
         "last_updated": "2025-11-24",
         "modalities": {
@@ -121300,8 +130287,8 @@
         },
         "open_weights": false,
         "limit": {
-          "context": 400000,
-          "input": 272000,
+          "context": 1050000,
+          "input": 922000,
           "output": 128000
         }
       },
@@ -121418,8 +130405,8 @@
         },
         "open_weights": false,
         "limit": {
-          "context": 200000,
-          "input": 136000,
+          "context": 1000000,
+          "input": 936000,
           "output": 64000
         }
       },
@@ -121606,6 +130593,49 @@
               }
             }
           }
+        }
+      },
+      "gpt-5.6-sol": {
+        "id": "gpt-5.6-sol",
+        "name": "GPT-5.6 Sol",
+        "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-02-16",
+        "release_date": "2026-07-09",
+        "last_updated": "2026-07-09",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
         }
       },
       "gpt-5.2-codex": {
@@ -121976,15 +131006,27 @@
       "agent-prime": {
         "id": "agent-prime",
         "name": "Agent Prime",
-        "description": "Preview model for early access evaluation, prototyping, and compatibility testing",
+        "description": "Reliable models for dependable agentic applications, multi-step tool use, and reasoning workflows. Any model that meets the contract spec can serve your request.",
         "attachment": false,
         "reasoning": true,
-        "reasoning_options": [],
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
         "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
         "structured_output": true,
         "temperature": true,
         "release_date": "2026-05-04",
-        "last_updated": "2026-05-19",
+        "last_updated": "2026-07-06",
         "modalities": {
           "input": [
             "text"
@@ -121995,18 +131037,33 @@
         },
         "open_weights": false,
         "limit": {
-          "context": 128000,
-          "output": 64000
+          "context": 196608,
+          "input": 120000,
+          "output": 30000
         },
         "status": "beta"
       },
       "agent-max": {
         "id": "agent-max",
         "name": "Agent Max",
-        "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+        "description": "Frontier models for autonomous research, deep multi-step tool chains, and complex long-horizon tasks. Any model that meets the contract spec can serve your request.",
         "attachment": false,
         "reasoning": true,
-        "reasoning_options": [],
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
         "tool_call": true,
         "interleaved": {
           "field": "reasoning_content"
@@ -122014,7 +131071,7 @@
         "structured_output": true,
         "temperature": true,
         "release_date": "2026-05-04",
-        "last_updated": "2026-05-19",
+        "last_updated": "2026-07-06",
         "modalities": {
           "input": [
             "text",
@@ -122027,6 +131084,7 @@
         "open_weights": false,
         "limit": {
           "context": 1000000,
+          "input": 922000,
           "output": 128000
         },
         "status": "beta"
@@ -122034,15 +131092,27 @@
       "text-standard": {
         "id": "text-standard",
         "name": "Text Standard",
-        "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
+        "description": "Price-optimized models with low-latency, high-throughput and shorter maximum outputs. Any model that meets the contract spec can serve your request.",
         "attachment": false,
         "reasoning": true,
-        "reasoning_options": [],
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
         "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
         "structured_output": true,
         "temperature": true,
         "release_date": "2026-02-26",
-        "last_updated": "2026-05-19",
+        "last_updated": "2026-07-06",
         "modalities": {
           "input": [
             "text"
@@ -122054,69 +131124,26 @@
         "open_weights": false,
         "limit": {
           "context": 128000,
+          "input": 120000,
           "output": 16000
         }
       },
       "code-prime": {
         "id": "code-prime",
         "name": "Code Prime",
-        "description": "Coding model for repository understanding, refactors, and agentic engineering tasks",
+        "description": "Reliable models for everyday software tasks, code completion, review, and standard debugging. Any model that meets the contract spec can serve your request.",
         "attachment": false,
         "reasoning": true,
-        "reasoning_options": [],
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": true,
-        "release_date": "2026-05-04",
-        "last_updated": "2026-05-19",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": false,
-        "limit": {
-          "context": 128000,
-          "output": 64000
-        },
-        "status": "beta"
-      },
-      "text-prime": {
-        "id": "text-prime",
-        "name": "Text Prime",
-        "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
-        "attachment": false,
-        "reasoning": true,
-        "reasoning_options": [],
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": true,
-        "release_date": "2026-02-26",
-        "last_updated": "2026-05-19",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": false,
-        "limit": {
-          "context": 128000,
-          "output": 30000
-        }
-      },
-      "code-max": {
-        "id": "code-max",
-        "name": "Code Max",
-        "description": "Coding model for repository understanding, refactors, and agentic engineering tasks",
-        "attachment": false,
-        "reasoning": true,
-        "reasoning_options": [],
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
         "tool_call": true,
         "interleaved": {
           "field": "reasoning_content"
@@ -122124,7 +131151,91 @@
         "structured_output": true,
         "temperature": true,
         "release_date": "2026-05-04",
-        "last_updated": "2026-05-19",
+        "last_updated": "2026-07-06",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 196608,
+          "input": 120000,
+          "output": 30000
+        },
+        "status": "beta"
+      },
+      "text-prime": {
+        "id": "text-prime",
+        "name": "Text Prime",
+        "description": "Reliable models for everyday text generation, editing, and analysis across diverse workflows. Any model that meets the contract spec can serve your request.",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-26",
+        "last_updated": "2026-07-06",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 196608,
+          "input": 120000,
+          "output": 30000
+        }
+      },
+      "code-max": {
+        "id": "code-max",
+        "name": "Code Max",
+        "description": "Frontier models for complex research, architectural decisions, debugging, and multi-file development. Any model that meets the contract spec can serve your request.",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-05-04",
+        "last_updated": "2026-07-06",
         "modalities": {
           "input": [
             "text",
@@ -122137,6 +131248,7 @@
         "open_weights": false,
         "limit": {
           "context": 1000000,
+          "input": 922000,
           "output": 128000
         },
         "status": "beta"
@@ -122144,15 +131256,27 @@
       "agent-standard": {
         "id": "agent-standard",
         "name": "Agent Standard",
-        "description": "Preview model for early access evaluation, prototyping, and compatibility testing",
+        "description": "Price-optimized models for fast tool calls, simple agent loops, high-throughput automation, and orchestration. Any model that meets the contract spec can serve your request.",
         "attachment": false,
         "reasoning": true,
-        "reasoning_options": [],
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
         "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
         "structured_output": true,
         "temperature": true,
         "release_date": "2026-05-04",
-        "last_updated": "2026-05-19",
+        "last_updated": "2026-07-06",
         "modalities": {
           "input": [
             "text"
@@ -122164,6 +131288,7 @@
         "open_weights": false,
         "limit": {
           "context": 128000,
+          "input": 120000,
           "output": 16000
         },
         "status": "beta"
@@ -122171,10 +131296,24 @@
       "text-max": {
         "id": "text-max",
         "name": "Text Max",
-        "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
+        "description": "Frontier models for deep reasoning, long context, and complex workflows. Any model that meets the contract spec can serve your request.",
         "attachment": false,
         "reasoning": true,
-        "reasoning_options": [],
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        ],
         "tool_call": true,
         "interleaved": {
           "field": "reasoning_content"
@@ -122182,7 +131321,7 @@
         "structured_output": true,
         "temperature": true,
         "release_date": "2026-03-24",
-        "last_updated": "2026-05-19",
+        "last_updated": "2026-07-06",
         "modalities": {
           "input": [
             "text",
@@ -122195,21 +131334,34 @@
         "open_weights": false,
         "limit": {
           "context": 1000000,
+          "input": 922000,
           "output": 128000
         }
       },
       "code-standard": {
         "id": "code-standard",
         "name": "Code Standard",
-        "description": "Coding model for repository understanding, refactors, and agentic engineering tasks",
+        "description": "Price-optimized models for rapid autocomplete, linting, high-frequency suggestions, and batch edits. Any model that meets the contract spec can serve your request.",
         "attachment": false,
         "reasoning": true,
-        "reasoning_options": [],
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        ],
         "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
         "structured_output": true,
         "temperature": true,
         "release_date": "2026-05-04",
-        "last_updated": "2026-05-19",
+        "last_updated": "2026-07-06",
         "modalities": {
           "input": [
             "text"
@@ -122221,6 +131373,7 @@
         "open_weights": false,
         "limit": {
           "context": 128000,
+          "input": 120000,
           "output": 16000
         },
         "status": "beta"

--- a/packages/ax-code/test/cli/tui/stability-phase-wiring.test.ts
+++ b/packages/ax-code/test/cli/tui/stability-phase-wiring.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest"
+import fs from "fs/promises"
+import path from "path"
+
+/**
+ * Lightweight wiring locks for ADR-047 Phase 1–2. Prefer behavioral tests for
+ * logic (terminal-suspend, sync-session-store); these only ensure call sites
+ * stay on the lifecycle/prune helpers.
+ */
+
+const TUI_ROOT = path.resolve(import.meta.dirname, "../../../src/cli/cmd/tui")
+
+describe("tui stability phase wiring (ADR-047)", () => {
+  test("app uses lifecycle terminal suspend and scheduleTuiTimeout for putJson", async () => {
+    const app = await fs.readFile(path.join(TUI_ROOT, "app.tsx"), "utf8")
+
+    expect(app).toContain('from "@tui/util/terminal-suspend"')
+    expect(app).toContain("createTerminalSuspendController")
+    expect(app).toContain("terminalSuspend.suspend(")
+    expect(app).toContain("terminalSuspend.dispose()")
+    expect(app).not.toMatch(/process\.once\(\s*["']SIGCONT["']/)
+    expect(app).not.toMatch(/process\.kill\(\s*0\s*,\s*["']SIGTSTP["']/)
+    expect(app).toContain('name: "app-put-json-timeout"')
+    expect(app).toContain("scheduleTuiTimeout(() => ctrl.abort()")
+  })
+
+  test("session route prunes heavy projection on leave", async () => {
+    const session = await fs.readFile(path.join(TUI_ROOT, "routes/session/index.tsx"), "utf8")
+
+    expect(session).toContain("applySessionLeavePrune")
+    expect(session).toContain("applySessionLeavePrune(draft, sessionID)")
+  })
+
+  test("leave prune helper keeps permission/question/status fields", async () => {
+    const store = await fs.readFile(path.join(TUI_ROOT, "context/sync-session-store.ts"), "utf8")
+
+    expect(store).toContain("export function applySessionLeavePrune")
+    // Must not delete interactive maps or the session list row.
+    const leaveFn = store.slice(store.indexOf("export function applySessionLeavePrune"))
+    const nextExport = leaveFn.indexOf("\nexport ", 1)
+    const body = nextExport >= 0 ? leaveFn.slice(0, nextExport) : leaveFn
+    expect(body).not.toContain("delete store.permission")
+    expect(body).not.toContain("delete store.question")
+    expect(body).not.toContain("delete store.session_status")
+    expect(body).not.toContain("removeByID(store.session")
+    expect(body).toContain("delete store.message[sessionID]")
+    expect(body).toContain("delete store.part[message.id]")
+  })
+})

--- a/packages/ax-code/test/cli/tui/stability-phase-wiring.test.ts
+++ b/packages/ax-code/test/cli/tui/stability-phase-wiring.test.ts
@@ -24,11 +24,13 @@ describe("tui stability phase wiring (ADR-047)", () => {
     expect(app).toContain("scheduleTuiTimeout(() => ctrl.abort()")
   })
 
-  test("session route prunes heavy projection on leave", async () => {
+  test("session route prunes heavy projection on leave and clears session sync", async () => {
     const session = await fs.readFile(path.join(TUI_ROOT, "routes/session/index.tsx"), "utf8")
 
     expect(session).toContain("applySessionLeavePrune")
     expect(session).toContain("applySessionLeavePrune(draft, sessionID)")
+    // Without clear(), fullSyncedSessions keeps re-entry from reloading.
+    expect(session).toContain("sync.session.clear(sessionID)")
   })
 
   test("leave prune helper keeps permission/question/status fields", async () => {

--- a/packages/ax-code/test/cli/tui/sync-result.test.ts
+++ b/packages/ax-code/test/cli/tui/sync-result.test.ts
@@ -5,6 +5,10 @@ describe("tui sync result", () => {
   test("builds the sync facade around store state and injected actions", () => {
     const setStore = Symbol("setStore")
     const sessionSync = (sessionID: string) => sessionID
+    const cleared: string[] = []
+    const sessionClear = (sessionID: string) => {
+      cleared.push(sessionID)
+    }
     const workspaceSync = () => "workspace-sync"
     const bootstrap = () => "bootstrap"
 
@@ -39,6 +43,7 @@ describe("tui sync result", () => {
       store,
       setStore,
       sessionSync,
+      sessionClear,
       workspaceSync,
       bootstrap,
       runtime: {},
@@ -68,6 +73,8 @@ describe("tui sync result", () => {
     expect(result.workspace.get("repo-b")).toBe("repo-b")
     expect(result.workspace.get("repo-missing")).toBeUndefined()
     expect(result.session.sync).toBe(sessionSync)
+    result.session.clear("ses_1")
+    expect(cleared).toEqual(["ses_1"])
     expect(result.workspace.sync).toBe(workspaceSync)
     expect(result.bootstrap).toBe(bootstrap)
   })

--- a/packages/ax-code/test/cli/tui/sync-session-coordinator.test.ts
+++ b/packages/ax-code/test/cli/tui/sync-session-coordinator.test.ts
@@ -135,4 +135,67 @@ describe("tui sync session coordinator", () => {
 
     expect(fetches).toEqual(["ses_5", "ses_6", "ses_5", "ses_6"])
   })
+
+  test("clear during in-flight fetch skips apply and does not mark fullSynced", async () => {
+    const applied: string[] = []
+    let release: (() => void) | undefined
+    const pending = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const controller = createSessionSyncController({
+      async fetchSnapshot(sessionID) {
+        await pending
+        return { id: sessionID }
+      },
+      applySnapshot(sessionID) {
+        applied.push(sessionID)
+      },
+    })
+
+    const flight = controller.sync("ses_leave")
+    controller.clear("ses_leave")
+    release?.()
+    await flight
+
+    expect(applied).toEqual([])
+    // Without force, a fresh sync must run again because clear dropped fullSynced.
+    await controller.sync("ses_leave")
+    expect(applied).toEqual(["ses_leave"])
+  })
+
+  test("clear during in-flight allows a concurrent re-enter sync to apply once", async () => {
+    const applied: string[] = []
+    const fetches: string[] = []
+    let releaseFirst: (() => void) | undefined
+    const firstPending = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let firstFetch = true
+    const controller = createSessionSyncController({
+      async fetchSnapshot(sessionID) {
+        fetches.push(sessionID)
+        if (firstFetch) {
+          firstFetch = false
+          await firstPending
+          return { id: "stale" }
+        }
+        return { id: "fresh" }
+      },
+      applySnapshot(sessionID, snapshot) {
+        applied.push(`${sessionID}:${(snapshot as { id: string }).id}`)
+      },
+    })
+
+    const staleFlight = controller.sync("ses_reenter")
+    controller.clear("ses_reenter")
+    const reenter = controller.sync("ses_reenter")
+    releaseFirst?.()
+    await Promise.all([staleFlight, reenter])
+
+    expect(fetches).toEqual(["ses_reenter", "ses_reenter"])
+    expect(applied).toEqual(["ses_reenter:fresh"])
+    // Re-enter marked fullSynced; no force should not fetch again.
+    await controller.sync("ses_reenter")
+    expect(fetches).toEqual(["ses_reenter", "ses_reenter"])
+  })
 })

--- a/packages/ax-code/test/cli/tui/sync-session-store.test.ts
+++ b/packages/ax-code/test/cli/tui/sync-session-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest"
 import {
   applySessionDeleteCleanup,
+  applySessionLeavePrune,
   applySessionSyncSnapshot,
   createSessionSyncSnapshot,
 } from "../../../src/cli/cmd/tui/context/sync-session-store"
@@ -380,6 +381,85 @@ describe("tui sync session store", () => {
       part: {
         msg_3: [{ id: "part_3" }],
       },
+    })
+  })
+
+  test("leave prune drops heavy transcript state but keeps list row and interactive maps", () => {
+    const store = {
+      session: [{ id: "ses_1" }, { id: "ses_2" }],
+      permission: {
+        ses_1: [{ id: "perm_1" }],
+        ses_2: [{ id: "perm_2" }],
+      },
+      question: {
+        ses_1: [{ id: "question_1" }],
+      },
+      session_status: {
+        ses_1: "busy",
+        ses_2: "idle",
+      },
+      session_risk: {
+        ses_1: { score: 1 },
+        ses_2: { score: 2 },
+      },
+      session_goal: {
+        ses_1: { objective: "leave" },
+        ses_2: { objective: "keep" },
+      },
+      session_diff: {
+        ses_1: [{ path: "leave.ts" }],
+        ses_2: [{ path: "keep.ts" }],
+      },
+      todo: {
+        ses_1: [{ id: "todo_1" }],
+        ses_2: [{ id: "todo_2" }],
+      },
+      message: {
+        ses_1: [{ id: "msg_1" }, { id: "msg_2" }],
+        ses_2: [{ id: "msg_3" }],
+      },
+      part: {
+        msg_1: [{ id: "part_1" }],
+        msg_2: [{ id: "part_2" }],
+        msg_3: [{ id: "part_3" }],
+      },
+    }
+
+    applySessionLeavePrune(store, "ses_1")
+
+    expect(store.session).toEqual([{ id: "ses_1" }, { id: "ses_2" }])
+    expect(store.permission.ses_1).toEqual([{ id: "perm_1" }])
+    expect(store.question.ses_1).toEqual([{ id: "question_1" }])
+    expect(store.session_status.ses_1).toBe("busy")
+    expect(store.message.ses_1).toBeUndefined()
+    expect(store.todo.ses_1).toBeUndefined()
+    expect(store.session_diff.ses_1).toBeUndefined()
+    expect(store.session_risk.ses_1).toBeUndefined()
+    expect(store.session_goal.ses_1).toBeUndefined()
+    expect(store.part.msg_1).toBeUndefined()
+    expect(store.part.msg_2).toBeUndefined()
+    expect(store.message.ses_2).toEqual([{ id: "msg_3" }])
+    expect(store.part.msg_3).toEqual([{ id: "part_3" }])
+  })
+
+  test("leave prune is a no-op for sessions with no heavy projection", () => {
+    const store = {
+      session_risk: {},
+      session_goal: {},
+      session_diff: {},
+      todo: {},
+      message: {},
+      part: {},
+    }
+
+    expect(() => applySessionLeavePrune(store, "ses_missing")).not.toThrow()
+    expect(store).toEqual({
+      session_risk: {},
+      session_goal: {},
+      session_diff: {},
+      todo: {},
+      message: {},
+      part: {},
     })
   })
 })

--- a/packages/ax-code/test/cli/tui/sync-session-sync.test.ts
+++ b/packages/ax-code/test/cli/tui/sync-session-sync.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "vitest"
-import { createStore } from "solid-js/store"
+import { createStore, produce } from "solid-js/store"
 import {
   createStoreBackedSessionSyncController,
   type SessionSyncStoreState,
 } from "../../../src/cli/cmd/tui/context/sync-session-sync"
+import { applySessionLeavePrune } from "../../../src/cli/cmd/tui/context/sync-session-store"
 import type { SyncedSessionRisk } from "../../../src/cli/cmd/tui/context/sync-session-risk"
 
 type Session = { id: string; title: string }
@@ -164,5 +165,122 @@ describe("tui sync session sync", () => {
       session_risk: {},
       session_goal: {},
     })
+  })
+
+  test("leave prune + clear then re-enter sync reloads heavy state without force", async () => {
+    // Integrated leave→re-enter path: mirrors session route onCleanup
+    // (clear + applySessionLeavePrune) then runInitialSessionSync without force.
+    const [store, setStore] = createState()
+    let messageFetch = 0
+
+    const controller = createStoreBackedSessionSyncController<
+      Session,
+      Todo,
+      Message,
+      Part,
+      Diff,
+      Risk,
+      Goal,
+      SessionSyncStoreState<Session, Todo, Message, Part, Diff, Risk, Goal>
+    >({
+      timeoutMs: 10_000,
+      withTimeout: async (_label, promise) => promise,
+      setStore,
+      fetchSession: async (sessionID) => ({ data: { id: sessionID, title: "Session" } }),
+      fetchMessages: async () => {
+        messageFetch += 1
+        return {
+          data: [
+            {
+              info: { id: `msg_${messageFetch}` },
+              parts: [{ id: `part_${messageFetch}` }],
+            },
+          ],
+        }
+      },
+      fetchTodo: async () => ({ data: [{ id: `todo_${messageFetch || 1}` }] }),
+      fetchDiff: async () => ({ data: [{ path: `file_${messageFetch || 1}.ts` }] }),
+    })
+
+    await controller.sync("ses_leave")
+    expect(store.message.ses_leave).toEqual([{ id: "msg_1" }])
+    expect(store.part.msg_1).toEqual([{ id: "part_1" }])
+    expect(messageFetch).toBe(1)
+
+    // Without clear, a second sync would no-op (fullSynced). Leave path clears.
+    controller.clear("ses_leave")
+    setStore(
+      produce((draft) => {
+        applySessionLeavePrune(draft, "ses_leave")
+      }),
+    )
+
+    expect(store.session).toEqual([{ id: "ses_leave", title: "Session" }])
+    expect(store.message.ses_leave).toBeUndefined()
+    expect(store.part.msg_1).toBeUndefined()
+    expect(store.todo.ses_leave).toBeUndefined()
+    expect(store.session_diff.ses_leave).toBeUndefined()
+
+    // Re-enter: same as runInitialSessionSync without force.
+    await controller.sync("ses_leave")
+    expect(messageFetch).toBe(2)
+    expect(store.message.ses_leave).toEqual([{ id: "msg_2" }])
+    expect(store.part.msg_2).toEqual([{ id: "part_2" }])
+    expect(store.todo.ses_leave).toEqual([{ id: "todo_2" }])
+    expect(store.session_diff.ses_leave).toEqual([{ path: "file_2.ts" }])
+  })
+
+  test("leave clear during in-flight sync drops late apply so re-enter loads cleanly", async () => {
+    const [store, setStore] = createState()
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let fetches = 0
+
+    const controller = createStoreBackedSessionSyncController<
+      Session,
+      Todo,
+      Message,
+      Part,
+      Diff,
+      Risk,
+      Goal,
+      SessionSyncStoreState<Session, Todo, Message, Part, Diff, Risk, Goal>
+    >({
+      timeoutMs: 10_000,
+      withTimeout: async (_label, promise) => promise,
+      setStore,
+      fetchSession: async (sessionID) => {
+        fetches += 1
+        if (fetches === 1) await gate
+        return { data: { id: sessionID, title: fetches === 1 ? "stale" : "fresh" } }
+      },
+      fetchMessages: async () => ({
+        data: [{ info: { id: `msg_${fetches}` }, parts: [{ id: `part_${fetches}` }] }],
+      }),
+      fetchTodo: async () => ({ data: [] }),
+      fetchDiff: async () => ({ data: [] }),
+    })
+
+    const first = controller.sync("ses_race")
+    // Leave while first fetch is still open.
+    controller.clear("ses_race")
+    setStore(
+      produce((draft) => {
+        applySessionLeavePrune(draft, "ses_race")
+      }),
+    )
+    release?.()
+    await first
+
+    // Stale flight must not have re-filled heavy state after prune.
+    expect(store.message.ses_race).toBeUndefined()
+    expect(store.session.find((s) => s.id === "ses_race")).toBeUndefined()
+
+    await controller.sync("ses_race")
+    expect(fetches).toBe(2)
+    expect(store.session).toEqual([{ id: "ses_race", title: "fresh" }])
+    expect(store.message.ses_race).toEqual([{ id: "msg_2" }])
   })
 })

--- a/packages/ax-code/test/cli/tui/terminal-suspend.test.ts
+++ b/packages/ax-code/test/cli/tui/terminal-suspend.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test, vi } from "vitest"
+import { createTerminalSuspendController } from "../../../src/cli/cmd/tui/util/terminal-suspend"
+
+describe("createTerminalSuspendController", () => {
+  test("registers SIGCONT, suspends, and sends stop", () => {
+    const handlers = new Map<string | symbol, Set<(...args: unknown[]) => void>>()
+    const registerProcessHandler = vi.fn(
+      (event: string | symbol, handler: (...args: unknown[]) => void, _input: { name: string }) => {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return () => {
+          set.delete(handler)
+        }
+      },
+    )
+    const sendStop = vi.fn()
+    const suspend = vi.fn()
+    const resume = vi.fn()
+
+    const controller = createTerminalSuspendController({
+      registerProcessHandler,
+      sendStop,
+    })
+
+    controller.suspend({ suspend, resume })
+
+    expect(suspend).toHaveBeenCalledTimes(1)
+    expect(sendStop).toHaveBeenCalledTimes(1)
+    expect(registerProcessHandler).toHaveBeenCalledWith("SIGCONT", expect.any(Function), {
+      name: "terminal-suspend-sigcont",
+      logger: expect.anything(),
+    })
+    expect(handlers.get("SIGCONT")?.size).toBe(1)
+
+    // Simulate shell continuing the process group.
+    for (const handler of handlers.get("SIGCONT") ?? []) handler()
+    expect(resume).toHaveBeenCalledTimes(1)
+    expect(handlers.get("SIGCONT")?.size).toBe(0)
+  })
+
+  test("dispose removes a pending SIGCONT handler without resuming", () => {
+    const handlers = new Map<string | symbol, Set<(...args: unknown[]) => void>>()
+    const registerProcessHandler = (
+      event: string | symbol,
+      handler: (...args: unknown[]) => void,
+      _input: { name: string },
+    ) => {
+      const set = handlers.get(event) ?? new Set()
+      set.add(handler)
+      handlers.set(event, set)
+      return () => {
+        set.delete(handler)
+      }
+    }
+
+    const controller = createTerminalSuspendController({
+      registerProcessHandler,
+      sendStop: () => {},
+    })
+    const resume = vi.fn()
+    controller.suspend({ suspend: () => {}, resume })
+    expect(handlers.get("SIGCONT")?.size).toBe(1)
+
+    controller.dispose()
+    expect(handlers.get("SIGCONT")?.size).toBe(0)
+    expect(resume).not.toHaveBeenCalled()
+  })
+
+  test("re-suspend replaces the previous SIGCONT handler", () => {
+    const handlers = new Map<string | symbol, Set<(...args: unknown[]) => void>>()
+    const registerProcessHandler = (
+      event: string | symbol,
+      handler: (...args: unknown[]) => void,
+      _input: { name: string },
+    ) => {
+      const set = handlers.get(event) ?? new Set()
+      set.add(handler)
+      handlers.set(event, set)
+      return () => {
+        set.delete(handler)
+      }
+    }
+
+    const controller = createTerminalSuspendController({
+      registerProcessHandler,
+      sendStop: () => {},
+    })
+    const firstResume = vi.fn()
+    const secondResume = vi.fn()
+
+    controller.suspend({ suspend: () => {}, resume: firstResume })
+    controller.suspend({ suspend: () => {}, resume: secondResume })
+    expect(handlers.get("SIGCONT")?.size).toBe(1)
+
+    for (const handler of handlers.get("SIGCONT") ?? []) handler()
+    expect(firstResume).not.toHaveBeenCalled()
+    expect(secondResume).toHaveBeenCalledTimes(1)
+  })
+
+  test("swallows resume errors instead of throwing into the signal path", () => {
+    const handlers = new Map<string | symbol, Set<(...args: unknown[]) => void>>()
+    const registerProcessHandler = (
+      event: string | symbol,
+      handler: (...args: unknown[]) => void,
+      _input: { name: string },
+    ) => {
+      const set = handlers.get(event) ?? new Set()
+      set.add(handler)
+      handlers.set(event, set)
+      return () => {
+        set.delete(handler)
+      }
+    }
+    const logger = { warn: vi.fn() }
+
+    const controller = createTerminalSuspendController({
+      registerProcessHandler,
+      sendStop: () => {},
+      logger,
+    })
+    controller.suspend({
+      suspend: () => {},
+      resume: () => {
+        throw new Error("resume boom")
+      },
+    })
+
+    expect(() => {
+      for (const handler of handlers.get("SIGCONT") ?? []) handler()
+    }).not.toThrow()
+    expect(logger.warn).toHaveBeenCalledWith(
+      "tui terminal resume failed",
+      expect.objectContaining({ error: expect.any(Error) }),
+    )
+  })
+
+  test("resumes and disposes when sendStop fails", () => {
+    const handlers = new Map<string | symbol, Set<(...args: unknown[]) => void>>()
+    const registerProcessHandler = (
+      event: string | symbol,
+      handler: (...args: unknown[]) => void,
+      _input: { name: string },
+    ) => {
+      const set = handlers.get(event) ?? new Set()
+      set.add(handler)
+      handlers.set(event, set)
+      return () => {
+        set.delete(handler)
+      }
+    }
+    const logger = { warn: vi.fn() }
+    const resume = vi.fn()
+
+    const controller = createTerminalSuspendController({
+      registerProcessHandler,
+      sendStop: () => {
+        throw new Error("stop failed")
+      },
+      logger,
+    })
+    controller.suspend({ suspend: () => {}, resume })
+
+    expect(resume).toHaveBeenCalledTimes(1)
+    expect(handlers.get("SIGCONT")?.size ?? 0).toBe(0)
+    expect(logger.warn).toHaveBeenCalledWith(
+      "tui terminal stop signal failed",
+      expect.objectContaining({ error: expect.any(Error) }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Implements the ADR-047 TUI stability hardening program (Phases 1–3 code):

- **Lifecycle-safe terminal suspend** — replace raw `process.once("SIGCONT")` with `createTerminalSuspendController` (dispose on unmount, re-suspend replaces handler, resume/stop errors swallowed).
- **Timer consistency** — `putJsonWithTimeout` uses `scheduleTuiTimeout` instead of raw `setTimeout`.
- **Session-leave prune** — when leaving a session (or switching `sessionID`), drop heavy transcript projection (`message`/`part`/`diff`/`todo`/`risk`/`goal`) while keeping list rows and permission/question/status. Re-entry reloads via existing session sync + generation guards.
- **Regression locks** — unit tests for suspend + leave prune, plus wiring checks so call sites do not regress.

Internal PRD/ADR/tech-spec live under gitignored `.internal/tui-stability/`.

Note: pre-commit hook also refreshed `models-snapshot.json` (repo-standard models.dev update).

## Test plan

- [x] `pnpm --dir packages/ax-code exec vitest run test/cli/tui/terminal-suspend.test.ts test/cli/tui/sync-session-store.test.ts test/cli/tui/stability-phase-wiring.test.ts test/cli/tui/timer.test.ts`
- [ ] CI green
- [ ] Manual: open session A → session B → confirm A transcript reloads after re-open
- [ ] Manual (optional): terminal suspend/resume keybind if available