### PR TITLE
fix(tui): harden backend sync and transient feedback

### DIFF
--- a/packages/ax-code/src/cli/cmd/tui/app.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/app.tsx
@@ -391,7 +391,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
 
     await Clipboard.copy(text)
       .then(() => {
-        toast.show({ message: "Copied to clipboard", variant: "info" })
+        toast.show({ message: "Copied to clipboard", variant: "info", duration: 1500 })
         renderer.clearSelection()
       })
       .catch(toast.error)

--- a/packages/ax-code/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -717,7 +717,7 @@ function AutoMethod(props: AutoMethodProps) {
     if (evt.name === "c" && !evt.ctrl && !evt.meta) {
       const code = props.authorization.instructions.match(/[A-Z0-9]{4}-[A-Z0-9]{4,5}/)?.[0] ?? props.authorization.url
       Clipboard.copy(code)
-        .then(() => toast.show({ message: "Copied to clipboard", variant: "info" }))
+        .then(() => toast.show({ message: "Copied to clipboard", variant: "info", duration: 1500 }))
         .catch(toast.error)
     }
   })

--- a/packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1137,6 +1137,10 @@ export function Prompt(props: PromptProps) {
       !slashHasArguments &&
       command.trySlash(slashName)
     ) {
+      // Local slash commands dispatch through the command dialog instead of
+      // the async message path below, so settle the draft here as well.
+      clearPromptDraft()
+      props.onSubmit?.()
       log.info("tui.prompt.submit: slash command dispatched", { command: slashName })
       return
     }
@@ -1266,8 +1270,7 @@ export function Prompt(props: PromptProps) {
     // commands and shell input keep the existing async routes; new sessions and
     // idle sessions dispatch immediately below.
     const isKnownSlashCommand =
-      workRouted.kind === "command" ||
-      (slashName != null && sync.data.command.some((x) => x.name === slashName))
+      workRouted.kind === "command" || (slashName != null && sync.data.command.some((x) => x.name === slashName))
     if (
       queueModeEnabled() &&
       currentMode === "normal" &&

--- a/packages/ax-code/src/cli/cmd/tui/context/sync-session-urls.ts
+++ b/packages/ax-code/src/cli/cmd/tui/context/sync-session-urls.ts
@@ -1,0 +1,23 @@
+import { directoryRequestHeaders } from "@tui/util/request-headers"
+
+export function sessionRiskURL(input: { baseUrl: string; sessionID: string }) {
+  const url = new URL(`${input.baseUrl}/session/${encodeURIComponent(input.sessionID)}/risk`)
+  url.searchParams.set("quality", "true")
+  url.searchParams.set("findings", "true")
+  url.searchParams.set("envelopes", "true")
+  url.searchParams.set("reviewResults", "true")
+  url.searchParams.set("debug", "true")
+  url.searchParams.set("hints", "true")
+  return url.toString()
+}
+
+export function sessionGoalURL(input: { baseUrl: string; sessionID: string }) {
+  return new URL(`${input.baseUrl}/session/${encodeURIComponent(input.sessionID)}/goal`).toString()
+}
+
+export function sessionDerivedRequestHeaders(directory?: string) {
+  return directoryRequestHeaders({
+    directory,
+    accept: "application/json",
+  })
+}

--- a/packages/ax-code/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/context/sync.tsx
@@ -29,6 +29,7 @@ import { registerSyncLifecycle } from "./sync-lifecycle"
 import { parseSyncedSessionRisk } from "./sync-session-risk"
 import { createRuntimeSyncProbeScheduler } from "./sync-runtime-probe"
 import { DiagnosticLog } from "@/debug/diagnostic-log"
+import { sessionDerivedRequestHeaders, sessionGoalURL, sessionRiskURL } from "./sync-session-urls"
 
 const BOOTSTRAP_REQUEST_TIMEOUT_MS = 10_000
 const SESSION_SYNC_REQUEST_TIMEOUT_MS = 10_000
@@ -36,24 +37,6 @@ const MAX_SESSION_MESSAGES = 100
 
 function withSyncTimeout<T>(label: string, promise: Promise<T>, timeoutMs = BOOTSTRAP_REQUEST_TIMEOUT_MS) {
   return withTimeout(promise, timeoutMs, `${label} timed out after ${timeoutMs}ms`)
-}
-
-function sessionRiskURL(input: { baseUrl: string; sessionID: string; directory?: string }) {
-  const url = new URL(`${input.baseUrl}/session/${encodeURIComponent(input.sessionID)}/risk`)
-  url.searchParams.set("quality", "true")
-  url.searchParams.set("findings", "true")
-  url.searchParams.set("envelopes", "true")
-  url.searchParams.set("reviewResults", "true")
-  url.searchParams.set("debug", "true")
-  url.searchParams.set("hints", "true")
-  if (input.directory) url.searchParams.set("directory", input.directory)
-  return url.toString()
-}
-
-function sessionGoalURL(input: { baseUrl: string; sessionID: string; directory?: string }) {
-  const url = new URL(`${input.baseUrl}/session/${encodeURIComponent(input.sessionID)}/goal`)
-  if (input.directory) url.searchParams.set("directory", input.directory)
-  return url.toString()
 }
 
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
@@ -105,8 +88,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           sessionRiskURL({
             baseUrl: sdk.url,
             sessionID,
-            directory: sdk.directory,
           }),
+          { headers: sessionDerivedRequestHeaders(sdk.directory) },
         )
         if (!response.ok) throw new Error(`session risk request failed: ${response.status}`)
         return { data: parseSyncedSessionRisk(await response.json()) }
@@ -116,8 +99,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           sessionGoalURL({
             baseUrl: sdk.url,
             sessionID,
-            directory: sdk.directory,
           }),
+          { headers: sessionDerivedRequestHeaders(sdk.directory) },
         )
         if (!response.ok) throw new Error(`session goal request failed: ${response.status}`)
         return { data: (await response.json()) as SessionGoal.PublicInfo | null }

--- a/packages/ax-code/src/cli/cmd/tui/routes/session/dialog-capability-catalog.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/routes/session/dialog-capability-catalog.tsx
@@ -2,6 +2,7 @@ import { createMemo, createResource, onMount } from "solid-js"
 import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
 import { useDialog } from "@tui/ui/dialog"
 import { useSDK } from "@tui/context/sdk"
+import { directoryRequestHeaders } from "@tui/util/request-headers"
 import { createAbortableResourceFetcher } from "../../util/abortable-resource"
 import {
   capabilityCatalogOptions,
@@ -26,8 +27,10 @@ async function loadCapabilityCatalog(sdk: ReturnType<typeof useSDK>, signal: Abo
   }
 
   const url = new URL("/capability", sdk.url)
-  if (sdk.directory) url.searchParams.set("directory", sdk.directory)
-  const response = await sdk.fetch(url, { signal })
+  const response = await sdk.fetch(url, {
+    signal,
+    headers: directoryRequestHeaders({ directory: sdk.directory, accept: "application/json" }),
+  })
   if (!response.ok) throw new Error(`Failed to load capability catalog: ${response.status}`)
   return normalizeCapabilityCatalogItems(await response.json())
 }

--- a/packages/ax-code/src/cli/cmd/tui/routes/session/dialog-quality.tsx
+++ b/packages/ax-code/src/cli/cmd/tui/routes/session/dialog-quality.tsx
@@ -130,7 +130,7 @@ export function DialogQualityDetail(props: {
           }
           await Clipboard.copy(current.prompt.input)
             .then(() => {
-              toast.show({ message: "Copied quality next-step prompt", variant: "success" })
+              toast.show({ message: "Copied quality next-step prompt", variant: "success", duration: 1500 })
             })
             .catch((error) => {
               toast.show({
@@ -153,7 +153,7 @@ export function DialogQualityDetail(props: {
           }
           await Clipboard.copy(renderSessionQualityBrief(current))
             .then(() => {
-              toast.show({ message: "Copied quality readiness brief", variant: "success" })
+              toast.show({ message: "Copied quality readiness brief", variant: "success", duration: 1500 })
             })
             .catch((error) => {
               toast.show({

--- a/packages/ax-code/src/cli/cmd/tui/routes/session/display-commands.ts
+++ b/packages/ax-code/src/cli/cmd/tui/routes/session/display-commands.ts
@@ -56,11 +56,7 @@ export function displayCommands(input: {
     url: string
     client: {
       session: {
-        summarize: (input: {
-          sessionID: string
-          modelID: string
-          providerID: string
-        }) => Promise<{ error?: unknown }>
+        summarize: (input: { sessionID: string; modelID: string; providerID: string }) => Promise<{ error?: unknown }>
       }
     }
   }
@@ -508,7 +504,7 @@ export function displayCommands(input: {
         }
 
         Clipboard.copy(result.text)
-          .then(() => input.toast.show({ message: "Message copied to clipboard!", variant: "success" }))
+          .then(() => input.toast.show({ message: "Message copied to clipboard!", variant: "success", duration: 1500 }))
           .catch(() => input.toast.show({ message: "Failed to copy to clipboard", variant: "error" }))
         dialog.clear()
       },
@@ -535,7 +531,7 @@ export function displayCommands(input: {
             agents: input.agents,
           })
           await Clipboard.copy(transcript)
-          input.toast.show({ message: "Session transcript copied to clipboard!", variant: "success" })
+          input.toast.show({ message: "Session transcript copied to clipboard!", variant: "success", duration: 1500 })
         } catch {
           input.toast.show({ message: "Failed to copy session transcript", variant: "error" })
         }

--- a/packages/ax-code/src/cli/cmd/tui/thread.ts
+++ b/packages/ax-code/src/cli/cmd/tui/thread.ts
@@ -221,7 +221,7 @@ function isBackendProtocolMessage(line: string) {
   return type === "rpc.result" || type === "rpc.error" || type === "rpc.event"
 }
 
-function createProcessWire(child: any, target: string): RpcWireTarget {
+export function createProcessWire(child: any, target: string): RpcWireTarget {
   const wire: RpcWireTarget = {
     onmessage: null,
     onWireDeath: null,
@@ -233,9 +233,7 @@ function createProcessWire(child: any, target: string): RpcWireTarget {
         // waiting the full 60s `RPC_TIMEOUT_MS` each. Idempotent —
         // null'd handlers below mean a second death event is a no-op.
         DiagnosticLog.recordProcess("tui.backendStdinUnavailable", { target })
-        wire.onWireDeath?.()
-        wire.onmessage = null
-        wire.onWireDeath = null
+        notifyWireDeath()
         return
       }
       try {
@@ -246,11 +244,18 @@ function createProcessWire(child: any, target: string): RpcWireTarget {
           target,
           error: toErrorMessage(error),
         })
-        wire.onWireDeath?.()
-        wire.onmessage = null
-        wire.onWireDeath = null
+        notifyWireDeath()
       }
     },
+  }
+  // The backend can exit before a write discovers the broken stdin pipe.
+  // Notify the RPC client from the child lifecycle too, so startup and
+  // in-flight requests fail immediately instead of waiting for timeouts.
+  const notifyWireDeath = () => {
+    const onWireDeath = wire.onWireDeath
+    wire.onmessage = null
+    wire.onWireDeath = null
+    onWireDeath?.()
   }
   // Stream-level "error" events (EPIPE, broken pipe on SIGKILL, etc.)
   // crash the parent process if no listener is attached. These pipes
@@ -264,10 +269,12 @@ function createProcessWire(child: any, target: string): RpcWireTarget {
       target,
       error: toErrorMessage(error),
     })
-    wire.onWireDeath?.()
-    wire.onmessage = null
-    wire.onWireDeath = null
+    notifyWireDeath()
   })
+  // `exit` is emitted for a running backend that stops. `error` covers a
+  // spawn failure where no exit event is guaranteed. The helper is idempotent.
+  child.on?.("exit", notifyWireDeath)
+  child.on?.("error", notifyWireDeath)
   child.stdout?.on("error", (error: unknown) => {
     DiagnosticLog.recordProcess("tui.backendStdoutStreamError", { target, error })
     Log.Default.warn("TUI backend stdout stream error", {

--- a/packages/ax-code/src/cli/cmd/tui/thread.ts
+++ b/packages/ax-code/src/cli/cmd/tui/thread.ts
@@ -69,6 +69,7 @@ type RpcWireTarget = {
   // fast-fail every pending call instead of waiting the full
   // RPC_TIMEOUT_MS each.
   onWireDeath?: (() => void) | null
+  wireClosed?: boolean
 }
 
 type BackendRuntime = {
@@ -225,6 +226,7 @@ export function createProcessWire(child: any, target: string): RpcWireTarget {
   const wire: RpcWireTarget = {
     onmessage: null,
     onWireDeath: null,
+    wireClosed: false,
     postMessage(data) {
       const stdin = child.stdin
       if (!stdin || stdin.destroyed) {
@@ -252,6 +254,8 @@ export function createProcessWire(child: any, target: string): RpcWireTarget {
   // Notify the RPC client from the child lifecycle too, so startup and
   // in-flight requests fail immediately instead of waiting for timeouts.
   const notifyWireDeath = () => {
+    if (wire.wireClosed) return
+    wire.wireClosed = true
     const onWireDeath = wire.onWireDeath
     wire.onmessage = null
     wire.onWireDeath = null

--- a/packages/ax-code/src/cli/cmd/tui/util/selection.ts
+++ b/packages/ax-code/src/cli/cmd/tui/util/selection.ts
@@ -1,7 +1,7 @@
 import { Clipboard } from "./clipboard"
 
 type Toast = {
-  show: (input: { message: string; variant: "info" | "success" | "warning" | "error" }) => void
+  show: (input: { message: string; variant: "info" | "success" | "warning" | "error"; duration?: number }) => void
   error: (err: unknown) => void
 }
 
@@ -17,7 +17,7 @@ export namespace Selection {
 
     Clipboard.copy(text)
       .then(() => {
-        toast.show({ message: "Copied to clipboard", variant: "info" })
+        toast.show({ message: "Copied to clipboard", variant: "info", duration: 1500 })
         renderer.clearSelection()
       })
       .catch(toast.error)

--- a/packages/ax-code/src/util/rpc.ts
+++ b/packages/ax-code/src/util/rpc.ts
@@ -26,6 +26,12 @@ export namespace Rpc {
      * up to a minute while in-flight calls drain one by one.
      */
     onWireDeath?: (() => void) | null
+    /**
+     * Indicates the physical transport closed before the RPC client attached
+     * its `onWireDeath` handler. This preserves the startup failure signal so
+     * the first client call fails immediately instead of timing out.
+     */
+    wireClosed?: boolean
   }
 
   export type WireMessage = Record<string, any> & {
@@ -260,7 +266,8 @@ export namespace Rpc {
     // Without this hook, a backend crash leaves callers waiting up to
     // RPC_TIMEOUT_MS each before they reject — which is what made the
     // TUI appear frozen for ~60s after a backend exit.
-    target.onWireDeath = () => {
+    const handleWireDeath = () => {
+      if (wireClosed) return
       wireClosed = true
       const error = wireClosedError()
       for (const [pendingId, entry] of pending) {
@@ -269,6 +276,10 @@ export namespace Rpc {
         pending.delete(pendingId)
       }
     }
+    target.onWireDeath = handleWireDeath
+    // A process transport can exit while the TUI is still constructing its
+    // client. Honor that already-observed failure after installing the handler.
+    if (target.wireClosed) handleWireDeath()
     target.onmessage = async (evt) => {
       // See Rpc.listen — drop malformed messages instead of crashing.
       const parsed = parseWireMessage(evt.data)

--- a/packages/ax-code/src/util/rpc.ts
+++ b/packages/ax-code/src/util/rpc.ts
@@ -254,13 +254,15 @@ export namespace Rpc {
     // a lot of RPC traffic through here; the bound is defensive.
     const ID_WRAP = Number.MAX_SAFE_INTEGER - 1
     let id = 0
+    let wireClosed = false
+    const wireClosedError = () => new Error("RPC wire closed")
     // Fast-fail every pending call when the wire signals it's dead.
     // Without this hook, a backend crash leaves callers waiting up to
     // RPC_TIMEOUT_MS each before they reject — which is what made the
     // TUI appear frozen for ~60s after a backend exit.
     target.onWireDeath = () => {
-      if (pending.size === 0) return
-      const error = new Error("RPC wire closed")
+      wireClosed = true
+      const error = wireClosedError()
       for (const [pendingId, entry] of pending) {
         clearTimeout(entry.timer)
         entry.reject(error)
@@ -294,6 +296,7 @@ export namespace Rpc {
     }
     return {
       call<Method extends keyof T>(method: Method, input: Parameters<T[Method]>[0]): Promise<ReturnType<T[Method]>> {
+        if (wireClosed) return Promise.reject(wireClosedError())
         const requestId = id
         id = id >= ID_WRAP ? 0 : id + 1
         return new Promise((resolve, reject) => {

--- a/packages/ax-code/test/cli/tui/process-wire.test.ts
+++ b/packages/ax-code/test/cli/tui/process-wire.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events"
 import { describe, expect, test, vi } from "vitest"
 import { createProcessWire } from "../../../src/cli/cmd/tui/thread"
+import { Rpc } from "../../../src/util/rpc"
 
 function createChild() {
   const child = new EventEmitter() as EventEmitter & {
@@ -37,5 +38,16 @@ describe("tui process RPC wire", () => {
     child.emit("error", new Error("spawn failed"))
 
     expect(onWireDeath).toHaveBeenCalledOnce()
+  })
+
+  test("rejects calls when the backend exits before the RPC client attaches", async () => {
+    const child = createChild()
+    const wire = createProcessWire(child, "test-backend")
+
+    child.emit("exit", 1, null)
+
+    const client = Rpc.client<{ health(input: undefined): Promise<void> }>(wire)
+    await expect(client.call("health", undefined)).rejects.toThrow("RPC wire closed")
+    expect(child.stdin.write).not.toHaveBeenCalled()
   })
 })

--- a/packages/ax-code/test/cli/tui/process-wire.test.ts
+++ b/packages/ax-code/test/cli/tui/process-wire.test.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from "node:events"
+import { describe, expect, test, vi } from "vitest"
+import { createProcessWire } from "../../../src/cli/cmd/tui/thread"
+
+function createChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: EventEmitter & { destroyed: boolean; write: (data: string) => void }
+    stdout: EventEmitter & { setEncoding: (encoding: string) => void }
+    stderr: EventEmitter & { setEncoding: (encoding: string) => void }
+  }
+  child.stdin = Object.assign(new EventEmitter(), { destroyed: false, write: vi.fn() })
+  child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
+  child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
+  return child
+}
+
+describe("tui process RPC wire", () => {
+  test("rejects pending RPC calls as soon as the backend child exits", () => {
+    const child = createChild()
+    const wire = createProcessWire(child, "test-backend")
+    const onWireDeath = vi.fn()
+    wire.onWireDeath = onWireDeath
+
+    child.emit("exit", 1, null)
+
+    expect(onWireDeath).toHaveBeenCalledOnce()
+    expect(wire.onmessage).toBeNull()
+    expect(wire.onWireDeath).toBeNull()
+  })
+
+  test("treats a spawn error as a dead RPC wire", () => {
+    const child = createChild()
+    const wire = createProcessWire(child, "test-backend")
+    const onWireDeath = vi.fn()
+    wire.onWireDeath = onWireDeath
+
+    child.emit("error", new Error("spawn failed"))
+
+    expect(onWireDeath).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/ax-code/test/cli/tui/render-anti-patterns.test.ts
+++ b/packages/ax-code/test/cli/tui/render-anti-patterns.test.ts
@@ -936,6 +936,8 @@ describe("tui OpenTUI stability guardrails", () => {
     expect(slashDispatch).toBeGreaterThan(-1)
     expect(autocompleteReturn).toBeGreaterThan(-1)
     expect(slashDispatch).toBeLessThan(autocompleteReturn)
+    const slashDispatchBlock = submitBody.slice(slashDispatch, autocompleteReturn)
+    expect(slashDispatchBlock).toContain("clearPromptDraft()")
     expect(submitBody).toContain("const slashHasArguments = slashToken ? routedText.trim() !== slashToken : false")
     expect(submitBody).toContain('workRouted.kind === "prompt"')
 

--- a/packages/ax-code/test/cli/tui/render-anti-patterns.test.ts
+++ b/packages/ax-code/test/cli/tui/render-anti-patterns.test.ts
@@ -1181,7 +1181,7 @@ describe("tui OpenTUI stability guardrails", () => {
 
     expect(app).toContain("renderer.console.onCopySelection = async (text: string) => {")
     expect(app).toContain(".then(() => {")
-    expect(app).toContain('toast.show({ message: "Copied to clipboard", variant: "info" })')
+    expect(app).toContain('toast.show({ message: "Copied to clipboard", variant: "info", duration: 1500 })')
     expect(app).toContain("renderer.clearSelection()")
   })
 

--- a/packages/ax-code/test/cli/tui/selection.test.ts
+++ b/packages/ax-code/test/cli/tui/selection.test.ts
@@ -3,6 +3,11 @@ import { Clipboard } from "@tui/util/clipboard"
 import { Selection } from "@tui/util/selection"
 
 const originalCopy = Clipboard.copy
+type ToastInput = {
+  message: string
+  variant: "info" | "success" | "warning" | "error"
+  duration?: number
+}
 
 afterEach(() => {
   Clipboard.copy = originalCopy
@@ -23,10 +28,10 @@ describe("Selection.copy", () => {
         cleared++
       },
     }
-    const shown: Array<{ message: string; duration?: number }> = []
+    const shown: ToastInput[] = []
     const errors: unknown[] = []
     const toast = {
-      show: (input: { message: string; variant: "info" | "success" | "warning" | "error"; duration?: number }) => {
+      show: (input: ToastInput) => {
         shown.push(input)
       },
       error: (error: unknown) => {
@@ -56,10 +61,10 @@ describe("Selection.copy", () => {
         cleared++
       },
     }
-    const shown: Array<{ message: string; duration?: number }> = []
+    const shown: ToastInput[] = []
     const errors: unknown[] = []
     const toast = {
-      show: (input: { message: string; variant: "info" | "success" | "warning" | "error"; duration?: number }) => {
+      show: (input: ToastInput) => {
         shown.push(input)
       },
       error: (error: unknown) => {

--- a/packages/ax-code/test/cli/tui/selection.test.ts
+++ b/packages/ax-code/test/cli/tui/selection.test.ts
@@ -23,11 +23,11 @@ describe("Selection.copy", () => {
         cleared++
       },
     }
-    const shown: string[] = []
+    const shown: Array<{ message: string; duration?: number }> = []
     const errors: unknown[] = []
     const toast = {
-      show: (input: { message: string; variant: "info" | "success" | "warning" | "error" }) => {
-        shown.push(input.message)
+      show: (input: { message: string; variant: "info" | "success" | "warning" | "error"; duration?: number }) => {
+        shown.push(input)
       },
       error: (error: unknown) => {
         errors.push(error)
@@ -41,7 +41,7 @@ describe("Selection.copy", () => {
     await Promise.resolve()
 
     expect(cleared).toBe(1)
-    expect(shown).toEqual(["Copied to clipboard"])
+    expect(shown).toEqual([{ message: "Copied to clipboard", variant: "info", duration: 1500 }])
     expect(errors).toEqual([])
   })
 
@@ -56,11 +56,11 @@ describe("Selection.copy", () => {
         cleared++
       },
     }
-    const shown: string[] = []
+    const shown: Array<{ message: string; duration?: number }> = []
     const errors: unknown[] = []
     const toast = {
-      show: (input: { message: string; variant: "info" | "success" | "warning" | "error" }) => {
-        shown.push(input.message)
+      show: (input: { message: string; variant: "info" | "success" | "warning" | "error"; duration?: number }) => {
+        shown.push(input)
       },
       error: (error: unknown) => {
         errors.push(error)

--- a/packages/ax-code/test/cli/tui/sync-risk-url.test.ts
+++ b/packages/ax-code/test/cli/tui/sync-risk-url.test.ts
@@ -1,18 +1,12 @@
 import { describe, expect, test } from "vitest"
-import fs from "fs/promises"
-import path from "path"
-
-const SYNC_SRC = path.resolve(import.meta.dirname, "../../../src/cli/cmd/tui/context/sync.tsx")
+import { sessionRiskURL } from "../../../src/cli/cmd/tui/context/sync-session-urls"
 
 describe("tui session risk sync url", () => {
-  test("opts into all sidebar risk summaries", async () => {
-    const source = await fs.readFile(SYNC_SRC, "utf8")
+  test("opts into all sidebar risk summaries", () => {
+    const url = new URL(sessionRiskURL({ baseUrl: "http://localhost:4096", sessionID: "ses_123" }))
 
-    expect(source).toContain('url.searchParams.set("quality", "true")')
-    expect(source).toContain('url.searchParams.set("findings", "true")')
-    expect(source).toContain('url.searchParams.set("envelopes", "true")')
-    expect(source).toContain('url.searchParams.set("reviewResults", "true")')
-    expect(source).toContain('url.searchParams.set("debug", "true")')
-    expect(source).toContain('url.searchParams.set("hints", "true")')
+    for (const name of ["quality", "findings", "envelopes", "reviewResults", "debug", "hints"]) {
+      expect(url.searchParams.get(name)).toBe("true")
+    }
   })
 })

--- a/packages/ax-code/test/cli/tui/sync-session-urls.test.ts
+++ b/packages/ax-code/test/cli/tui/sync-session-urls.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest"
+import {
+  sessionDerivedRequestHeaders,
+  sessionGoalURL,
+  sessionRiskURL,
+} from "../../../src/cli/cmd/tui/context/sync-session-urls"
+
+describe("tui derived session requests", () => {
+  test("uses workspace headers for risk and goal data instead of unsupported query parameters", () => {
+    const directory = "/workspace/other-project"
+    const headers = sessionDerivedRequestHeaders(directory)
+    const risk = new URL(sessionRiskURL({ baseUrl: "http://localhost:4096", sessionID: "ses_123" }))
+    const goal = new URL(sessionGoalURL({ baseUrl: "http://localhost:4096", sessionID: "ses_123" }))
+
+    expect(headers).toMatchObject({
+      accept: "application/json",
+      "x-ax-code-directory": directory,
+      "x-opencode-directory": directory,
+    })
+    expect(risk.searchParams.get("directory")).toBeNull()
+    expect(goal.searchParams.get("directory")).toBeNull()
+    expect(risk.searchParams.get("quality")).toBe("true")
+  })
+})

--- a/packages/ax-code/test/util/rpc.test.ts
+++ b/packages/ax-code/test/util/rpc.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, test } from "vitest"
+import { afterEach, describe, expect, test, vi } from "vitest"
 import { EventEmitter } from "node:events"
 import { Rpc } from "../../src/util/rpc"
 
 type Endpoint = {
   onmessage: ((event: { data: string }) => void | Promise<void>) | null
+  onWireDeath?: (() => void) | null
   postMessage(data: string): void
 }
 
@@ -92,6 +93,20 @@ describe("Rpc", () => {
     } finally {
       pair.restore()
     }
+  })
+
+  test("rejects new calls immediately after the transport has closed", async () => {
+    const postMessage = vi.fn()
+    const target: Endpoint = {
+      onmessage: null,
+      postMessage,
+    }
+    const client = Rpc.client<{ health(input: undefined): Promise<void> }>(target)
+
+    target.onWireDeath?.()
+
+    await expect(client.call("health", undefined)).rejects.toThrow("RPC wire closed")
+    expect(postMessage).not.toHaveBeenCalled()
   })
 
   test("serializes unprintable worker handler failures", async () => {

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -789,6 +789,13 @@ export type EventMcpBrowserOpenFailed = {
   }
 }
 
+export type EventVcsBranchUpdated = {
+  type: "vcs.branch.updated"
+  properties: {
+    branch?: string
+  }
+}
+
 export type EventCommandExecuted = {
   type: "command.executed"
   properties: {
@@ -805,6 +812,97 @@ export type EventCommandExecuted = {
       message: string
       severity: "info" | "warn" | "error"
     }>
+  }
+}
+
+export type EventTaskQueueCreated = {
+  type: "task.queue.created"
+  properties: {
+    item: {
+      id: string
+      projectID: string
+      directory: string
+      worktree?: string
+      sessionID?: string
+      kind: "prompt" | "command" | "shell" | "followup" | "subagent" | "review" | "automation"
+      status:
+        | "queued"
+        | "waiting_for_idle"
+        | "running"
+        | "blocked_permission"
+        | "blocked_question"
+        | "paused"
+        | "failed"
+        | "completed"
+        | "cancelled"
+      priority: number
+      position: number
+      title: string
+      agent?: string
+      model?: unknown
+      sourceMessageID?: string
+      sourceTaskID?: string
+      payload: {
+        [key: string]: unknown
+      }
+      error?: string
+      time: {
+        created: number
+        updated?: number
+        started?: number
+        completed?: number
+      }
+    }
+  }
+}
+
+export type EventTaskQueueUpdated = {
+  type: "task.queue.updated"
+  properties: {
+    item: {
+      id: string
+      projectID: string
+      directory: string
+      worktree?: string
+      sessionID?: string
+      kind: "prompt" | "command" | "shell" | "followup" | "subagent" | "review" | "automation"
+      status:
+        | "queued"
+        | "waiting_for_idle"
+        | "running"
+        | "blocked_permission"
+        | "blocked_question"
+        | "paused"
+        | "failed"
+        | "completed"
+        | "cancelled"
+      priority: number
+      position: number
+      title: string
+      agent?: string
+      model?: unknown
+      sourceMessageID?: string
+      sourceTaskID?: string
+      payload: {
+        [key: string]: unknown
+      }
+      error?: string
+      time: {
+        created: number
+        updated?: number
+        started?: number
+        completed?: number
+      }
+    }
+  }
+}
+
+export type EventTaskQueueDeleted = {
+  type: "task.queue.deleted"
+  properties: {
+    id: string
+    projectID: string
+    sessionID?: string
   }
 }
 
@@ -1273,6 +1371,135 @@ export type EventWorkflowVerificationAttached = {
   }
 }
 
+export type EventScheduledTaskCreated = {
+  type: "scheduled.task.created"
+  properties: {
+    task: {
+      id: string
+      projectID: string
+      directory: string
+      title: string
+      prompt: string
+      schedule:
+        | {
+            type: "once"
+            runAt: number
+          }
+        | {
+            type: "daily"
+            time: string
+            timezone?: string
+          }
+        | {
+            type: "weekly"
+            day: number
+            time: string
+            timezone?: string
+          }
+        | {
+            type: "cron"
+            expression: string
+            timezone?: string
+          }
+      status: "active" | "paused" | "disabled"
+      agent?: string
+      model?: unknown
+      workflowTemplateID?: string
+      workflowStartOptions?: {
+        allowScaleBeyondDefaults?: boolean
+        allowWriteWorkflows?: boolean
+        durableChildren?: boolean
+        enqueueChildren?: boolean
+      }
+      lastQueueID?: string
+      lastWorkflowRunID?: string
+      error?: string
+      nextRunAt?: number
+      lastRunAt?: number
+      time: {
+        created: number
+        updated?: number
+      }
+    }
+  }
+}
+
+export type EventScheduledTaskUpdated = {
+  type: "scheduled.task.updated"
+  properties: {
+    task: {
+      id: string
+      projectID: string
+      directory: string
+      title: string
+      prompt: string
+      schedule:
+        | {
+            type: "once"
+            runAt: number
+          }
+        | {
+            type: "daily"
+            time: string
+            timezone?: string
+          }
+        | {
+            type: "weekly"
+            day: number
+            time: string
+            timezone?: string
+          }
+        | {
+            type: "cron"
+            expression: string
+            timezone?: string
+          }
+      status: "active" | "paused" | "disabled"
+      agent?: string
+      model?: unknown
+      workflowTemplateID?: string
+      workflowStartOptions?: {
+        allowScaleBeyondDefaults?: boolean
+        allowWriteWorkflows?: boolean
+        durableChildren?: boolean
+        enqueueChildren?: boolean
+      }
+      lastQueueID?: string
+      lastWorkflowRunID?: string
+      error?: string
+      nextRunAt?: number
+      lastRunAt?: number
+      time: {
+        created: number
+        updated?: number
+      }
+    }
+  }
+}
+
+export type EventScheduledTaskDeleted = {
+  type: "scheduled.task.deleted"
+  properties: {
+    id: string
+    projectID: string
+  }
+}
+
+export type EventWorktreeReady = {
+  type: "worktree.ready"
+  properties: {
+    name: string
+    branch: string
+  }
+}
+
+export type EventWorktreeFailed = {
+  type: "worktree.failed"
+  properties: {
+    message: string
+  }
+}
+
 export type EventCodeIndexProgress = {
   type: "code.index.progress"
   properties: {
@@ -1440,218 +1667,6 @@ export type EventTuiSessionSelect = {
   }
 }
 
-export type EventVcsBranchUpdated = {
-  type: "vcs.branch.updated"
-  properties: {
-    branch?: string
-  }
-}
-
-export type EventTaskQueueCreated = {
-  type: "task.queue.created"
-  properties: {
-    item: {
-      id: string
-      projectID: string
-      directory: string
-      worktree?: string
-      sessionID?: string
-      kind: "prompt" | "command" | "shell" | "followup" | "subagent" | "review" | "automation"
-      status:
-        | "queued"
-        | "waiting_for_idle"
-        | "running"
-        | "blocked_permission"
-        | "blocked_question"
-        | "paused"
-        | "failed"
-        | "completed"
-        | "cancelled"
-      priority: number
-      position: number
-      title: string
-      agent?: string
-      model?: unknown
-      sourceMessageID?: string
-      sourceTaskID?: string
-      payload: {
-        [key: string]: unknown
-      }
-      error?: string
-      time: {
-        created: number
-        updated?: number
-        started?: number
-        completed?: number
-      }
-    }
-  }
-}
-
-export type EventTaskQueueUpdated = {
-  type: "task.queue.updated"
-  properties: {
-    item: {
-      id: string
-      projectID: string
-      directory: string
-      worktree?: string
-      sessionID?: string
-      kind: "prompt" | "command" | "shell" | "followup" | "subagent" | "review" | "automation"
-      status:
-        | "queued"
-        | "waiting_for_idle"
-        | "running"
-        | "blocked_permission"
-        | "blocked_question"
-        | "paused"
-        | "failed"
-        | "completed"
-        | "cancelled"
-      priority: number
-      position: number
-      title: string
-      agent?: string
-      model?: unknown
-      sourceMessageID?: string
-      sourceTaskID?: string
-      payload: {
-        [key: string]: unknown
-      }
-      error?: string
-      time: {
-        created: number
-        updated?: number
-        started?: number
-        completed?: number
-      }
-    }
-  }
-}
-
-export type EventTaskQueueDeleted = {
-  type: "task.queue.deleted"
-  properties: {
-    id: string
-    projectID: string
-    sessionID?: string
-  }
-}
-
-export type EventScheduledTaskCreated = {
-  type: "scheduled.task.created"
-  properties: {
-    task: {
-      id: string
-      projectID: string
-      directory: string
-      title: string
-      prompt: string
-      schedule:
-        | {
-            type: "once"
-            runAt: number
-          }
-        | {
-            type: "daily"
-            time: string
-            timezone?: string
-          }
-        | {
-            type: "weekly"
-            day: number
-            time: string
-            timezone?: string
-          }
-        | {
-            type: "cron"
-            expression: string
-            timezone?: string
-          }
-      status: "active" | "paused" | "disabled"
-      agent?: string
-      model?: unknown
-      workflowTemplateID?: string
-      workflowStartOptions?: {
-        allowScaleBeyondDefaults?: boolean
-        allowWriteWorkflows?: boolean
-        durableChildren?: boolean
-        enqueueChildren?: boolean
-      }
-      lastQueueID?: string
-      lastWorkflowRunID?: string
-      error?: string
-      nextRunAt?: number
-      lastRunAt?: number
-      time: {
-        created: number
-        updated?: number
-      }
-    }
-  }
-}
-
-export type EventScheduledTaskUpdated = {
-  type: "scheduled.task.updated"
-  properties: {
-    task: {
-      id: string
-      projectID: string
-      directory: string
-      title: string
-      prompt: string
-      schedule:
-        | {
-            type: "once"
-            runAt: number
-          }
-        | {
-            type: "daily"
-            time: string
-            timezone?: string
-          }
-        | {
-            type: "weekly"
-            day: number
-            time: string
-            timezone?: string
-          }
-        | {
-            type: "cron"
-            expression: string
-            timezone?: string
-          }
-      status: "active" | "paused" | "disabled"
-      agent?: string
-      model?: unknown
-      workflowTemplateID?: string
-      workflowStartOptions?: {
-        allowScaleBeyondDefaults?: boolean
-        allowWriteWorkflows?: boolean
-        durableChildren?: boolean
-        enqueueChildren?: boolean
-      }
-      lastQueueID?: string
-      lastWorkflowRunID?: string
-      error?: string
-      nextRunAt?: number
-      lastRunAt?: number
-      time: {
-        created: number
-        updated?: number
-      }
-    }
-  }
-}
-
-export type EventScheduledTaskDeleted = {
-  type: "scheduled.task.deleted"
-  properties: {
-    id: string
-    projectID: string
-  }
-}
-
 export type Pty = {
   id: string
   title: string
@@ -1691,21 +1706,6 @@ export type EventPtyDeleted = {
   }
 }
 
-export type EventWorktreeReady = {
-  type: "worktree.ready"
-  properties: {
-    name: string
-    branch: string
-  }
-}
-
-export type EventWorktreeFailed = {
-  type: "worktree.failed"
-  properties: {
-    message: string
-  }
-}
-
 export type Event =
   | EventInstallationUpdated
   | EventInstallationUpdateAvailable
@@ -1736,7 +1736,11 @@ export type Event =
   | EventDebugEngineCorrelatedDiagnostics
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
+  | EventVcsBranchUpdated
   | EventCommandExecuted
+  | EventTaskQueueCreated
+  | EventTaskQueueUpdated
+  | EventTaskQueueDeleted
   | EventWorkflowRunCreated
   | EventWorkflowRunUpdated
   | EventWorkflowRunStarted
@@ -1761,6 +1765,11 @@ export type Event =
   | EventWorkflowBudgetWarning
   | EventWorkflowBudgetExceeded
   | EventWorkflowVerificationAttached
+  | EventScheduledTaskCreated
+  | EventScheduledTaskUpdated
+  | EventScheduledTaskDeleted
+  | EventWorktreeReady
+  | EventWorktreeFailed
   | EventCodeIndexProgress
   | EventCodeIndexState
   | EventSessionCreated
@@ -1773,19 +1782,10 @@ export type Event =
   | EventTuiCommandExecute
   | EventTuiToastShow
   | EventTuiSessionSelect
-  | EventVcsBranchUpdated
-  | EventTaskQueueCreated
-  | EventTaskQueueUpdated
-  | EventTaskQueueDeleted
-  | EventScheduledTaskCreated
-  | EventScheduledTaskUpdated
-  | EventScheduledTaskDeleted
   | EventPtyCreated
   | EventPtyUpdated
   | EventPtyExited
   | EventPtyDeleted
-  | EventWorktreeReady
-  | EventWorktreeFailed
 
 export type GlobalEvent = {
   directory: string
@@ -2440,6 +2440,83 @@ export type Config = {
      * Run the autonomous-mode diff critic at every phase boundary. Default: false.
      */
     critic_enabled?: boolean
+  }
+  /**
+   * Execution modes: local, cloud, hybrid placement, multi-provider council, and arena ensemble (ADR-049).
+   */
+  modes?: {
+    /**
+     * Default execution mode. When unset: hybrid if local AX Engine is available, else cloud. Arena/council are typically invoked via tools rather than as the global default.
+     */
+    default?: "local" | "cloud" | "hybrid" | "arena" | "council"
+    /**
+     * Hybrid local/cloud placement policy
+     */
+    hybrid?: {
+      /**
+       * Prefer local placement when AX Engine (or configured local) is available. Default: true.
+       */
+      preferLocalWhenAvailable?: boolean
+      /**
+       * Route high-complexity work to cloud when hybrid is active. Default: true.
+       */
+      escalateOnHighComplexity?: boolean
+      /**
+       * Provider id treated as local for hybrid placement. Default: ax-engine.
+       */
+      localProviderID?: string
+    }
+    /**
+     * Multi-provider council (advisory review / design) settings
+     */
+    council?: {
+      /**
+       * Allow the council multi-provider advisory tool. Default: true.
+       */
+      enabled?: boolean
+      /**
+       * Maximum council members per invocation (default: 3, hard max: 6).
+       */
+      maxMembers?: number
+      /**
+       * Per-member timeout in ms for council fan-out (default: 60000).
+       */
+      timeoutMs?: number
+      /**
+       * Optional multi-round anonymous debate rounds (default: 0; Phase 3+).
+       */
+      debateRounds?: number
+    }
+    /**
+     * Arena best-of-N implementation comparison settings
+     */
+    arena?: {
+      /**
+       * Enable arena multi-contestant mode tools. Default: false until Phase 2.
+       */
+      enabled?: boolean
+      /**
+       * Maximum arena contestants (default: 3, hard max: 5).
+       */
+      maxContestants?: number
+      /**
+       * Ranking strategy for arena candidates. verify_first is the recommended default (never pure popularity).
+       */
+      strategy?: "verify_first" | "diversity" | "hybrid_score"
+    }
+    /**
+     * Ensemble cost budget controls
+     */
+    budget?: {
+      /**
+       * Maximum estimated USD for an ensemble fan-out (fail-closed when exceeded).
+       */
+      maxEstimatedUsd?: number
+      /**
+       * Rough USD cost per council/arena member call used with maxEstimatedUsd to cap fan-out size.
+       */
+      estimatedUsdPerMember?: number
+    }
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -789,6 +789,13 @@ export type EventMcpBrowserOpenFailed = {
   }
 }
 
+export type EventVcsBranchUpdated = {
+  type: "vcs.branch.updated"
+  properties: {
+    branch?: string
+  }
+}
+
 export type EventCommandExecuted = {
   type: "command.executed"
   properties: {
@@ -805,6 +812,97 @@ export type EventCommandExecuted = {
       message: string
       severity: "info" | "warn" | "error"
     }>
+  }
+}
+
+export type EventTaskQueueCreated = {
+  type: "task.queue.created"
+  properties: {
+    item: {
+      id: string
+      projectID: string
+      directory: string
+      worktree?: string
+      sessionID?: string
+      kind: "prompt" | "command" | "shell" | "followup" | "subagent" | "review" | "automation"
+      status:
+        | "queued"
+        | "waiting_for_idle"
+        | "running"
+        | "blocked_permission"
+        | "blocked_question"
+        | "paused"
+        | "failed"
+        | "completed"
+        | "cancelled"
+      priority: number
+      position: number
+      title: string
+      agent?: string
+      model?: unknown
+      sourceMessageID?: string
+      sourceTaskID?: string
+      payload: {
+        [key: string]: unknown
+      }
+      error?: string
+      time: {
+        created: number
+        updated?: number
+        started?: number
+        completed?: number
+      }
+    }
+  }
+}
+
+export type EventTaskQueueUpdated = {
+  type: "task.queue.updated"
+  properties: {
+    item: {
+      id: string
+      projectID: string
+      directory: string
+      worktree?: string
+      sessionID?: string
+      kind: "prompt" | "command" | "shell" | "followup" | "subagent" | "review" | "automation"
+      status:
+        | "queued"
+        | "waiting_for_idle"
+        | "running"
+        | "blocked_permission"
+        | "blocked_question"
+        | "paused"
+        | "failed"
+        | "completed"
+        | "cancelled"
+      priority: number
+      position: number
+      title: string
+      agent?: string
+      model?: unknown
+      sourceMessageID?: string
+      sourceTaskID?: string
+      payload: {
+        [key: string]: unknown
+      }
+      error?: string
+      time: {
+        created: number
+        updated?: number
+        started?: number
+        completed?: number
+      }
+    }
+  }
+}
+
+export type EventTaskQueueDeleted = {
+  type: "task.queue.deleted"
+  properties: {
+    id: string
+    projectID: string
+    sessionID?: string
   }
 }
 
@@ -1273,6 +1371,135 @@ export type EventWorkflowVerificationAttached = {
   }
 }
 
+export type EventScheduledTaskCreated = {
+  type: "scheduled.task.created"
+  properties: {
+    task: {
+      id: string
+      projectID: string
+      directory: string
+      title: string
+      prompt: string
+      schedule:
+        | {
+            type: "once"
+            runAt: number
+          }
+        | {
+            type: "daily"
+            time: string
+            timezone?: string
+          }
+        | {
+            type: "weekly"
+            day: number
+            time: string
+            timezone?: string
+          }
+        | {
+            type: "cron"
+            expression: string
+            timezone?: string
+          }
+      status: "active" | "paused" | "disabled"
+      agent?: string
+      model?: unknown
+      workflowTemplateID?: string
+      workflowStartOptions?: {
+        allowScaleBeyondDefaults?: boolean
+        allowWriteWorkflows?: boolean
+        durableChildren?: boolean
+        enqueueChildren?: boolean
+      }
+      lastQueueID?: string
+      lastWorkflowRunID?: string
+      error?: string
+      nextRunAt?: number
+      lastRunAt?: number
+      time: {
+        created: number
+        updated?: number
+      }
+    }
+  }
+}
+
+export type EventScheduledTaskUpdated = {
+  type: "scheduled.task.updated"
+  properties: {
+    task: {
+      id: string
+      projectID: string
+      directory: string
+      title: string
+      prompt: string
+      schedule:
+        | {
+            type: "once"
+            runAt: number
+          }
+        | {
+            type: "daily"
+            time: string
+            timezone?: string
+          }
+        | {
+            type: "weekly"
+            day: number
+            time: string
+            timezone?: string
+          }
+        | {
+            type: "cron"
+            expression: string
+            timezone?: string
+          }
+      status: "active" | "paused" | "disabled"
+      agent?: string
+      model?: unknown
+      workflowTemplateID?: string
+      workflowStartOptions?: {
+        allowScaleBeyondDefaults?: boolean
+        allowWriteWorkflows?: boolean
+        durableChildren?: boolean
+        enqueueChildren?: boolean
+      }
+      lastQueueID?: string
+      lastWorkflowRunID?: string
+      error?: string
+      nextRunAt?: number
+      lastRunAt?: number
+      time: {
+        created: number
+        updated?: number
+      }
+    }
+  }
+}
+
+export type EventScheduledTaskDeleted = {
+  type: "scheduled.task.deleted"
+  properties: {
+    id: string
+    projectID: string
+  }
+}
+
+export type EventWorktreeReady = {
+  type: "worktree.ready"
+  properties: {
+    name: string
+    branch: string
+  }
+}
+
+export type EventWorktreeFailed = {
+  type: "worktree.failed"
+  properties: {
+    message: string
+  }
+}
+
 export type EventCodeIndexProgress = {
   type: "code.index.progress"
   properties: {
@@ -1440,218 +1667,6 @@ export type EventTuiSessionSelect = {
   }
 }
 
-export type EventVcsBranchUpdated = {
-  type: "vcs.branch.updated"
-  properties: {
-    branch?: string
-  }
-}
-
-export type EventTaskQueueCreated = {
-  type: "task.queue.created"
-  properties: {
-    item: {
-      id: string
-      projectID: string
-      directory: string
-      worktree?: string
-      sessionID?: string
-      kind: "prompt" | "command" | "shell" | "followup" | "subagent" | "review" | "automation"
-      status:
-        | "queued"
-        | "waiting_for_idle"
-        | "running"
-        | "blocked_permission"
-        | "blocked_question"
-        | "paused"
-        | "failed"
-        | "completed"
-        | "cancelled"
-      priority: number
-      position: number
-      title: string
-      agent?: string
-      model?: unknown
-      sourceMessageID?: string
-      sourceTaskID?: string
-      payload: {
-        [key: string]: unknown
-      }
-      error?: string
-      time: {
-        created: number
-        updated?: number
-        started?: number
-        completed?: number
-      }
-    }
-  }
-}
-
-export type EventTaskQueueUpdated = {
-  type: "task.queue.updated"
-  properties: {
-    item: {
-      id: string
-      projectID: string
-      directory: string
-      worktree?: string
-      sessionID?: string
-      kind: "prompt" | "command" | "shell" | "followup" | "subagent" | "review" | "automation"
-      status:
-        | "queued"
-        | "waiting_for_idle"
-        | "running"
-        | "blocked_permission"
-        | "blocked_question"
-        | "paused"
-        | "failed"
-        | "completed"
-        | "cancelled"
-      priority: number
-      position: number
-      title: string
-      agent?: string
-      model?: unknown
-      sourceMessageID?: string
-      sourceTaskID?: string
-      payload: {
-        [key: string]: unknown
-      }
-      error?: string
-      time: {
-        created: number
-        updated?: number
-        started?: number
-        completed?: number
-      }
-    }
-  }
-}
-
-export type EventTaskQueueDeleted = {
-  type: "task.queue.deleted"
-  properties: {
-    id: string
-    projectID: string
-    sessionID?: string
-  }
-}
-
-export type EventScheduledTaskCreated = {
-  type: "scheduled.task.created"
-  properties: {
-    task: {
-      id: string
-      projectID: string
-      directory: string
-      title: string
-      prompt: string
-      schedule:
-        | {
-            type: "once"
-            runAt: number
-          }
-        | {
-            type: "daily"
-            time: string
-            timezone?: string
-          }
-        | {
-            type: "weekly"
-            day: number
-            time: string
-            timezone?: string
-          }
-        | {
-            type: "cron"
-            expression: string
-            timezone?: string
-          }
-      status: "active" | "paused" | "disabled"
-      agent?: string
-      model?: unknown
-      workflowTemplateID?: string
-      workflowStartOptions?: {
-        allowScaleBeyondDefaults?: boolean
-        allowWriteWorkflows?: boolean
-        durableChildren?: boolean
-        enqueueChildren?: boolean
-      }
-      lastQueueID?: string
-      lastWorkflowRunID?: string
-      error?: string
-      nextRunAt?: number
-      lastRunAt?: number
-      time: {
-        created: number
-        updated?: number
-      }
-    }
-  }
-}
-
-export type EventScheduledTaskUpdated = {
-  type: "scheduled.task.updated"
-  properties: {
-    task: {
-      id: string
-      projectID: string
-      directory: string
-      title: string
-      prompt: string
-      schedule:
-        | {
-            type: "once"
-            runAt: number
-          }
-        | {
-            type: "daily"
-            time: string
-            timezone?: string
-          }
-        | {
-            type: "weekly"
-            day: number
-            time: string
-            timezone?: string
-          }
-        | {
-            type: "cron"
-            expression: string
-            timezone?: string
-          }
-      status: "active" | "paused" | "disabled"
-      agent?: string
-      model?: unknown
-      workflowTemplateID?: string
-      workflowStartOptions?: {
-        allowScaleBeyondDefaults?: boolean
-        allowWriteWorkflows?: boolean
-        durableChildren?: boolean
-        enqueueChildren?: boolean
-      }
-      lastQueueID?: string
-      lastWorkflowRunID?: string
-      error?: string
-      nextRunAt?: number
-      lastRunAt?: number
-      time: {
-        created: number
-        updated?: number
-      }
-    }
-  }
-}
-
-export type EventScheduledTaskDeleted = {
-  type: "scheduled.task.deleted"
-  properties: {
-    id: string
-    projectID: string
-  }
-}
-
 export type Pty = {
   id: string
   title: string
@@ -1691,21 +1706,6 @@ export type EventPtyDeleted = {
   }
 }
 
-export type EventWorktreeReady = {
-  type: "worktree.ready"
-  properties: {
-    name: string
-    branch: string
-  }
-}
-
-export type EventWorktreeFailed = {
-  type: "worktree.failed"
-  properties: {
-    message: string
-  }
-}
-
 export type Event =
   | EventInstallationUpdated
   | EventInstallationUpdateAvailable
@@ -1736,7 +1736,11 @@ export type Event =
   | EventDebugEngineCorrelatedDiagnostics
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
+  | EventVcsBranchUpdated
   | EventCommandExecuted
+  | EventTaskQueueCreated
+  | EventTaskQueueUpdated
+  | EventTaskQueueDeleted
   | EventWorkflowRunCreated
   | EventWorkflowRunUpdated
   | EventWorkflowRunStarted
@@ -1761,6 +1765,11 @@ export type Event =
   | EventWorkflowBudgetWarning
   | EventWorkflowBudgetExceeded
   | EventWorkflowVerificationAttached
+  | EventScheduledTaskCreated
+  | EventScheduledTaskUpdated
+  | EventScheduledTaskDeleted
+  | EventWorktreeReady
+  | EventWorktreeFailed
   | EventCodeIndexProgress
   | EventCodeIndexState
   | EventSessionCreated
@@ -1773,19 +1782,10 @@ export type Event =
   | EventTuiCommandExecute
   | EventTuiToastShow
   | EventTuiSessionSelect
-  | EventVcsBranchUpdated
-  | EventTaskQueueCreated
-  | EventTaskQueueUpdated
-  | EventTaskQueueDeleted
-  | EventScheduledTaskCreated
-  | EventScheduledTaskUpdated
-  | EventScheduledTaskDeleted
   | EventPtyCreated
   | EventPtyUpdated
   | EventPtyExited
   | EventPtyDeleted
-  | EventWorktreeReady
-  | EventWorktreeFailed
 
 export type GlobalEvent = {
   directory: string
@@ -2440,6 +2440,83 @@ export type Config = {
      * Run the autonomous-mode diff critic at every phase boundary. Default: false.
      */
     critic_enabled?: boolean
+  }
+  /**
+   * Execution modes: local, cloud, hybrid placement, multi-provider council, and arena ensemble (ADR-049).
+   */
+  modes?: {
+    /**
+     * Default execution mode. When unset: hybrid if local AX Engine is available, else cloud. Arena/council are typically invoked via tools rather than as the global default.
+     */
+    default?: "local" | "cloud" | "hybrid" | "arena" | "council"
+    /**
+     * Hybrid local/cloud placement policy
+     */
+    hybrid?: {
+      /**
+       * Prefer local placement when AX Engine (or configured local) is available. Default: true.
+       */
+      preferLocalWhenAvailable?: boolean
+      /**
+       * Route high-complexity work to cloud when hybrid is active. Default: true.
+       */
+      escalateOnHighComplexity?: boolean
+      /**
+       * Provider id treated as local for hybrid placement. Default: ax-engine.
+       */
+      localProviderID?: string
+    }
+    /**
+     * Multi-provider council (advisory review / design) settings
+     */
+    council?: {
+      /**
+       * Allow the council multi-provider advisory tool. Default: true.
+       */
+      enabled?: boolean
+      /**
+       * Maximum council members per invocation (default: 3, hard max: 6).
+       */
+      maxMembers?: number
+      /**
+       * Per-member timeout in ms for council fan-out (default: 60000).
+       */
+      timeoutMs?: number
+      /**
+       * Optional multi-round anonymous debate rounds (default: 0; Phase 3+).
+       */
+      debateRounds?: number
+    }
+    /**
+     * Arena best-of-N implementation comparison settings
+     */
+    arena?: {
+      /**
+       * Enable arena multi-contestant mode tools. Default: false until Phase 2.
+       */
+      enabled?: boolean
+      /**
+       * Maximum arena contestants (default: 3, hard max: 5).
+       */
+      maxContestants?: number
+      /**
+       * Ranking strategy for arena candidates. verify_first is the recommended default (never pure popularity).
+       */
+      strategy?: "verify_first" | "diversity" | "hybrid_score"
+    }
+    /**
+     * Ensemble cost budget controls
+     */
+    budget?: {
+      /**
+       * Maximum estimated USD for an ensemble fan-out (fail-closed when exceeded).
+       */
+      maxEstimatedUsd?: number
+      /**
+       * Rough USD cost per council/arena member call used with maxEstimatedUsd to cap fan-out size.
+       */
+      estimatedUsdPerMember?: number
+    }
   }
 }
 

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -36477,6 +36477,27 @@
           "properties"
         ]
       },
+      "Event.vcs.branch.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "vcs.branch.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "branch": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
       "Event.command.executed": {
         "type": "object",
         "properties": {
@@ -36552,6 +36573,307 @@
               "sessionID",
               "arguments",
               "messageID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.task.queue.created": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "task.queue.created"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "item": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^tsk.*"
+                  },
+                  "projectID": {
+                    "type": "string"
+                  },
+                  "directory": {
+                    "type": "string"
+                  },
+                  "worktree": {
+                    "type": "string"
+                  },
+                  "sessionID": {
+                    "type": "string",
+                    "pattern": "^ses.*"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "prompt",
+                      "command",
+                      "shell",
+                      "followup",
+                      "subagent",
+                      "review",
+                      "automation"
+                    ]
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "queued",
+                      "waiting_for_idle",
+                      "running",
+                      "blocked_permission",
+                      "blocked_question",
+                      "paused",
+                      "failed",
+                      "completed",
+                      "cancelled"
+                    ]
+                  },
+                  "priority": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "position": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "agent": {
+                    "type": "string"
+                  },
+                  "model": {},
+                  "sourceMessageID": {
+                    "type": "string"
+                  },
+                  "sourceTaskID": {
+                    "type": "string"
+                  },
+                  "payload": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {}
+                  },
+                  "error": {
+                    "type": "string"
+                  },
+                  "time": {
+                    "type": "object",
+                    "properties": {
+                      "created": {
+                        "type": "number"
+                      },
+                      "updated": {
+                        "type": "number"
+                      },
+                      "started": {
+                        "type": "number"
+                      },
+                      "completed": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "created"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "projectID",
+                  "directory",
+                  "kind",
+                  "status",
+                  "priority",
+                  "position",
+                  "title",
+                  "payload",
+                  "time"
+                ]
+              }
+            },
+            "required": [
+              "item"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.task.queue.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "task.queue.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "item": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^tsk.*"
+                  },
+                  "projectID": {
+                    "type": "string"
+                  },
+                  "directory": {
+                    "type": "string"
+                  },
+                  "worktree": {
+                    "type": "string"
+                  },
+                  "sessionID": {
+                    "type": "string",
+                    "pattern": "^ses.*"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "prompt",
+                      "command",
+                      "shell",
+                      "followup",
+                      "subagent",
+                      "review",
+                      "automation"
+                    ]
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "queued",
+                      "waiting_for_idle",
+                      "running",
+                      "blocked_permission",
+                      "blocked_question",
+                      "paused",
+                      "failed",
+                      "completed",
+                      "cancelled"
+                    ]
+                  },
+                  "priority": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "position": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "agent": {
+                    "type": "string"
+                  },
+                  "model": {},
+                  "sourceMessageID": {
+                    "type": "string"
+                  },
+                  "sourceTaskID": {
+                    "type": "string"
+                  },
+                  "payload": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {}
+                  },
+                  "error": {
+                    "type": "string"
+                  },
+                  "time": {
+                    "type": "object",
+                    "properties": {
+                      "created": {
+                        "type": "number"
+                      },
+                      "updated": {
+                        "type": "number"
+                      },
+                      "started": {
+                        "type": "number"
+                      },
+                      "completed": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "created"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "projectID",
+                  "directory",
+                  "kind",
+                  "status",
+                  "priority",
+                  "position",
+                  "title",
+                  "payload",
+                  "time"
+                ]
+              }
+            },
+            "required": [
+              "item"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.task.queue.deleted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "task.queue.deleted"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^tsk.*"
+              },
+              "projectID": {
+                "type": "string"
+              },
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses.*"
+              }
+            },
+            "required": [
+              "id",
+              "projectID"
             ]
           }
         },
@@ -38583,6 +38905,497 @@
           "properties"
         ]
       },
+      "Event.scheduled.task.created": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "scheduled.task.created"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "task": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^sch.*"
+                  },
+                  "projectID": {
+                    "type": "string"
+                  },
+                  "directory": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "prompt": {
+                    "type": "string"
+                  },
+                  "schedule": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "once"
+                          },
+                          "runAt": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "runAt"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "daily"
+                          },
+                          "time": {
+                            "type": "string",
+                            "pattern": "^\\d{2}:\\d{2}$"
+                          },
+                          "timezone": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "time"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "weekly"
+                          },
+                          "day": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 6
+                          },
+                          "time": {
+                            "type": "string",
+                            "pattern": "^\\d{2}:\\d{2}$"
+                          },
+                          "timezone": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "day",
+                          "time"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "cron"
+                          },
+                          "expression": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "timezone": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "expression"
+                        ]
+                      }
+                    ]
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "paused",
+                      "disabled"
+                    ]
+                  },
+                  "agent": {
+                    "type": "string"
+                  },
+                  "model": {},
+                  "workflowTemplateID": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120,
+                    "pattern": "^(builtin|user|project):[a-z][a-z0-9-]*$"
+                  },
+                  "workflowStartOptions": {
+                    "type": "object",
+                    "properties": {
+                      "allowScaleBeyondDefaults": {
+                        "type": "boolean"
+                      },
+                      "allowWriteWorkflows": {
+                        "type": "boolean"
+                      },
+                      "durableChildren": {
+                        "type": "boolean"
+                      },
+                      "enqueueChildren": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "lastQueueID": {
+                    "type": "string"
+                  },
+                  "lastWorkflowRunID": {
+                    "type": "string"
+                  },
+                  "error": {
+                    "type": "string"
+                  },
+                  "nextRunAt": {
+                    "type": "number"
+                  },
+                  "lastRunAt": {
+                    "type": "number"
+                  },
+                  "time": {
+                    "type": "object",
+                    "properties": {
+                      "created": {
+                        "type": "number"
+                      },
+                      "updated": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "created"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "projectID",
+                  "directory",
+                  "title",
+                  "prompt",
+                  "schedule",
+                  "status",
+                  "time"
+                ]
+              }
+            },
+            "required": [
+              "task"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.scheduled.task.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "scheduled.task.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "task": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^sch.*"
+                  },
+                  "projectID": {
+                    "type": "string"
+                  },
+                  "directory": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "prompt": {
+                    "type": "string"
+                  },
+                  "schedule": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "once"
+                          },
+                          "runAt": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "runAt"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "daily"
+                          },
+                          "time": {
+                            "type": "string",
+                            "pattern": "^\\d{2}:\\d{2}$"
+                          },
+                          "timezone": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "time"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "weekly"
+                          },
+                          "day": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 6
+                          },
+                          "time": {
+                            "type": "string",
+                            "pattern": "^\\d{2}:\\d{2}$"
+                          },
+                          "timezone": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "day",
+                          "time"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "cron"
+                          },
+                          "expression": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "timezone": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "expression"
+                        ]
+                      }
+                    ]
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "paused",
+                      "disabled"
+                    ]
+                  },
+                  "agent": {
+                    "type": "string"
+                  },
+                  "model": {},
+                  "workflowTemplateID": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120,
+                    "pattern": "^(builtin|user|project):[a-z][a-z0-9-]*$"
+                  },
+                  "workflowStartOptions": {
+                    "type": "object",
+                    "properties": {
+                      "allowScaleBeyondDefaults": {
+                        "type": "boolean"
+                      },
+                      "allowWriteWorkflows": {
+                        "type": "boolean"
+                      },
+                      "durableChildren": {
+                        "type": "boolean"
+                      },
+                      "enqueueChildren": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "lastQueueID": {
+                    "type": "string"
+                  },
+                  "lastWorkflowRunID": {
+                    "type": "string"
+                  },
+                  "error": {
+                    "type": "string"
+                  },
+                  "nextRunAt": {
+                    "type": "number"
+                  },
+                  "lastRunAt": {
+                    "type": "number"
+                  },
+                  "time": {
+                    "type": "object",
+                    "properties": {
+                      "created": {
+                        "type": "number"
+                      },
+                      "updated": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "created"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "projectID",
+                  "directory",
+                  "title",
+                  "prompt",
+                  "schedule",
+                  "status",
+                  "time"
+                ]
+              }
+            },
+            "required": [
+              "task"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.scheduled.task.deleted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "scheduled.task.deleted"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^sch.*"
+              },
+              "projectID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "projectID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.worktree.ready": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "worktree.ready"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "branch": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "branch"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.worktree.failed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "worktree.failed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
       "Event.code.index.progress": {
         "type": "object",
         "properties": {
@@ -39127,767 +39940,6 @@
           "properties"
         ]
       },
-      "Event.vcs.branch.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "vcs.branch.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "branch": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.task.queue.created": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "task.queue.created"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "item": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "pattern": "^tsk.*"
-                  },
-                  "projectID": {
-                    "type": "string"
-                  },
-                  "directory": {
-                    "type": "string"
-                  },
-                  "worktree": {
-                    "type": "string"
-                  },
-                  "sessionID": {
-                    "type": "string",
-                    "pattern": "^ses.*"
-                  },
-                  "kind": {
-                    "type": "string",
-                    "enum": [
-                      "prompt",
-                      "command",
-                      "shell",
-                      "followup",
-                      "subagent",
-                      "review",
-                      "automation"
-                    ]
-                  },
-                  "status": {
-                    "type": "string",
-                    "enum": [
-                      "queued",
-                      "waiting_for_idle",
-                      "running",
-                      "blocked_permission",
-                      "blocked_question",
-                      "paused",
-                      "failed",
-                      "completed",
-                      "cancelled"
-                    ]
-                  },
-                  "priority": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
-                  },
-                  "position": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9007199254740991
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "agent": {
-                    "type": "string"
-                  },
-                  "model": {},
-                  "sourceMessageID": {
-                    "type": "string"
-                  },
-                  "sourceTaskID": {
-                    "type": "string"
-                  },
-                  "payload": {
-                    "type": "object",
-                    "propertyNames": {
-                      "type": "string"
-                    },
-                    "additionalProperties": {}
-                  },
-                  "error": {
-                    "type": "string"
-                  },
-                  "time": {
-                    "type": "object",
-                    "properties": {
-                      "created": {
-                        "type": "number"
-                      },
-                      "updated": {
-                        "type": "number"
-                      },
-                      "started": {
-                        "type": "number"
-                      },
-                      "completed": {
-                        "type": "number"
-                      }
-                    },
-                    "required": [
-                      "created"
-                    ]
-                  }
-                },
-                "required": [
-                  "id",
-                  "projectID",
-                  "directory",
-                  "kind",
-                  "status",
-                  "priority",
-                  "position",
-                  "title",
-                  "payload",
-                  "time"
-                ]
-              }
-            },
-            "required": [
-              "item"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.task.queue.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "task.queue.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "item": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "pattern": "^tsk.*"
-                  },
-                  "projectID": {
-                    "type": "string"
-                  },
-                  "directory": {
-                    "type": "string"
-                  },
-                  "worktree": {
-                    "type": "string"
-                  },
-                  "sessionID": {
-                    "type": "string",
-                    "pattern": "^ses.*"
-                  },
-                  "kind": {
-                    "type": "string",
-                    "enum": [
-                      "prompt",
-                      "command",
-                      "shell",
-                      "followup",
-                      "subagent",
-                      "review",
-                      "automation"
-                    ]
-                  },
-                  "status": {
-                    "type": "string",
-                    "enum": [
-                      "queued",
-                      "waiting_for_idle",
-                      "running",
-                      "blocked_permission",
-                      "blocked_question",
-                      "paused",
-                      "failed",
-                      "completed",
-                      "cancelled"
-                    ]
-                  },
-                  "priority": {
-                    "type": "integer",
-                    "minimum": -9007199254740991,
-                    "maximum": 9007199254740991
-                  },
-                  "position": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9007199254740991
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "agent": {
-                    "type": "string"
-                  },
-                  "model": {},
-                  "sourceMessageID": {
-                    "type": "string"
-                  },
-                  "sourceTaskID": {
-                    "type": "string"
-                  },
-                  "payload": {
-                    "type": "object",
-                    "propertyNames": {
-                      "type": "string"
-                    },
-                    "additionalProperties": {}
-                  },
-                  "error": {
-                    "type": "string"
-                  },
-                  "time": {
-                    "type": "object",
-                    "properties": {
-                      "created": {
-                        "type": "number"
-                      },
-                      "updated": {
-                        "type": "number"
-                      },
-                      "started": {
-                        "type": "number"
-                      },
-                      "completed": {
-                        "type": "number"
-                      }
-                    },
-                    "required": [
-                      "created"
-                    ]
-                  }
-                },
-                "required": [
-                  "id",
-                  "projectID",
-                  "directory",
-                  "kind",
-                  "status",
-                  "priority",
-                  "position",
-                  "title",
-                  "payload",
-                  "time"
-                ]
-              }
-            },
-            "required": [
-              "item"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.task.queue.deleted": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "task.queue.deleted"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "pattern": "^tsk.*"
-              },
-              "projectID": {
-                "type": "string"
-              },
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              }
-            },
-            "required": [
-              "id",
-              "projectID"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.scheduled.task.created": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "scheduled.task.created"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "task": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "pattern": "^sch.*"
-                  },
-                  "projectID": {
-                    "type": "string"
-                  },
-                  "directory": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "prompt": {
-                    "type": "string"
-                  },
-                  "schedule": {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "const": "once"
-                          },
-                          "runAt": {
-                            "type": "integer",
-                            "exclusiveMinimum": 0,
-                            "maximum": 9007199254740991
-                          }
-                        },
-                        "required": [
-                          "type",
-                          "runAt"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "const": "daily"
-                          },
-                          "time": {
-                            "type": "string",
-                            "pattern": "^\\d{2}:\\d{2}$"
-                          },
-                          "timezone": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "type",
-                          "time"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "const": "weekly"
-                          },
-                          "day": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "maximum": 6
-                          },
-                          "time": {
-                            "type": "string",
-                            "pattern": "^\\d{2}:\\d{2}$"
-                          },
-                          "timezone": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "type",
-                          "day",
-                          "time"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "const": "cron"
-                          },
-                          "expression": {
-                            "type": "string",
-                            "minLength": 1,
-                            "maxLength": 120
-                          },
-                          "timezone": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "type",
-                          "expression"
-                        ]
-                      }
-                    ]
-                  },
-                  "status": {
-                    "type": "string",
-                    "enum": [
-                      "active",
-                      "paused",
-                      "disabled"
-                    ]
-                  },
-                  "agent": {
-                    "type": "string"
-                  },
-                  "model": {},
-                  "workflowTemplateID": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 120,
-                    "pattern": "^(builtin|user|project):[a-z][a-z0-9-]*$"
-                  },
-                  "workflowStartOptions": {
-                    "type": "object",
-                    "properties": {
-                      "allowScaleBeyondDefaults": {
-                        "type": "boolean"
-                      },
-                      "allowWriteWorkflows": {
-                        "type": "boolean"
-                      },
-                      "durableChildren": {
-                        "type": "boolean"
-                      },
-                      "enqueueChildren": {
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "lastQueueID": {
-                    "type": "string"
-                  },
-                  "lastWorkflowRunID": {
-                    "type": "string"
-                  },
-                  "error": {
-                    "type": "string"
-                  },
-                  "nextRunAt": {
-                    "type": "number"
-                  },
-                  "lastRunAt": {
-                    "type": "number"
-                  },
-                  "time": {
-                    "type": "object",
-                    "properties": {
-                      "created": {
-                        "type": "number"
-                      },
-                      "updated": {
-                        "type": "number"
-                      }
-                    },
-                    "required": [
-                      "created"
-                    ]
-                  }
-                },
-                "required": [
-                  "id",
-                  "projectID",
-                  "directory",
-                  "title",
-                  "prompt",
-                  "schedule",
-                  "status",
-                  "time"
-                ]
-              }
-            },
-            "required": [
-              "task"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.scheduled.task.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "scheduled.task.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "task": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "pattern": "^sch.*"
-                  },
-                  "projectID": {
-                    "type": "string"
-                  },
-                  "directory": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "prompt": {
-                    "type": "string"
-                  },
-                  "schedule": {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "const": "once"
-                          },
-                          "runAt": {
-                            "type": "integer",
-                            "exclusiveMinimum": 0,
-                            "maximum": 9007199254740991
-                          }
-                        },
-                        "required": [
-                          "type",
-                          "runAt"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "const": "daily"
-                          },
-                          "time": {
-                            "type": "string",
-                            "pattern": "^\\d{2}:\\d{2}$"
-                          },
-                          "timezone": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "type",
-                          "time"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "const": "weekly"
-                          },
-                          "day": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "maximum": 6
-                          },
-                          "time": {
-                            "type": "string",
-                            "pattern": "^\\d{2}:\\d{2}$"
-                          },
-                          "timezone": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "type",
-                          "day",
-                          "time"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "const": "cron"
-                          },
-                          "expression": {
-                            "type": "string",
-                            "minLength": 1,
-                            "maxLength": 120
-                          },
-                          "timezone": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "type",
-                          "expression"
-                        ]
-                      }
-                    ]
-                  },
-                  "status": {
-                    "type": "string",
-                    "enum": [
-                      "active",
-                      "paused",
-                      "disabled"
-                    ]
-                  },
-                  "agent": {
-                    "type": "string"
-                  },
-                  "model": {},
-                  "workflowTemplateID": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 120,
-                    "pattern": "^(builtin|user|project):[a-z][a-z0-9-]*$"
-                  },
-                  "workflowStartOptions": {
-                    "type": "object",
-                    "properties": {
-                      "allowScaleBeyondDefaults": {
-                        "type": "boolean"
-                      },
-                      "allowWriteWorkflows": {
-                        "type": "boolean"
-                      },
-                      "durableChildren": {
-                        "type": "boolean"
-                      },
-                      "enqueueChildren": {
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "lastQueueID": {
-                    "type": "string"
-                  },
-                  "lastWorkflowRunID": {
-                    "type": "string"
-                  },
-                  "error": {
-                    "type": "string"
-                  },
-                  "nextRunAt": {
-                    "type": "number"
-                  },
-                  "lastRunAt": {
-                    "type": "number"
-                  },
-                  "time": {
-                    "type": "object",
-                    "properties": {
-                      "created": {
-                        "type": "number"
-                      },
-                      "updated": {
-                        "type": "number"
-                      }
-                    },
-                    "required": [
-                      "created"
-                    ]
-                  }
-                },
-                "required": [
-                  "id",
-                  "projectID",
-                  "directory",
-                  "title",
-                  "prompt",
-                  "schedule",
-                  "status",
-                  "time"
-                ]
-              }
-            },
-            "required": [
-              "task"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.scheduled.task.deleted": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "scheduled.task.deleted"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "pattern": "^sch.*"
-              },
-              "projectID": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id",
-              "projectID"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
       "Pty": {
         "type": "object",
         "properties": {
@@ -40033,58 +40085,6 @@
           "properties"
         ]
       },
-      "Event.worktree.ready": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "worktree.ready"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "branch": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name",
-              "branch"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.worktree.failed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "worktree.failed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
       "Event": {
         "oneOf": [
           {
@@ -40175,7 +40175,19 @@
             "$ref": "#/components/schemas/Event.mcp.browser.open.failed"
           },
           {
+            "$ref": "#/components/schemas/Event.vcs.branch.updated"
+          },
+          {
             "$ref": "#/components/schemas/Event.command.executed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.task.queue.created"
+          },
+          {
+            "$ref": "#/components/schemas/Event.task.queue.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.task.queue.deleted"
           },
           {
             "$ref": "#/components/schemas/Event.workflow.run.created"
@@ -40250,6 +40262,21 @@
             "$ref": "#/components/schemas/Event.workflow.verification.attached"
           },
           {
+            "$ref": "#/components/schemas/Event.scheduled.task.created"
+          },
+          {
+            "$ref": "#/components/schemas/Event.scheduled.task.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.scheduled.task.deleted"
+          },
+          {
+            "$ref": "#/components/schemas/Event.worktree.ready"
+          },
+          {
+            "$ref": "#/components/schemas/Event.worktree.failed"
+          },
+          {
             "$ref": "#/components/schemas/Event.code.index.progress"
           },
           {
@@ -40286,27 +40313,6 @@
             "$ref": "#/components/schemas/Event.tui.session.select"
           },
           {
-            "$ref": "#/components/schemas/Event.vcs.branch.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.task.queue.created"
-          },
-          {
-            "$ref": "#/components/schemas/Event.task.queue.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.task.queue.deleted"
-          },
-          {
-            "$ref": "#/components/schemas/Event.scheduled.task.created"
-          },
-          {
-            "$ref": "#/components/schemas/Event.scheduled.task.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.scheduled.task.deleted"
-          },
-          {
             "$ref": "#/components/schemas/Event.pty.created"
           },
           {
@@ -40317,12 +40323,6 @@
           },
           {
             "$ref": "#/components/schemas/Event.pty.deleted"
-          },
-          {
-            "$ref": "#/components/schemas/Event.worktree.ready"
-          },
-          {
-            "$ref": "#/components/schemas/Event.worktree.failed"
           }
         ]
       },
@@ -41716,6 +41716,110 @@
               "critic_enabled": {
                 "description": "Run the autonomous-mode diff critic at every phase boundary. Default: false.",
                 "type": "boolean"
+              }
+            }
+          },
+          "modes": {
+            "description": "Execution modes: local, cloud, hybrid placement, multi-provider council, and arena ensemble (ADR-049).",
+            "type": "object",
+            "properties": {
+              "default": {
+                "description": "Default execution mode. When unset: hybrid if local AX Engine is available, else cloud. Arena/council are typically invoked via tools rather than as the global default.",
+                "type": "string",
+                "enum": [
+                  "local",
+                  "cloud",
+                  "hybrid",
+                  "arena",
+                  "council"
+                ]
+              },
+              "hybrid": {
+                "description": "Hybrid local/cloud placement policy",
+                "type": "object",
+                "properties": {
+                  "preferLocalWhenAvailable": {
+                    "description": "Prefer local placement when AX Engine (or configured local) is available. Default: true.",
+                    "type": "boolean"
+                  },
+                  "escalateOnHighComplexity": {
+                    "description": "Route high-complexity work to cloud when hybrid is active. Default: true.",
+                    "type": "boolean"
+                  },
+                  "localProviderID": {
+                    "description": "Provider id treated as local for hybrid placement. Default: ax-engine.",
+                    "type": "string"
+                  }
+                }
+              },
+              "council": {
+                "description": "Multi-provider council (advisory review / design) settings",
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "description": "Allow the council multi-provider advisory tool. Default: true.",
+                    "type": "boolean"
+                  },
+                  "maxMembers": {
+                    "description": "Maximum council members per invocation (default: 3, hard max: 6).",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "timeoutMs": {
+                    "description": "Per-member timeout in ms for council fan-out (default: 60000).",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "debateRounds": {
+                    "description": "Optional multi-round anonymous debate rounds (default: 0; Phase 3+).",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              },
+              "arena": {
+                "description": "Arena best-of-N implementation comparison settings",
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "description": "Enable arena multi-contestant mode tools. Default: false until Phase 2.",
+                    "type": "boolean"
+                  },
+                  "maxContestants": {
+                    "description": "Maximum arena contestants (default: 3, hard max: 5).",
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "strategy": {
+                    "description": "Ranking strategy for arena candidates. verify_first is the recommended default (never pure popularity).",
+                    "type": "string",
+                    "enum": [
+                      "verify_first",
+                      "diversity",
+                      "hybrid_score"
+                    ]
+                  }
+                }
+              },
+              "budget": {
+                "description": "Ensemble cost budget controls",
+                "type": "object",
+                "properties": {
+                  "maxEstimatedUsd": {
+                    "description": "Maximum estimated USD for an ensemble fan-out (fail-closed when exceeded).",
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "estimatedUsdPerMember": {
+                    "description": "Rough USD cost per council/arena member call used with maxEstimatedUsd to cap fan-out size.",
+                    "type": "number",
+                    "minimum": 0
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary\n- reject new TUI RPC calls immediately after the backend transport exits\n- scope workspace-related TUI sync requests to the active directory\n- clear handled slash commands after dispatch\n- shorten transient clipboard confirmations to 1.5 seconds\n- refresh generated SDK API contract to match the current server surface\n\n## Validation\n- corepack pnpm --dir packages/sdk/js run typecheck\n- corepack pnpm --dir packages/ax-code exec vitest run test/cli/tui --reporter=dot\n- corepack pnpm --dir packages/ax-code run typecheck\n- corepack pnpm --dir packages/ax-code run tui:startup-smoke\n- corepack pnpm --dir packages/ax-code run build\n- corepack pnpm --dir packages/sdk/js run build && git diff --exit-code