### PR TITLE
fix(ci): stabilize self-scan baseline fingerprints

### DIFF
--- a/.github/workflows/ax-code-ci.yml
+++ b/.github/workflows/ax-code-ci.yml
@@ -112,7 +112,7 @@ jobs:
         run: pnpm --dir packages/ax-code run typecheck
 
       - name: Download coverage baseline
-        if: always()
+        if: always() && github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -137,12 +137,6 @@ jobs:
           find "$dest" -maxdepth 2 -type f -print || true
 
       - name: Run deterministic ax-code tests
-        env:
-          # Coverage for the session-heavy deterministic suite can exceed the
-          # default Node heap when several Vitest workers retain V8 data.
-          NODE_OPTIONS: --max-old-space-size=12288
-          AX_TEST_MAX_WORKERS: "1"
-          AX_TEST_SHARD_SIZE: "25"
         shell: bash
         run: |
           set -euo pipefail
@@ -157,18 +151,30 @@ jobs:
             deterministic
             --rerun-on-fail
             1
-            --coverage
-            --coverage-dir
-            .tmp/coverage
-            --coverage-summary-out
-            .tmp/coverage-summary.json
-            --coverage-report-out
-            .tmp/coverage-report.md
           )
 
-          baseline="$(find packages/ax-code/.tmp/coverage-baseline -name '*.json' | head -n1 || true)"
-          if [ -n "$baseline" ]; then
-            cmd+=(--coverage-baseline "${baseline#packages/ax-code/}")
+          # Full V8 coverage is retained on post-merge dev pushes, where it
+          # produces the baseline artifact. Running it on every PR keeps
+          # hundreds of instrumented test files in memory and makes feedback
+          # unacceptably slow.
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            export NODE_OPTIONS="--max-old-space-size=12288"
+            export AX_TEST_MAX_WORKERS="1"
+            export AX_TEST_SHARD_SIZE="25"
+            cmd+=(
+              --coverage
+              --coverage-dir
+              .tmp/coverage
+              --coverage-summary-out
+              .tmp/coverage-summary.json
+              --coverage-report-out
+              .tmp/coverage-report.md
+            )
+
+            baseline="$(find packages/ax-code/.tmp/coverage-baseline -name '*.json' | head -n1 || true)"
+            if [ -n "$baseline" ]; then
+              cmd+=(--coverage-baseline "${baseline#packages/ax-code/}")
+            fi
           fi
 
           "${cmd[@]}"
@@ -188,7 +194,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload coverage artifacts
-        if: always()
+        if: always() && github.event_name == 'push'
         uses: actions/upload-artifact@v7
         with:
           name: ax-code-coverage-report

--- a/.github/workflows/ax-code-ci.yml
+++ b/.github/workflows/ax-code-ci.yml
@@ -137,6 +137,12 @@ jobs:
           find "$dest" -maxdepth 2 -type f -print || true
 
       - name: Run deterministic ax-code tests
+        env:
+          # Coverage for the session-heavy deterministic suite can exceed the
+          # default Node heap when several Vitest workers retain V8 data.
+          NODE_OPTIONS: --max-old-space-size=12288
+          AX_TEST_MAX_WORKERS: "1"
+          AX_TEST_SHARD_SIZE: "25"
         shell: bash
         run: |
           set -euo pipefail

--- a/packages/ax-code/script/self-scan-baseline.json
+++ b/packages/ax-code/script/self-scan-baseline.json
@@ -1,12 +1,12 @@
 {
-  "version": 1,
+  "version": 2,
   "scope": "packages/ax-code/src",
   "scanners": {
     "race_scan": {
-      "count": 100,
+      "count": 105,
       "findings": [
         {
-          "fingerprint": "06d963ccfe889a3d64d161ccf6613cf60691d1761e3f5a69224dce95c7fa9886",
+          "fingerprint": "3d3065523434f5546e63b368db904bd163079d8cf1a87fe366a8ccd7229dfc45",
           "file": "src/cli/cmd/tui/component/prompt/follow-up-queue-store.ts",
           "line": 123,
           "endLine": 142,
@@ -15,7 +15,7 @@
           "summary": "toctou"
         },
         {
-          "fingerprint": "aeeb8679cc88a0a1c2e9a654c308065c16b1f50ad2d51ec499a8903038cd3857",
+          "fingerprint": "3ff517ec6a8094a17b3ef5599039b544f915b0ad68004143b9c6c30a49037aae",
           "file": "src/debug-engine/prewarm-lsp.ts",
           "line": 40,
           "endLine": 53,
@@ -24,25 +24,16 @@
           "summary": "toctou"
         },
         {
-          "fingerprint": "a2ab425eb13482098f0182ab1794c3a8869514c7cffdc76a70be7236aca60d83",
+          "fingerprint": "49cf239d908d2e0b51d0366e5950eba42705206cb278f7c16cb0e1a0e34d141c",
           "file": "src/provider/ax-engine/server.ts",
-          "line": 396,
-          "endLine": 403,
+          "line": 403,
+          "endLine": 410,
           "severity": "high",
           "kind": "toctou",
           "summary": "toctou"
         },
         {
-          "fingerprint": "87d7a976846555b7d730dfa581419ca3357195d76490b706e525b75310788540",
-          "file": "src/provider/provider-impl.ts",
-          "line": 1047,
-          "endLine": 1076,
-          "severity": "high",
-          "kind": "toctou",
-          "summary": "toctou"
-        },
-        {
-          "fingerprint": "ef6f016e2d3e840abb1bf4b4c7caccdc07de4a0db30c9f5622caa8d9ba1203b3",
+          "fingerprint": "9006ba2cc657da9d057d776ba1689d1af78e015984d4b2fc15816fc1aaeaafd1",
           "file": "src/provider/provider-impl.ts",
           "line": 1047,
           "endLine": 1066,
@@ -51,7 +42,16 @@
           "summary": "toctou"
         },
         {
-          "fingerprint": "946c312c2c3b853631c4fdd3dcf20a87f35a1a661920bf105e7c7112c72573dc",
+          "fingerprint": "9006ba2cc657da9d057d776ba1689d1af78e015984d4b2fc15816fc1aaeaafd1",
+          "file": "src/provider/provider-impl.ts",
+          "line": 1047,
+          "endLine": 1076,
+          "severity": "high",
+          "kind": "toctou",
+          "summary": "toctou"
+        },
+        {
+          "fingerprint": "ebdb937221c5606fbb186bfe077c4934aef737b8aff521521808bb557fd2ba3a",
           "file": "src/provider/provider-impl.ts",
           "line": 1052,
           "endLine": 1090,
@@ -60,7 +60,7 @@
           "summary": "toctou"
         },
         {
-          "fingerprint": "e9c9e3007e389276dc0c2600d28ac1e58d5588733b05d253504b51a6e937b97c",
+          "fingerprint": "ebdb937221c5606fbb186bfe077c4934aef737b8aff521521808bb557fd2ba3a",
           "file": "src/provider/provider-impl.ts",
           "line": 1052,
           "endLine": 1098,
@@ -69,7 +69,7 @@
           "summary": "toctou"
         },
         {
-          "fingerprint": "ce907e1617c9a8a8e5f7568851e9f857c2346c5b412fbcc57fe8dc34bae70b76",
+          "fingerprint": "8641019dfe607445546ccf02b7419f0124493526a300724c4582d26386d44d71",
           "file": "src/cli/boot.ts",
           "line": 267,
           "severity": "medium",
@@ -77,7 +77,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "da8e30780abb916dd6dbc3654c3c8a23452140089a5c6d65981a41ee4b4971fd",
+          "fingerprint": "20e897e013620da366afeab19c609c3173939ad7d84c6815b7c3c6fdd33a26c6",
           "file": "src/cli/cmd/account.ts",
           "line": 57,
           "severity": "medium",
@@ -85,7 +85,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "a05d78dddb33a07896d7aa1d4961d39196f595717feff43c7ed329159539de5b",
+          "fingerprint": "5546c3324d0af8c227a946e184cf81eb7043d040738c680909fe9441bfe01a30",
           "file": "src/cli/cmd/release/check.ts",
           "line": 366,
           "severity": "medium",
@@ -93,7 +93,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "dbef23cf3bcefa5e0ea27733759757971865a6ae0a1e7341599dd26266b86736",
+          "fingerprint": "f059c3caa1907d3ecde7d8d88e39f956299b9563c750cf708cc7f12584d14fdc",
           "file": "src/cli/cmd/release/check.ts",
           "line": 390,
           "severity": "medium",
@@ -101,7 +101,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "f45b6e5115a4bc7f9903d9807881656f31e78238c77e0484dc004d46c38f49fe",
+          "fingerprint": "4dbdbe83c5d305e030cc800081c295b81013e64ea52587ff123689884defebe4",
           "file": "src/cli/cmd/release/check.ts",
           "line": 406,
           "severity": "medium",
@@ -109,7 +109,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "aaf84743c79888f2ab9d793d972c09595bb370a8458f1f18b703846e8e112a0a",
+          "fingerprint": "56663462b1325512399188015597015b16f0a6f565c3111b6c944d05f9ecaa42",
           "file": "src/cli/cmd/release/check.ts",
           "line": 534,
           "severity": "medium",
@@ -117,7 +117,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "22c3a1412424a52716f56c956a77cf409ac1849bb83401601bbaae72d44d6821",
+          "fingerprint": "5331583bb7b8a3423155e5138515b2c9594e4db0cd588f1f2ef33ea3c1340d4c",
           "file": "src/cli/cmd/release/check.ts",
           "line": 567,
           "severity": "medium",
@@ -125,7 +125,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "22c3a1412424a52716f56c956a77cf409ac1849bb83401601bbaae72d44d6821",
+          "fingerprint": "5331583bb7b8a3423155e5138515b2c9594e4db0cd588f1f2ef33ea3c1340d4c",
           "file": "src/cli/cmd/release/check.ts",
           "line": 567,
           "severity": "medium",
@@ -133,7 +133,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "d08592405ac2f7a6872570e173b72db1b8405912e90668b17bcc2a91c2edd270",
+          "fingerprint": "139a374b2a8591be3acdfa6574acf665c8556feaa2bde2f9a73687ea43b3b027",
           "file": "src/cli/cmd/stats.ts",
           "line": 222,
           "severity": "medium",
@@ -141,7 +141,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "171e9ec8783928b129f2072946323c366cdefe64f573dd43c3c7d1114a08bd1d",
+          "fingerprint": "02f82e48307b4136ae98bc2204331b0054079a0d4177d62efa83c5e2cf2a92dc",
           "file": "src/cli/cmd/stats.ts",
           "line": 225,
           "severity": "medium",
@@ -149,7 +149,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "b9851639a431456d775a093ccaf5fcc1513f2634b839be031f3ec0f0d49c8f2f",
+          "fingerprint": "5a16047c2d8b141bf6b41cbb055d8632fca7d225d208fea035f3f409308e9a21",
           "file": "src/cli/cmd/stats.ts",
           "line": 226,
           "severity": "medium",
@@ -157,7 +157,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "b485a1346c5adcb1e15ea3af1d04caa0627cf54f5611a8fc1ef175e030902cb1",
+          "fingerprint": "67ce65fa21fbccd71e0eba7f8ab839c2500cc057587525377cb621f83679d3ff",
           "file": "src/cli/cmd/stats.ts",
           "line": 227,
           "severity": "medium",
@@ -165,7 +165,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "029819c434cb6491f3ec982eecc46d2c52afd1c6d619c972868671efeec4adce",
+          "fingerprint": "d8bb0d1ec402c40527aff7ca2b81594236ed5a0c25f01bc0d8e9728e041111f1",
           "file": "src/cli/cmd/stats.ts",
           "line": 228,
           "severity": "medium",
@@ -173,7 +173,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "4c5e6d6837c3d2552d4f2699a671d1748d166053f07404e3b0828ee90e44bb9b",
+          "fingerprint": "6fe99c3eabecefdc40212bf02a3c23ee0e742d4822ee1792f462d63bc2551ceb",
           "file": "src/cli/cmd/stats.ts",
           "line": 229,
           "severity": "medium",
@@ -181,7 +181,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "64b571a6243a3061b292b9663ab34c0f426df738236f2b8ef4795ac9e884e09a",
+          "fingerprint": "aa66ca1ce3b3c72c7a4684bd860ed66e922b01dd9684b1cef8bec67b280a06b2",
           "file": "src/cli/cmd/stats.ts",
           "line": 231,
           "severity": "medium",
@@ -189,7 +189,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "acdd8d0a61cf6aaa200541f8e2e761e7ab2b4cf92385435352e3b9a09ce0a224",
+          "fingerprint": "c297aa745abd9f760a3361ae2d6e64afefb7c496df6835cde23c9c015c981a7e",
           "file": "src/cli/cmd/stats.ts",
           "line": 232,
           "severity": "medium",
@@ -197,7 +197,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "8ab423f2538d06d5cf47677619d19cf9c05981a0c68935d0b63c5352014599c2",
+          "fingerprint": "920fdccbde730541c4642c03ffd793e87974288a18f754e488df15ed25b25f4e",
           "file": "src/cli/cmd/stats.ts",
           "line": 234,
           "severity": "medium",
@@ -205,7 +205,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "d054528b6c0364a57b03776940b2c2fd007b13ad6ffdf71ef9160a7cb1aff758",
+          "fingerprint": "87fd03e42a97b222324abea40a2519f88df6126152cdf19a601b233f468bd207",
           "file": "src/cli/cmd/stats.ts",
           "line": 235,
           "severity": "medium",
@@ -213,7 +213,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "919347518f6528590a132b4ccdb4908abaadfa842d0f2040f9eaee6aa4b7cee7",
+          "fingerprint": "634b59cb63559dfcaa6ce41872cb9bea0cff23df8fd8dcac6d936b222c8d09f9",
           "file": "src/cli/cmd/stats.ts",
           "line": 274,
           "severity": "medium",
@@ -221,7 +221,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "886e22baad50aed5b019c1ae40946f43b83c21d298d91295ed481bda787b1d5f",
+          "fingerprint": "7660b58b9a93809a9f28707796e96a93cb16ba25f40c334a53614297e2d22db5",
           "file": "src/cli/cmd/stats.ts",
           "line": 275,
           "severity": "medium",
@@ -229,7 +229,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "f9c69f4e73b3f622a039677d71f0aafb23b57bfd120c2de69d08fa514387f824",
+          "fingerprint": "e054c5b0f5731a6b745ed34b3a09250fa8485d5c0bba0ba25caf419e177832ac",
           "file": "src/cli/cmd/stats.ts",
           "line": 276,
           "severity": "medium",
@@ -237,7 +237,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "fef72e060454d1150ce1cb22cc795175f52f09beb02ab8f21f1862158aa73fda",
+          "fingerprint": "bedae40f034e5a636763d69c0ab1a2fe8eb0a0eddba57b6f0fea2cc815ed0324",
           "file": "src/cli/cmd/stats.ts",
           "line": 277,
           "severity": "medium",
@@ -245,7 +245,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "ab3db068d11dba8ca59a5d65279aca62c1fe61ef23b2c6a049cc5f178e6c76c2",
+          "fingerprint": "09ab0dc9445dae3f62e6614ec953a8f413bd0b89c28eb3fd02afcd2038d5cc41",
           "file": "src/cli/cmd/stats.ts",
           "line": 278,
           "severity": "medium",
@@ -253,7 +253,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "69468d55bc5eeee2d85292e18606625f843976230807d7fcb5dcc0ad91369919",
+          "fingerprint": "b852ddbd3fdb229fb89546e9e4866db452bfe9b2844126d7c88af0f615efd5a1",
           "file": "src/cli/cmd/stats.ts",
           "line": 279,
           "severity": "medium",
@@ -261,7 +261,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "c7c6413b8f64406604b0d8844928d30afe9de053e265d6ecd159307103a1a148",
+          "fingerprint": "7d73ef4dbccd011ae8c7239324405f028c5c65dd6886113004daa6a7da8fad2a",
           "file": "src/cli/cmd/stats.ts",
           "line": 292,
           "severity": "medium",
@@ -269,7 +269,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "99c8534f15c0e168ffa6004e95fa9755fcbf712d3f2dd1b3f6664560a8e6997b",
+          "fingerprint": "998ed66b469962159fae24c670f5d3c205887371d391dd49f36089809b85d43b",
           "file": "src/cli/cmd/stats.ts",
           "line": 293,
           "severity": "medium",
@@ -277,7 +277,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "86236063168345b8ff922c12c506bc427153bcd9b2cc9cf5cc98055bdff0aa40",
+          "fingerprint": "2e73b796a49cb9e5d2e89dcbbe02c3f7cae36f90b5ab82d185e7f6e8f92aa235",
           "file": "src/cli/cmd/stats.ts",
           "line": 294,
           "severity": "medium",
@@ -285,7 +285,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "7fecc0071b715d0fd1dcc990a3dcd4a04a8567c2111ab5bfee3e6e436058972d",
+          "fingerprint": "ff148e734a173bb22acb7f493e49429244998ee7b63e59478081d90bc0b79a1a",
           "file": "src/cli/cmd/stats.ts",
           "line": 295,
           "severity": "medium",
@@ -293,7 +293,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "484e3fc644d2d0a234fb554412b01aa241cce0d09f31693fbd40faf99137d023",
+          "fingerprint": "32afa24cc8cf31596979a63357b072e93b9d56d81b392b5b52a7d735208ab965",
           "file": "src/cli/cmd/stats.ts",
           "line": 296,
           "severity": "medium",
@@ -301,7 +301,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "bef7e55025b25c33970e248691d1f98c6943be6021becae384c7fe4d88c9e3ac",
+          "fingerprint": "3b859ad7fd382f8e9eaff0154b916cde39044b6cca65bf64cbc711e2e4f27314",
           "file": "src/cli/cmd/tui/context/sync-bootstrap-phase.ts",
           "line": 47,
           "severity": "medium",
@@ -309,7 +309,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "e07464350e0b4920d33882335b5449f474126de21e557d33399ab557c749ec7e",
+          "fingerprint": "0982c13b7d62c1425536321205f4e779cbbb8bb31c4553b34cfc8e55eca7769c",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 313,
           "severity": "medium",
@@ -317,7 +317,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "b44d759675e544824da4a1cdd9decd29050138847b89b6152c352cbc98bdca06",
+          "fingerprint": "d316227d26f17d6ceadcefd38c04fd814170983365f54a8267f48d0a560b37f8",
           "file": "src/context/analyzer.ts",
           "line": 419,
           "severity": "medium",
@@ -325,7 +325,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "d1916c4c1330cec54cb128829a50f69a8a2b89b2118496e1a22578200234e770",
+          "fingerprint": "ca5eab6513113dc88da215db033faef179708854a848881d79b7af12ea4cfc80",
           "file": "src/context/analyzer.ts",
           "line": 420,
           "severity": "medium",
@@ -333,7 +333,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "ffed19ee33f7e5974b8686c7121c9171a8cbaacce2017c4cfaa896a80c5e6cee",
+          "fingerprint": "d316227d26f17d6ceadcefd38c04fd814170983365f54a8267f48d0a560b37f8",
           "file": "src/context/analyzer.ts",
           "line": 430,
           "severity": "medium",
@@ -341,7 +341,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "739b159984cd79bd6f94fbe7719f0d6a6a6a2cbf7410957e7a9f1d4c19cdcccb",
+          "fingerprint": "ca5eab6513113dc88da215db033faef179708854a848881d79b7af12ea4cfc80",
           "file": "src/context/analyzer.ts",
           "line": 431,
           "severity": "medium",
@@ -349,7 +349,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "b50f15ae6cdbe0666e92a90028bd2bd655fbf25c7d200640dbbaaf5547cfd8ff",
+          "fingerprint": "b3192d6b381edb8edb80e282d3f114bf4b5993e00ae3081500ed53d03b7d8c96",
           "file": "src/control-plane/abort.ts",
           "line": 26,
           "severity": "medium",
@@ -357,7 +357,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "6e5ba24ab99d1a7a5f1e9057b03a893ad259526491a570d3500bf5b31903ab43",
+          "fingerprint": "483b808ae3d36e2314700854278d2218435c63e97416c1870761e7d695419dc7",
           "file": "src/control-plane/sse.ts",
           "line": 109,
           "severity": "medium",
@@ -365,7 +365,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "d58051b47dfc96b285c31dadd2bf16a36a5759278c7fa57c88abd3de64bc5d1d",
+          "fingerprint": "63201ba806b99dfd40645b1d7684fdc2dafe4165ebe43d161f7281eef1a2b395",
           "file": "src/control-plane/sse.ts",
           "line": 127,
           "severity": "medium",
@@ -373,7 +373,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "86cca9594d8fe3a52961c62016440940d913e9e30bebe719f8abcc8c8129b26a",
+          "fingerprint": "0c8fb83a73e5f0c8e2c7957476a41bde6606ec38334fd86494ac9a54d315b9d4",
           "file": "src/debug-engine/prewarm-lsp.ts",
           "line": 61,
           "severity": "medium",
@@ -381,7 +381,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "97e0291463faf4cec1b7dc2eede2540b866d95fa44931389f257f0c5246af433",
+          "fingerprint": "180a65640e683a0cac7c8f0c745acffd3e1e33b2f0137ad6ac4316e070300d78",
           "file": "src/debug-engine/prewarm-lsp.ts",
           "line": 63,
           "severity": "medium",
@@ -389,7 +389,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "626f8e048b2598bd9483081c7767798bf1c0cf6f637c73862d009578b4084c2a",
+          "fingerprint": "58731604215c0552a93bbc8c238a2658040d822224f5fce575038cf034b1d1b9",
           "file": "src/design-check/index.ts",
           "line": 97,
           "severity": "medium",
@@ -397,7 +397,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "99b5245b8d0df2772151458d6c51b3adeaa61045cb20782c565ba4a87de2c53f",
+          "fingerprint": "c9e0915d270d035b82b3df6c8e34f0466a517aeb26df2938cf90a67cd63c5428",
           "file": "src/design-check/index.ts",
           "line": 98,
           "severity": "medium",
@@ -405,7 +405,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "5dee827897cc63fa51c2e3b0cbde2550e70895e565325a051997f35cdefb3609",
+          "fingerprint": "08f504bed4812683de42c6bf96b42656c5480c7f7161a7876dca952f4378f19c",
           "file": "src/desktop/webui.ts",
           "line": 167,
           "severity": "medium",
@@ -413,7 +413,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "58194e7bc494888b57a0a47615d8a7c0029c1ae54de072340b244b51450401a1",
+          "fingerprint": "38ac6603b0d9b1256ae4f9152e467b6e670e6f401924e3c84d3257cba682a3aa",
           "file": "src/desktop/webui.ts",
           "line": 168,
           "severity": "medium",
@@ -421,7 +421,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "b416b975de6114055ed33fa72d09f9d54b56f8d2239ff5c47f49cb07906e6fb3",
+          "fingerprint": "91bde4c2b7b20279b9a43b2a300a191324200a4548d7eff4e2caa27e6aa90831",
           "file": "src/desktop/webui.ts",
           "line": 170,
           "severity": "medium",
@@ -429,7 +429,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "bd4da193988f1ebb3c7b0020d1b0de1d35cead7557d8473d569a944d68ae1625",
+          "fingerprint": "d767fb692ddd3c38f3438627a768c22722686f2af6d8d94a978336e03f3b1a67",
           "file": "src/desktop/webui.ts",
           "line": 171,
           "severity": "medium",
@@ -437,7 +437,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "a2239d8b1b3fd62ad57f930c772c5ebba9399b2ea70fe7de65963f317185e662",
+          "fingerprint": "05eeadc494b238d86e782cb54c833fc020338ce892405031488d278d691eee4f",
           "file": "src/desktop/webui.ts",
           "line": 173,
           "severity": "medium",
@@ -445,7 +445,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "a89d7601739c34acf269afeebb3543705d84a868812fdb8b5f9b0427456d0ab7",
+          "fingerprint": "74d277a5d2e865ab89cb02d1bbf40d0afb0c9cc4402784acf084fe05d946fe25",
           "file": "src/desktop/webui.ts",
           "line": 174,
           "severity": "medium",
@@ -453,7 +453,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "42de0ed6a3e9c4d791b7ef2af355fc6986f43c0132f2eed7dd6120ca44c37ad5",
+          "fingerprint": "05eeadc494b238d86e782cb54c833fc020338ce892405031488d278d691eee4f",
           "file": "src/desktop/webui.ts",
           "line": 255,
           "severity": "medium",
@@ -461,7 +461,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "46eb493a9c5afb5cb459ca9ed93eac89779ee59622a7d24e179c67b43318a771",
+          "fingerprint": "bff0392ffeac8bb9d2598393d4529fdb422a0b00555ea68e479be87a7af034d2",
           "file": "src/desktop/webui.ts",
           "line": 256,
           "severity": "medium",
@@ -469,7 +469,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "df7d70044c211bd7f032590f51b10e0a3d650324041bb1b5ae39a02124166c4a",
+          "fingerprint": "4821b528e1ce5d4c98530e5579f5fe00e375949f7686a27c80af726090b42a72",
           "file": "src/lsp/oxlint.ts",
           "line": 31,
           "severity": "medium",
@@ -477,7 +477,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "50e066fa5c15251c4b1f8246648b813a4ea58f9529ebb54f8b353256b33bbef3",
+          "fingerprint": "dcf7853552ab3cb60c7f1914d150a9d1244e7ee76130b5c601908efad87f5195",
           "file": "src/lsp/oxlint.ts",
           "line": 37,
           "severity": "medium",
@@ -485,7 +485,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "60badab2ec771d687b7586393e3b3a30996d769db3440183d42dadbe03dcc86d",
+          "fingerprint": "74f0a2ebd3b988571a463364f4a40d834c7ff4c943b9216da16761b5959731bf",
           "file": "src/planner/verification/runner.ts",
           "line": 68,
           "severity": "medium",
@@ -493,7 +493,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "60badab2ec771d687b7586393e3b3a30996d769db3440183d42dadbe03dcc86d",
+          "fingerprint": "74f0a2ebd3b988571a463364f4a40d834c7ff4c943b9216da16761b5959731bf",
           "file": "src/planner/verification/runner.ts",
           "line": 68,
           "severity": "medium",
@@ -501,7 +501,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "60badab2ec771d687b7586393e3b3a30996d769db3440183d42dadbe03dcc86d",
+          "fingerprint": "74f0a2ebd3b988571a463364f4a40d834c7ff4c943b9216da16761b5959731bf",
           "file": "src/planner/verification/runner.ts",
           "line": 68,
           "severity": "medium",
@@ -509,7 +509,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "a2b52717bb2d233daaa8e7a5584dca863f146366f976adffc179db3af35b6e41",
+          "fingerprint": "8e839ddea356c58e937fb10f66eb892b7dce26800795afee5f292ae8f974b92a",
           "file": "src/provider/ax-engine/delete.ts",
           "line": 30,
           "severity": "medium",
@@ -517,7 +517,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "521671dd6b7f1e499876234a04f32c43900d08079266a76dbcd7868a35ab2eac",
+          "fingerprint": "feb3c388956e901678fb121a688ac6224685ea9f5d2f40991b40041aab948025",
           "file": "src/provider/ax-engine/delete.ts",
           "line": 64,
           "severity": "medium",
@@ -525,7 +525,15 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "1b114593f482dffafcca54ce43ea01e0dc4207bcc8afa69742cdeeea649f1ff6",
+          "fingerprint": "8a109b64fea1149cc361f9d01642107679b222d1ba8e5ce4b9c6c03b11b240f6",
+          "file": "src/provider/ax-engine/dependency.ts",
+          "line": 44,
+          "severity": "medium",
+          "kind": "non_atomic_counter",
+          "summary": "non_atomic_counter"
+        },
+        {
+          "fingerprint": "7e35300a964f2dfe026057383515bd2f4e87588ebd91a3052e77a4c601a56a08",
           "file": "src/provider/ax-engine/model-cache.ts",
           "line": 127,
           "severity": "medium",
@@ -533,7 +541,15 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "dc800286a6f79e4f203679d224111c4db9b8b673284158191d97abc9dec71214",
+          "fingerprint": "29d3cd9a361e16d75eba534955cc309a0e2c9e980c3c8942674e469676612739",
+          "file": "src/provider/ax-engine/server.ts",
+          "line": 510,
+          "severity": "medium",
+          "kind": "non_atomic_counter",
+          "summary": "non_atomic_counter"
+        },
+        {
+          "fingerprint": "d40653244fe56619015e50d71cbd2d26501581d124f415d1d8907a9fa2f9fb11",
           "file": "src/quality/pr-diff.ts",
           "line": 64,
           "severity": "medium",
@@ -541,7 +557,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "c5ce408593c600dae16c40872bab890ea5520a4740cff6d825c2409a6fc7b6e3",
+          "fingerprint": "3ddfb144004f8561d841fad870fd33a35f3191cf24799e9f2da394c5ec518148",
           "file": "src/runtime/headless/event-sink-node.ts",
           "line": 36,
           "severity": "medium",
@@ -549,7 +565,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "ce0d95df1f8bf318ae3cba343dafe7fb605a964d59ba48e0c52c7d4ca4dba6eb",
+          "fingerprint": "19fdfdb6c737412902c3061a886f07579c3c70e6a9be334555015eace9cbd4f4",
           "file": "src/runtime/headless/event-sink-node.ts",
           "line": 37,
           "severity": "medium",
@@ -557,7 +573,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "9026a9a01e598b65ac09df0008193d2f312c58c06c07e8195de164b600c8a4b4",
+          "fingerprint": "0c47728cceea6ae7afba16c7a5fc77a5d141bbb98bd6d263eb096812bf0d3ff2",
           "file": "src/runtime/headless/event-sink-node.ts",
           "line": 57,
           "severity": "medium",
@@ -565,7 +581,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "c1d4ec3db840ae399a708b02cf12fddf220f028d62a53cdbc643776725b37fd8",
+          "fingerprint": "19fdfdb6c737412902c3061a886f07579c3c70e6a9be334555015eace9cbd4f4",
           "file": "src/runtime/headless/event-sink-node.ts",
           "line": 58,
           "severity": "medium",
@@ -573,7 +589,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "a3acf85d4d4c3cb0445731868c8ce5dd908389fa63518c9d3e1e20293fb90899",
+          "fingerprint": "201978cf6522b40aa14d142052a1dc46708c7081236c3a2b20fe97baa6b09f74",
           "file": "src/server/ipc-protocol.ts",
           "line": 69,
           "severity": "medium",
@@ -581,7 +597,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "d28d4d10088ee6feaebd318815c02daa1628c3510de765c31e5aa015f39ab004",
+          "fingerprint": "dc8f689d4bfe63384c8619afb313b2f48931482449276672be173b63428acf2c",
           "file": "src/server/ipc-transport.ts",
           "line": 54,
           "severity": "medium",
@@ -589,7 +605,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "1c7f4b39c26b08206b5c9eff9531490d3c35f6426d66e41e421f2d98ebbbaf86",
+          "fingerprint": "d44623bac8ca36d03387ee3dab4cd1f7d174ea25e9a2fa1b22e68bdc8b712e9e",
           "file": "src/server/ipc-transport.ts",
           "line": 295,
           "severity": "medium",
@@ -597,7 +613,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "e4ab700510c2995b156888d359954c671a03f3028668c8c6fd5f99654653cf11",
+          "fingerprint": "d402e05e733d5a7e907d657b8387a67cf170d784b5b8735c89384f0d4204db2d",
           "file": "src/server/ipc-transport.ts",
           "line": 306,
           "severity": "medium",
@@ -605,7 +621,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "04dd602afb2f8fd23aa8e4c20737750352103f3977d23144304ff59ac24e746b",
+          "fingerprint": "bfb7d19789bd1671a43dfa388db6c20893fb99fdb315ba13f31cbf4e082e477a",
           "file": "src/server/runtime-adapter.ts",
           "line": 150,
           "severity": "medium",
@@ -613,7 +629,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "dbf6f7c6d136e2de92af4f99f6ca0bd2d56500d313c4e70160c3ba71c699c14f",
+          "fingerprint": "4d267cdc98d48bfb47e6177e84099b329d73542923471de8a03cf2f9732c2fcd",
           "file": "src/session/prompt-goal-command.ts",
           "line": 99,
           "severity": "medium",
@@ -621,7 +637,7 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "cb995c5bd5a9e5df57f29af1e189926dba98ac4ce82d8b6747a76323f62432e6",
+          "fingerprint": "fb1d933bdfcd8d5db130889a83678bd50acfe692e687907ebff8d5eaf0e10591",
           "file": "src/session/prompt-shell-command.ts",
           "line": 187,
           "severity": "medium",
@@ -629,7 +645,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "92fa8f7adf67316b2b87cb08394b9f33107a17ca885036ddbdc8349ca6b8b92e",
+          "fingerprint": "672657514d4273d76b161f53816945efef8a96f8783ec7ff25059006e9fba807",
           "file": "src/session/prompt-shell-command.ts",
           "line": 236,
           "severity": "medium",
@@ -637,7 +653,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "6274fe700df509f511266858057e9456b2788436ff16c5f02a5f7aceaa18c402",
+          "fingerprint": "70aea89ecd7a41d9eaeb71f56b218cef98f3fed5b4485866e31c942d3e147536",
           "file": "src/session/prompt-shell-command.ts",
           "line": 241,
           "severity": "medium",
@@ -645,7 +661,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "8225a18be91d0b3f7a69325fc53f71e1685e39d903ae0ccf5e7425c293c9fc5e",
+          "fingerprint": "643af2792e448e5b3006e2ad5079f9406fbb91442041339f37fd54ba85ae6e99",
           "file": "src/session/prompt-shell-command.ts",
           "line": 253,
           "severity": "medium",
@@ -653,7 +669,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "d42fb54be755948537c8277061b45a696a86392d2ce4968c4a9a57af370508a9",
+          "fingerprint": "abb09fa059b2fb0d2bf88b995eee101805c281d98bf187ccd6f988a733921e65",
           "file": "src/session/prompt-shell-command.ts",
           "line": 261,
           "severity": "medium",
@@ -661,127 +677,143 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "2d4b53ebbdae3fa61278178d7398ee68a8677852944a80176c8621a11c32bf57",
+          "fingerprint": "7cf5cae2fabb1fd72cabc3f395d6bbb37aeeb17f9f0f31986415aa070960385e",
           "file": "src/tool/bash-impl.ts",
-          "line": 350,
+          "line": 351,
           "severity": "medium",
           "kind": "non_atomic_counter",
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "2433d486fc8298c1118e5f484f97eb12190d5f1dc50a57900eb9976f3c68bd5b",
+          "fingerprint": "4ef5f0c251dc147636531b7931f2297d9b40bccf5cc65d7635cbf70b34ac2736",
           "file": "src/tool/bash-impl.ts",
-          "line": 382,
+          "line": 383,
           "severity": "medium",
           "kind": "non_atomic_counter",
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "03974994fe2456f34f644184681c72ab45877045324e4bdfe5c428aea4442705",
+          "fingerprint": "7cf5cae2fabb1fd72cabc3f395d6bbb37aeeb17f9f0f31986415aa070960385e",
           "file": "src/tool/bash-impl.ts",
-          "line": 392,
+          "line": 393,
           "severity": "medium",
           "kind": "non_atomic_counter",
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "559f1dd93355f5b8bb878ba2f7e00245c8e449b12dfc4994e59858493c021d9c",
+          "fingerprint": "ca93f1cef8a51124444bc28773908c2a7a07d262420085ef9fe9dc6a56735214",
           "file": "src/tool/bash-impl.ts",
-          "line": 430,
+          "line": 431,
           "severity": "medium",
           "kind": "non_atomic_counter",
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "35391a78ff4dc14421f637982c8f6e11baa5f833a7707ca5206fc17a489b3cf0",
+          "fingerprint": "a4623bfd2301bac8c740b18295a9b6618677d77d922fd8a7e1466d6372899ada",
           "file": "src/tool/bash-impl.ts",
-          "line": 502,
+          "line": 503,
           "severity": "medium",
           "kind": "non_atomic_counter",
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "0a5eebb1a03dd445ff820acba7207403e49065db32a73e7d58d4eb074979476c",
+          "fingerprint": "a40e0bc5fead8009f03a4b787b6998c709b84e06ec53970dcef5f9fc4f66dbc7",
           "file": "src/tool/bash-impl.ts",
-          "line": 577,
+          "line": 578,
           "severity": "medium",
           "kind": "non_atomic_counter",
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "e69c38c821bf50ed4d18a6f3d9ce3666da1d9bbd514fc23f2d7f675af4be9f38",
+          "fingerprint": "ca93f1cef8a51124444bc28773908c2a7a07d262420085ef9fe9dc6a56735214",
           "file": "src/tool/bash-impl.ts",
-          "line": 612,
+          "line": 613,
           "severity": "medium",
           "kind": "non_atomic_counter",
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "45725f23f9f7777282bf25160fd1cfe65e9326b423c4ec3123657d179f14dbf4",
+          "fingerprint": "616e9a85a1ac74bf4aa42b2a1c21026a7b60731d4a70f92544fded017a54af78",
           "file": "src/tool/bash-impl.ts",
-          "line": 793,
-          "severity": "medium",
-          "kind": "non_atomic_counter",
-          "summary": "non_atomic_counter"
-        },
-        {
-          "fingerprint": "318d8c7823895b711fb8b31158a27e75cd2c589b3011d408d64ea8f027ae3bb3",
-          "file": "src/tool/bash-impl.ts",
-          "line": 799,
-          "severity": "medium",
-          "kind": "non_atomic_counter",
-          "summary": "non_atomic_counter"
-        },
-        {
-          "fingerprint": "b81acca6872a30d3d6bb8fdcf9753c14e35bdd679a8c6899455a238d6c7387b7",
-          "file": "src/tool/bash-impl.ts",
-          "line": 802,
-          "severity": "medium",
-          "kind": "non_atomic_counter",
-          "summary": "non_atomic_counter"
-        },
-        {
-          "fingerprint": "a5334dd1a73a00a207b2e7f816a13933f7fdd76ee9a423732f74c44b639e0c65",
-          "file": "src/tool/bash-impl.ts",
-          "line": 832,
+          "line": 771,
           "severity": "medium",
           "kind": "stale_listener",
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "90efbff4e43cab3e8beaf4231a3439225e2c1fa9e34e7cc7f67958bee9470d29",
+          "fingerprint": "7ac7861499fb5659192755521a995cb986131131d27df7ee50928f79b8ce6e9e",
           "file": "src/tool/bash-impl.ts",
-          "line": 855,
+          "line": 772,
           "severity": "medium",
           "kind": "stale_listener",
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "65ea440a006bcb86909aafbf367ef2d84a9ab425f0953ad4061e2a81feef5f4e",
+          "fingerprint": "47dd40928aebfd8688f22e7371ad500b3ed4a3e9730e6367514a42ec182a98af",
           "file": "src/tool/bash-impl.ts",
-          "line": 869,
-          "severity": "medium",
-          "kind": "stale_listener",
-          "summary": "stale_listener"
-        },
-        {
-          "fingerprint": "1b61753a2f5ef4977f52d4c7fd22485bed5a84e994f62869a90c502ba1ebefdd",
-          "file": "src/tool/bash-impl.ts",
-          "line": 874,
-          "severity": "medium",
-          "kind": "stale_listener",
-          "summary": "stale_listener"
-        },
-        {
-          "fingerprint": "2df224531cee9862d904f8f7e2c4ddb474c969ebc6cb13d500e6ee4411da81cd",
-          "file": "src/tool/bash-impl.ts",
-          "line": 901,
+          "line": 836,
           "severity": "medium",
           "kind": "non_atomic_counter",
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "9b77677e48b4365f3c82d2897be7d2cf5091a9e0d443b9ff69816a02d9d5511f",
+          "fingerprint": "58c9ca32d3401a451d6c61084e3692056db0bffb1741d4f42bef087255069a27",
+          "file": "src/tool/bash-impl.ts",
+          "line": 842,
+          "severity": "medium",
+          "kind": "non_atomic_counter",
+          "summary": "non_atomic_counter"
+        },
+        {
+          "fingerprint": "0b8fbd647b476533829aedd18dd9a40e2fc7ba4180a7502defa0b8cc36658ccc",
+          "file": "src/tool/bash-impl.ts",
+          "line": 845,
+          "severity": "medium",
+          "kind": "non_atomic_counter",
+          "summary": "non_atomic_counter"
+        },
+        {
+          "fingerprint": "b6ccd991efa86426087f6ba13ff4e83712d6ca771983e62f3a71feaca628587b",
+          "file": "src/tool/bash-impl.ts",
+          "line": 875,
+          "severity": "medium",
+          "kind": "stale_listener",
+          "summary": "stale_listener"
+        },
+        {
+          "fingerprint": "6fa902c9ef2e19fef4950c3cb389c828b2c25d063b008fac5c59728669fed0c9",
+          "file": "src/tool/bash-impl.ts",
+          "line": 898,
+          "severity": "medium",
+          "kind": "stale_listener",
+          "summary": "stale_listener"
+        },
+        {
+          "fingerprint": "c07b490b40e828a68cca6bdcd2c78f4c0541794987facbafdaaa5823e50176eb",
+          "file": "src/tool/bash-impl.ts",
+          "line": 912,
+          "severity": "medium",
+          "kind": "stale_listener",
+          "summary": "stale_listener"
+        },
+        {
+          "fingerprint": "d06989df56dc6957119f0a631d5c65722afbd4be54f36afbf614bd98c7ef6fc9",
+          "file": "src/tool/bash-impl.ts",
+          "line": 917,
+          "severity": "medium",
+          "kind": "stale_listener",
+          "summary": "stale_listener"
+        },
+        {
+          "fingerprint": "93d7561899b25fb58ea8a1ea18bcd926f31fe14d7ead3624726473d529cd31c7",
+          "file": "src/tool/bash-impl.ts",
+          "line": 944,
+          "severity": "medium",
+          "kind": "non_atomic_counter",
+          "summary": "non_atomic_counter"
+        },
+        {
+          "fingerprint": "841d86ebaf05845c8ae923856a9937029b9bf6fc54e944b8e86b17fc54fda511",
           "file": "src/tool/read.ts",
           "line": 389,
           "severity": "medium",
@@ -789,7 +821,15 @@
           "summary": "non_atomic_counter"
         },
         {
-          "fingerprint": "597da86460b59a5b3a1c32c6c7a89be27bc2539177055fd32c926323812eaa8e",
+          "fingerprint": "2ee3d64b2690803e99c4db5908875b6b173bbc2affb555ccc73b288514941dc8",
+          "file": "src/tool/task_parallel.ts",
+          "line": 94,
+          "severity": "medium",
+          "kind": "non_atomic_counter",
+          "summary": "non_atomic_counter"
+        },
+        {
+          "fingerprint": "b9d9a04724b36a10ee233d083096f7cdff3da08fd2d7be1114991c6f1f3628d0",
           "file": "src/tool/task.ts",
           "line": 127,
           "severity": "medium",
@@ -797,7 +837,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "dfa709cd7764efd6fc404837727c415362db4cc0a64c12756154ff5dbc2f7819",
+          "fingerprint": "a95f1ba3de560b3ffe2d2d7f53c2aa142aa03cf5ab1a6f97d922360e4adfb23e",
           "file": "src/tool/task.ts",
           "line": 129,
           "severity": "medium",
@@ -805,7 +845,7 @@
           "summary": "stale_listener"
         },
         {
-          "fingerprint": "56b69675c6214cbf1b37056e38ec5b36f48b0fd5f4fbaa0874c574965d553b28",
+          "fingerprint": "9268060b698b62af7ceb5ecc6a168a2833ac61336048bc082d91432bc08a76ae",
           "file": "src/tool/task.ts",
           "line": 142,
           "severity": "medium",
@@ -815,10 +855,10 @@
       ]
     },
     "lifecycle_scan": {
-      "count": 188,
+      "count": 189,
       "findings": [
         {
-          "fingerprint": "030c87b86efa17dba640e6927ec8a4ef6f9532dd4790bb566afbc3794cd0767c",
+          "fingerprint": "988fc40c0ae29463c01aa66d00474a79033c16bb47b846775fe9a251acb59cbf",
           "file": "src/account/index.ts",
           "line": 143,
           "severity": "high",
@@ -826,7 +866,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "53f9d538ad923015588d48c07f304a5a0fef717b8f59ac2d817fe6e832c38692",
+          "fingerprint": "d77017c3464f0519403bc9f98c3a2b34ba8213297cb1acf78a37babfdd4aa763",
           "file": "src/cli/boot-node.ts",
           "line": 36,
           "severity": "high",
@@ -834,7 +874,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "81f74e044d6f7a4297fd18abf0214b2856f87376bd2a4d6812ba41169417c4c2",
+          "fingerprint": "139bd6e0419ca024fda87bda08a45547a58ebed712c7259c6c808b84eaf05b37",
           "file": "src/cli/boot-node.ts",
           "line": 54,
           "severity": "high",
@@ -842,7 +882,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "8cbdbd4935e2e7475a9059a4706effcdd8934300eec87b8328efd22c61b5fbe9",
+          "fingerprint": "4694eee925be7e402f9109831225e040e8826425f838f82e2dc5293ea1097d3f",
           "file": "src/cli/boot.ts",
           "line": 126,
           "severity": "high",
@@ -850,7 +890,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "91097dc35222c8106a403568f096a17d69715373d2d1a300aabf3962db301bf9",
+          "fingerprint": "011375d5ca98bbf6180580718ed14802b80ec9f114d05d92d0285698610de733",
           "file": "src/cli/boot.ts",
           "line": 137,
           "severity": "high",
@@ -858,7 +898,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "8a3eb31b42d5b89a3faf9c8f6f52b5e0ce147385156ba229d8fbf12f0e9a4cbe",
+          "fingerprint": "3aaf4293b754bb0ed0bdb1082df9627320c3b8d8bc775f8f80091639ab66d0f2",
           "file": "src/cli/cmd/branch.ts",
           "line": 30,
           "severity": "high",
@@ -866,7 +906,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "7d37d28853a454082d7dab81aeba2764358002616e2351045293893a30980452",
+          "fingerprint": "d9abcdd41bf1582f1ced261814673baa89aab6161301179a2f9d3ddec1f6c1c0",
           "file": "src/cli/cmd/debug/index.ts",
           "line": 39,
           "severity": "high",
@@ -874,7 +914,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "97059a59a93e939a50408c8743497c50752d2272efcf99352fd74341ef09203f",
+          "fingerprint": "69495a037fae23f4d5d15aa9ae0644c33d77463b69800a67ba8fb2ab5be984d8",
           "file": "src/cli/cmd/doctor-health.ts",
           "line": 183,
           "severity": "high",
@@ -882,7 +922,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "a27390b7112a30e2da4234a57c8f77a67f11e19ad0147e6032948a213fee81b0",
+          "fingerprint": "77c4fc0655ac2616ef28efe8c6a09ce54c73fe8ba2a61491bf3aff374e69d3ec",
           "file": "src/cli/cmd/github-agent/install.ts",
           "line": 143,
           "severity": "high",
@@ -890,7 +930,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "4527a4ba6f5a0fde53ca9fb6c715b4c9976822520a0994d3cb38fefc0e579c28",
+          "fingerprint": "b9fd4688e563a47bb7c4087ce53c3292407bf0febecc738878618c7c07486e56",
           "file": "src/cli/cmd/github-agent/pr.ts",
           "line": 133,
           "severity": "high",
@@ -898,7 +938,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "43720710761b827f6da06fdb1425470359eb924c47449426196cf56800c8f960",
+          "fingerprint": "705011bdb911e8664c4ea40027766208b29afee3c7c3f5127e0c06dffbda723c",
           "file": "src/cli/cmd/index-graph.ts",
           "line": 654,
           "severity": "high",
@@ -906,7 +946,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "09aa0ed6d486d390984175cb47fdd234fb64a5769170234c176b80a54d8fd6b6",
+          "fingerprint": "3df915487f29e7b27b1dc38e6f74d1d607ea8f62374438c7c8627cafcb908b5b",
           "file": "src/cli/cmd/index-graph.ts",
           "line": 659,
           "severity": "high",
@@ -914,7 +954,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "5f86b8df9b62e7fa21e5b94466f38c6b49b1030cd9d8633ab7af75dbbdf4e128",
+          "fingerprint": "44b4446d901a159a3c80832efab1baf34962825e5aa728729218a0641f9bc858",
           "file": "src/cli/cmd/release/check.ts",
           "line": 465,
           "severity": "high",
@@ -922,15 +962,15 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "bbdf0f1f2a01658465995de6f198550de497aa0045d973e65d51ca9842793a19",
+          "fingerprint": "a3f418ecd687e764958602cd21d51259689d9a66bec12bdf3431e77bb50bfff8",
           "file": "src/cli/cmd/run.ts",
-          "line": 482,
+          "line": 483,
           "severity": "high",
           "kind": "child_process:no_cleanup",
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "2e8b98fee5aaddd0b06f08a51d846d5318ccec26a500c092731e64949efbe27e",
+          "fingerprint": "0d32bc72f5c452849db4e17e0f3c37f7227795f8d35d5c21703c56b1245b6339",
           "file": "src/cli/cmd/storage/session.ts",
           "line": 439,
           "severity": "high",
@@ -938,7 +978,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "7863cd1a2290a52317e8dc022a8d277536036895c1e62592eea942c28244cecc",
+          "fingerprint": "44b61f10a2521187003a63055086e8e8d97444de7f45362d37f855573db0421f",
           "file": "src/cli/cmd/tui/terminal-cleanup.ts",
           "line": 79,
           "severity": "high",
@@ -946,7 +986,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "1671acd291b49f75f0fba52312751b23ebbabfbdc3da0028042a48e076ed84c3",
+          "fingerprint": "b2bd7feb5db432777740b0c39043dafc7637c8fb2536e26acc714268e497d975",
           "file": "src/cli/cmd/tui/worker.ts",
           "line": 86,
           "severity": "high",
@@ -954,7 +994,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "688d4c296009ccecb73d819a146b2c866d8621ff247b94b53aa7af8d75d5f4d8",
+          "fingerprint": "c230626cc75225950cf2694c041c9de3dc36a0fbdedf15cb5fde2b69c0fff390",
           "file": "src/control-plane/sse.ts",
           "line": 112,
           "severity": "high",
@@ -962,7 +1002,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "be2619fa206da9698661162f4c9755ea715ba9dd085e105852790968db22cdbb",
+          "fingerprint": "6647c3866e353ab14151d1604db83f92f64e629a1ba6c84cc7455639f9e08142",
           "file": "src/debug-engine/detect-hardcodes.ts",
           "line": 113,
           "severity": "high",
@@ -970,7 +1010,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "1ac1c24a7f1d89a06bfd33474fc0f37716051774d22f514859f84482813a1360",
+          "fingerprint": "a7e2e9e583e89e226e9f030c81193279e5c8ff8989388285680cfbdab363ae40",
           "file": "src/debug-engine/detect-hardcodes.ts",
           "line": 140,
           "severity": "high",
@@ -978,7 +1018,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "c970f748496db86702a377f9d5daebc59357d42eb60bf74816e6f77395077cff",
+          "fingerprint": "4de12d5af148bc11c73de2758bea89100cf83cf018f86bc0f34ad33a7bb92f4d",
           "file": "src/debug-engine/detect-hardcodes.ts",
           "line": 154,
           "severity": "high",
@@ -986,7 +1026,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "cfc8ef3837d365bc5ac83955c6c4aff61b5a64f74f235438a04eaa7c901cb4ea",
+          "fingerprint": "7450084ebe371ded8bf3a9030e9cd96dce7c1485eddb59c1d19256871c6cf384",
           "file": "src/debug-engine/detect-hardcodes.ts",
           "line": 210,
           "severity": "high",
@@ -994,7 +1034,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "2aae6af7c7f0f58ef19beed190dbb744a35a30ad745003e58ff42c9e5bc7fd18",
+          "fingerprint": "d4c5a38f78bcfecb6c4f3358fd0b12eb5ca49f23efa2423d8c5b15d10062f055",
           "file": "src/debug-engine/detect-races.ts",
           "line": 217,
           "severity": "high",
@@ -1002,7 +1042,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "bd70d6fed628ab91fa66759f96627f29c5a1f31f4eeb149ac1f7db3aa1320ee3",
+          "fingerprint": "67ad1e5925c8509e075f257d3b0ea82d923a7e9f91e6e2245693178600074be7",
           "file": "src/debug-engine/detect-races.ts",
           "line": 247,
           "severity": "high",
@@ -1010,7 +1050,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "2402349bbd348f7188202253c7136f64712048c36da054fbe63a1652b9c9fa1f",
+          "fingerprint": "d22a06df05dfcf16ee9ad0a13461e164f260b1a87e2c92ec896d15626613f259",
           "file": "src/debug-engine/detect-races.ts",
           "line": 291,
           "severity": "high",
@@ -1018,7 +1058,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "f16a11dc05c2c78161cd8aaf43f04402616d5f9698b7ac71fab1fcf714288b0b",
+          "fingerprint": "29fbbb57f5b8e312aff35d1c0da1ef57663c7c26ad3c3d0028b82ef0dda6937a",
           "file": "src/debug-engine/detect-security.ts",
           "line": 55,
           "severity": "high",
@@ -1026,7 +1066,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "d8788943b324db66bfcbfd4efc7c90648b021b5a07ca3ed8782f02e30bdfbb91",
+          "fingerprint": "a000d89ad5e16831c674d6f33b7bcc2192fc763d6aa691e56922eee8211e1d64",
           "file": "src/debug-engine/language-scan.ts",
           "line": 421,
           "severity": "high",
@@ -1034,7 +1074,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "f779d65483293d3682263f1d58455e6b03d3b53b9d263932154ad2c4d8da7472",
+          "fingerprint": "84cd7511015c46967d2a7f74f9f29c17e86e03a243fdac2a6e8eb6c715cdc859",
           "file": "src/design-check/rules/spacing.ts",
           "line": 26,
           "severity": "high",
@@ -1042,7 +1082,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "8b38299a7bbed56175d313364eee13a93e4462fd023e1e45a03dd8051feb5ca4",
+          "fingerprint": "e22363f43e5354c3d6ea288ce2a3250b8050f5cfbb5088a6b3debcd124617918",
           "file": "src/format/formatter.ts",
           "line": 33,
           "severity": "high",
@@ -1050,7 +1090,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "a31c2dbdeb958ddeb44fef76791694353e857de0894598b439c7f590d8c265a1",
+          "fingerprint": "d7d04e2b73d0ec1208cd9f25c6015eadf45c0aac97071aa10244cd697e32ae22",
           "file": "src/lsp/oxlint.ts",
           "line": 25,
           "severity": "high",
@@ -1058,7 +1098,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "03d092059b8dc2acfbf1dc5e2b535be594c950184a03851c3f7ed124bece9c7a",
+          "fingerprint": "aad6551f9c024446c509cce8892a35118da8e83539c28e45268988f00925c280",
           "file": "src/lsp/server-defs/jvm-llvm-servers.ts",
           "line": 307,
           "severity": "high",
@@ -1066,7 +1106,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "716c9e7095917c4619f582bbffe12cb8ffc6fec18171a0cbbd7e66ad8f8233e0",
+          "fingerprint": "9d0835b321c3815232cba16439496ff86d8b3b5cd71b104562463114bdc257d4",
           "file": "src/lsp/server-defs/other-servers.ts",
           "line": 68,
           "severity": "high",
@@ -1074,7 +1114,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "c12f812f1fb05da791b2e82b9b71823bd1d189273f5a845e5ab3df9339b340bd",
+          "fingerprint": "deb2e3cf3808fde0146edf253ee56b194a869ed6d6e3afb6e5ef685c77573171",
           "file": "src/lsp/server-helpers.ts",
           "line": 141,
           "severity": "high",
@@ -1082,7 +1122,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "2295df892d6fea25b33224dfdf97ceffdfb229ec6a19ee15746502c947532d0d",
+          "fingerprint": "0440e563ce09322ea263a5b7a6dfc08038b292b40c63572f11adefdf4bee497f",
           "file": "src/lsp/server-helpers.ts",
           "line": 160,
           "severity": "high",
@@ -1090,7 +1130,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "abc9f07624996d693abcb21d3082f07b2c1a0ac314110b6a4606688ec9b0c8c6",
+          "fingerprint": "d860c3e7e323edee8bfc06c297a20cd632f95dc893084cc67dbf0f2713be9790",
           "file": "src/lsp/server-helpers.ts",
           "line": 185,
           "severity": "high",
@@ -1098,7 +1138,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "9b2a8b21caa1dd3001063c9ef0f2197fd3e1c9954897a7691005f4bafe4d30fa",
+          "fingerprint": "9ed3571a17bbfd53f2b19cd0f2316d55598bde6114f97175c42b9dba4606f6e0",
           "file": "src/mcp/discovery.ts",
           "line": 69,
           "severity": "high",
@@ -1106,7 +1146,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "07dd18317bc02488064d48d5de290a850c64c425a2aa9314d3091164505991c1",
+          "fingerprint": "984bb314e3fc1f9cd9764f85a9e60ae0488731b7b783e5f136b24232f4bb2216",
           "file": "src/planner/verification/index.ts",
           "line": 213,
           "severity": "high",
@@ -1114,31 +1154,31 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "32bb9d1026485797f06102d8aeb525624681658462256748b451205838c37a6a",
+          "fingerprint": "eb9262e63234254c65022b56f40eb4bd20816c31faaa928f64564ec930cc65a0",
           "file": "src/provider/ax-engine/server.ts",
-          "line": 152,
+          "line": 156,
           "severity": "high",
           "kind": "timer:no_cleanup",
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "043d68fab725f22314a6accabe5bb0363468548d65d38b811292b003079f918e",
+          "fingerprint": "d59deefdfb2a0775af8aa7e7fbc8e74e490a80b77680ad2a113b24afbffbf8a7",
           "file": "src/provider/ax-engine/server.ts",
-          "line": 294,
+          "line": 299,
           "severity": "high",
           "kind": "timer:no_cleanup",
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "1fa93cf877297260a9c209be60bab2901a54953c24f5b2282a0b7c87edf62bc1",
+          "fingerprint": "205ae80d3cc4e55b0beadb36e9dcbe9cf42c44a6063964169019dfc79874e990",
           "file": "src/provider/ax-engine/server.ts",
-          "line": 494,
+          "line": 503,
           "severity": "high",
           "kind": "child_process:no_cleanup",
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "f04f204173de57ede8609f8cf28f427a06de38c73b82a6d836f708501202d1b0",
+          "fingerprint": "5f110f690e9084a2ff5e7f1cc3cb54f1fc1c4bd69007b3c15b0ff159f74b9fce",
           "file": "src/runtime/shell-env.ts",
           "line": 35,
           "severity": "high",
@@ -1146,7 +1186,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "8d2a8a52212ac884a02f594829ff5083479772f5bdcae171235ab6cd0b889108",
+          "fingerprint": "8a4d9b83635380d36e2f7143be0bd2b589577e10e1c22d3f5ac3cc6fc855dc6d",
           "file": "src/sdk/programmatic-impl.ts",
           "line": 877,
           "severity": "high",
@@ -1154,7 +1194,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "a897cf68fa9b17b36e841598697b47b49a0c391bc77c8182add72a2791eaaebb",
+          "fingerprint": "20a058455668657087758f1cfa61361a819d64fa46151c6755afd1ec252ed3be",
           "file": "src/sdk/programmatic-impl.ts",
           "line": 879,
           "severity": "high",
@@ -1162,7 +1202,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "914a260ab9448608f926e7123219ee21e73ce9088241a976db44d95d1f8fb67c",
+          "fingerprint": "945d0b0e17609bc7beb8f6ccf5353ed3622248895c89423107d1dffa575ebf92",
           "file": "src/sdk/programmatic-impl.ts",
           "line": 957,
           "severity": "high",
@@ -1170,7 +1210,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "5e75aaf446d57d58256d0f0353b7a54b8abf0eee1603c8e545114b7e13eb81a8",
+          "fingerprint": "bde8e6a3df672844597095db6ecc6713072117ecae5fe6c802a9209f8d557124",
           "file": "src/sdk/programmatic-impl.ts",
           "line": 1041,
           "severity": "high",
@@ -1178,7 +1218,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "fce38581b01889ca3769d627332f04aa19fc1f0b6c17eb15b5dbb05351d7a074",
+          "fingerprint": "6b0fba9f6dea10d3f0052034d08fb1fd4d05fae0c7fc582e226db3f149f407c7",
           "file": "src/sdk/programmatic-impl.ts",
           "line": 1054,
           "severity": "high",
@@ -1186,7 +1226,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "b1b2c92df1f827b291db928243050f9919339a19c8779866e868d5265750b144",
+          "fingerprint": "4a08109fa25222d5cebf4ae916c230108fbdf9f36da4aa2c586890d57f154477",
           "file": "src/server/routes/session-impl.ts",
           "line": 894,
           "severity": "high",
@@ -1194,7 +1234,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "7742fdb4dd2ba914359349d34fa8f7dad7ccc80ba86e6ccafc8677037fcd49e9",
+          "fingerprint": "c4bf20d00bde73f20e1b97bed2495be109749f4e2729d63ffd6f1ee492c853aa",
           "file": "src/session/prompt-goal-arguments.ts",
           "line": 27,
           "severity": "high",
@@ -1202,7 +1242,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "6fcd8c09c7d0c4cf12d82dd4378477e077ec20cae8be726a2c5096ba6fd72d9f",
+          "fingerprint": "6eadeab55f818015517e7489f9a4ac8bce393fb7a5f107b35d46f631d5411a19",
           "file": "src/session/prompt-shell-command.ts",
           "line": 82,
           "severity": "high",
@@ -1210,7 +1250,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "22e29e24948f996fe2a46d11f8fde150f02996d2ca8b79baad3610ad537964fd",
+          "fingerprint": "018c1ffbafa611aed7204e99c38526bd8aaddf6c80ed2251808f63e65357374a",
           "file": "src/session/scheduled-task.ts",
           "line": 666,
           "severity": "high",
@@ -1218,7 +1258,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "e45ad939c4debbce350cd500c1abce0c17f35dbf60373d18acf87079d8ddd144",
+          "fingerprint": "8ac39a134080b8adf35936c4121eca7bf8f13b01b97b22a4bab528dda8f4aa56",
           "file": "src/session/scheduled-task.ts",
           "line": 675,
           "severity": "high",
@@ -1226,7 +1266,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "26be501a39bee0928daa517df691292dd71439fc6002a27adb57b54238ba0753",
+          "fingerprint": "cbdb584bc0df78a2b4941e2cc21f0b91e03df74dec3ae981bbb586ed8c8a5e6e",
           "file": "src/session/scheduled-task.ts",
           "line": 697,
           "severity": "high",
@@ -1234,7 +1274,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "d733a3bab053b20cbb8973e9cf1de7ace437ca489739abd82105d7a1090dc43d",
+          "fingerprint": "518cc9d61c28608b7333fa465dc8aaa72bd304c6a104173c0c875790d73c3e5c",
           "file": "src/session/task-queue-executor-impl.ts",
           "line": 199,
           "severity": "high",
@@ -1242,7 +1282,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "ae6eda06913d6ab1f451f5714446912d2234319a9ba030ba1e23863f5bcd743e",
+          "fingerprint": "545668efcf2713957893c05507526c15a8680d75d4cdeb4d88909cbc440deaf6",
           "file": "src/session/task-queue-executor-impl.ts",
           "line": 290,
           "severity": "high",
@@ -1250,7 +1290,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "aafd20d449d2a690851af0fc117dfdb08f7097a83f01b2aceb356873fe53f495",
+          "fingerprint": "a0a9180c586e30509f1c482768e6186475549a782044bfcf6f43ff875cb61fd8",
           "file": "src/storage/json-migration.ts",
           "line": 6,
           "severity": "high",
@@ -1258,31 +1298,15 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "13cf0f5da5d3889ee18c1302dfb059db12bf8841b3beed968e889d7f126e8196",
+          "fingerprint": "099ffe1ff6961959a830125a5c0a43a27658be53506ea848d32e441fb8300b63",
           "file": "src/tool/bash-impl.ts",
-          "line": 162,
+          "line": 163,
           "severity": "high",
           "kind": "timer:no_cleanup",
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "7463aa5ea2b0df670d90a183c5d822df4113f6b16e8e7dd74541e9252d88f1f8",
-          "file": "src/tool/bash-impl.ts",
-          "line": 703,
-          "severity": "high",
-          "kind": "child_process:no_cleanup",
-          "summary": "child_process:no_cleanup"
-        },
-        {
-          "fingerprint": "e52b00fdd8098aed9bc1cc459f397400d9ec2512e9604d669461e97415eaf515",
-          "file": "src/tool/bash-impl.ts",
-          "line": 712,
-          "severity": "high",
-          "kind": "child_process:no_cleanup",
-          "summary": "child_process:no_cleanup"
-        },
-        {
-          "fingerprint": "78f067615ba6db64c94181c1833720af36ba47f685695443d3cfd2b9fa6b6033",
+          "fingerprint": "a5cca76fee89225319b14ba89e06204565a0e3a65d07ad7a566783519ecd883f",
           "file": "src/tool/grep.ts",
           "line": 167,
           "severity": "high",
@@ -1290,7 +1314,7 @@
           "summary": "child_process:no_cleanup"
         },
         {
-          "fingerprint": "82ae337e53c84b0ab9acc6826e7ed978eab51a43125807065f1e6e95ab6b21f1",
+          "fingerprint": "672a2032b54b5023298f5c4a3eb3f35075dc47a2e082d63c01f34766fd6e5dd6",
           "file": "src/util/timeout.ts",
           "line": 5,
           "severity": "high",
@@ -1298,7 +1322,7 @@
           "summary": "timer:no_cleanup"
         },
         {
-          "fingerprint": "6331f9eb26ec962c3a06d8313fd2874d33df8ecbba845e04c1e76c53b7ca6d02",
+          "fingerprint": "84b63d6224694e78aeb25890ef4119d3d9f96516fc1419a17094e2f5b2f09b74",
           "file": "src/cli/boot-node.ts",
           "line": 42,
           "severity": "medium",
@@ -1306,7 +1330,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "410632ef6def25939aa03c9adc0d5964c05228dcb952b249a389e13c734950be",
+          "fingerprint": "49c267b408e4dc27b0a1852b07d601962ec206092fd63010b5d3b095dd097ccb",
           "file": "src/cli/boot-node.ts",
           "line": 43,
           "severity": "medium",
@@ -1314,7 +1338,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "990d33cb7cb1309b7e6e9312d23f7ee2e6327fe505e609d982bfdf1d16d6eda4",
+          "fingerprint": "62ca379c82fd5629e0de7f047bf23fa615df75c4859feab358d265cdd8e40f0e",
           "file": "src/cli/boot.ts",
           "line": 148,
           "severity": "medium",
@@ -1322,7 +1346,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "8c777ed084f8994415f593b028d2d099e960855260633307053658c3397bbec1",
+          "fingerprint": "a0e2e992829edc3444e341ba4deb0b823fb5d1db89c202da74451bc1137ba3fb",
           "file": "src/cli/boot.ts",
           "line": 149,
           "severity": "medium",
@@ -1330,7 +1354,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "39edc7ca88b0239a1884fc4306e31272c0d24c2b28585ecf449583f3fb7758d1",
+          "fingerprint": "454058c24052261a3f295f22fa3910d5f3bfa1f5592f00d1c1fbd116ea518d87",
           "file": "src/cli/cmd/acp.ts",
           "line": 24,
           "severity": "medium",
@@ -1338,7 +1362,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "8e58679a75e028156893bbde63c4a18e4d07e84d873c04f6269b37433e2755e5",
+          "fingerprint": "b6959dee3de64a3f88776bbf9125294e0d971bcf02a820efc19cc305159dce9a",
           "file": "src/cli/cmd/audit.ts",
           "line": 113,
           "severity": "medium",
@@ -1346,47 +1370,47 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "adb0fb2bed4bd36af051412d59c712082eee18e12ef69b7453718390e675294a",
+          "fingerprint": "afdb675b8ba8c3a8c0e8914a7c5badac8d7e0b48bc83030566d562ff4c562490",
           "file": "src/cli/cmd/debug/explain-impl.ts",
-          "line": 155,
+          "line": 157,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "7bfe1416d80f0cfbf6160381c524bf5a4829c72ceb15028715cdbd13b26965e3",
+          "fingerprint": "b6fb0d3114c8667d6e6634c85947b251107b47c60a0ee79ded73d7eed41b5a08",
           "file": "src/cli/cmd/debug/explain-impl.ts",
-          "line": 338,
+          "line": 340,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "bff502f4a7a19be6e5a6aa0622aabf5f92efb273f44419b5327488dfbf43df84",
+          "fingerprint": "7c5ccf3a4eb48fd9344ea0ad841407c2128fa83b34a5561a38520b422aecfb4a",
           "file": "src/cli/cmd/debug/explain-impl.ts",
-          "line": 403,
+          "line": 405,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "512b34b7a047255d49483b0676c114afc9964f973460172f065968363be5be38",
+          "fingerprint": "201a8c6170282f7303bb7564efbb1d1682f76d33730ee88d245225d0f190238f",
           "file": "src/cli/cmd/debug/explain-impl.ts",
-          "line": 517,
+          "line": 519,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "aac2a1ee56fc31fb7e16065e3d760f28e6d2eab8c06953c983d3907b66a26d99",
+          "fingerprint": "eb058e02c2f91ee86ec7202c77fb25a34dfc1cdc75e67d46501f70ff27c5d80a",
           "file": "src/cli/cmd/debug/explain-impl.ts",
-          "line": 1025,
+          "line": 1027,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "fbe9fa997401d012d3b6a43f8c89b2338fba5dac6d9aa63a3f279df54abc8bdc",
+          "fingerprint": "f583f7c0d53fd69192f09f2a952b05c3fb22c4bb495fd76825494107e1fa2946",
           "file": "src/cli/cmd/debug/perf.ts",
           "line": 110,
           "severity": "medium",
@@ -1394,7 +1418,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "1129395a94d3702df2edc844b4b4c9e5c6a92cf5093347426b73b30e1124d1e0",
+          "fingerprint": "23d2ecca7467e24dcff759ed0b7eb84a0e92d5673c5ff207c699d6b078539aba",
           "file": "src/cli/cmd/debug/perf.ts",
           "line": 135,
           "severity": "medium",
@@ -1402,7 +1426,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "1ed8375e9648b286792ddbe303a73bc0fb5ab973017b38bc893fa8e16ae03172",
+          "fingerprint": "aa917841cb8e43b57a8734ee9b5ac01c8b233b71ac7d36c60b631be24f6d4cbf",
           "file": "src/cli/cmd/debug/perf.ts",
           "line": 137,
           "severity": "medium",
@@ -1410,7 +1434,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "a22ed4d21ffcedabb06b3f13a22498a2a68dbbf28e74b1b5a79a888238a403fe",
+          "fingerprint": "a5f8f224ed0f761700c7f49de25850538b33b464b87c7097038ede5755d32c1a",
           "file": "src/cli/cmd/dre-graph.ts",
           "line": 55,
           "severity": "medium",
@@ -1418,7 +1442,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "4f1fcd357aaa3b9cdb9436c688ee01cb5487b7d0ef71a878ccd20f26dbcb61c0",
+          "fingerprint": "e28d5c0afbe59e1064d23344fecaa17461a278e991a942a79e5e2fccc4debeec",
           "file": "src/cli/cmd/dre-graph.ts",
           "line": 67,
           "severity": "medium",
@@ -1426,7 +1450,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "47dbe85d2917480e94e7146b6fc01a87153e231dae325b71a2634e39a7e6628a",
+          "fingerprint": "40b7c4942ae502261a4e17f2265698bac8da1524bc56cdd7bf23ef441cf456ff",
           "file": "src/cli/cmd/dre-graph.ts",
           "line": 68,
           "severity": "medium",
@@ -1434,7 +1458,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "94b34367173ceaee1738a254f61bb68cecdcc7e22f54b878a4fb35809623e431",
+          "fingerprint": "14d68e08e4cd07c07110cb4e61651f93aaced71859c941f412f89e1008e53c09",
           "file": "src/cli/cmd/github-agent/run.ts",
           "line": 404,
           "severity": "medium",
@@ -1442,15 +1466,15 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "fb1e7c3dcff0d3140bcbae7bc6457fad18ce72281a8811c64864b70b7bd295fd",
+          "fingerprint": "183a02cc104fe57cc8d8fb35e76b86432550ff6ff026840ece090466dce876c5",
           "file": "src/cli/cmd/headless-run.ts",
-          "line": 28,
+          "line": 26,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "bf821027cfbd8e3a60c1547f710d089e9dc346633b5a64e1c330cca54000d000",
+          "fingerprint": "1bdd46a2b2ccde1f2bfcaed5273921482e3f59b4f24851b14e5a542dba7919b6",
           "file": "src/cli/cmd/index-graph.ts",
           "line": 48,
           "severity": "medium",
@@ -1458,7 +1482,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "1100ec583eafbbc59bca64505e1c66c7de81747f6fc26cbe90a941660d6684d2",
+          "fingerprint": "096134477555c9fd0e662061148aa93973188ef67eced45a6e59279006b5faaf",
           "file": "src/cli/cmd/mcp-impl.ts",
           "line": 150,
           "severity": "medium",
@@ -1466,7 +1490,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "12a4192882351b791f5ab3192fb143f0b480bb5adc59c4bf4848cf7744f946d4",
+          "fingerprint": "87c7b21f04ac03f6e4b102a847e4dbe099691fc23802528c5c0fbf57cff65be5",
           "file": "src/cli/cmd/providers-impl.ts",
           "line": 28,
           "severity": "medium",
@@ -1474,23 +1498,23 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "0e55e5cd8552fff3db9abe94da9eeb0603b295911e8cb2741b6713cc59baac42",
+          "fingerprint": "1adbc1adf1d0b356cb6104d40110bb15086d4afd656fa18c6b74a2111fb168b7",
           "file": "src/cli/cmd/run.ts",
-          "line": 538,
+          "line": 539,
           "severity": "medium",
           "kind": "subscription:no_cleanup",
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "6a09028c404c16293ec2028995d98677e888f9e59d9d56497944ce996a44a75b",
+          "fingerprint": "aeb732a3e004738dcf5dceb3c1b29b0e98191cd2c2425912729796cc339015d5",
           "file": "src/cli/cmd/run.ts",
-          "line": 565,
+          "line": 566,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "09a4cb988d3f408a409efd000aa496b821f3df98176e531e4e82a86e2c7ce414",
+          "fingerprint": "f94b46445b0b137b91bd22d6116e3ec3222f08520c76a88eeae506fa76eb8c12",
           "file": "src/cli/cmd/storage/db.ts",
           "line": 71,
           "severity": "medium",
@@ -1498,7 +1522,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "a2d96f6418e8d49991054d924f70fe7a6035c710a68488888a211da616bee7c3",
+          "fingerprint": "7b76dbb311557f68f209e98b7dd6b4729c766b29f6c61ce2618ca8e9972edd25",
           "file": "src/cli/cmd/tui/component/dialog-agent.tsx",
           "line": 29,
           "severity": "medium",
@@ -1506,7 +1530,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "1bf17a565a784503f6c8bbb3fb48bc498ed5cecc5cb4284198fec6defda3f929",
+          "fingerprint": "f16952090f4bcf4d68b8e007fc3247b329bd2f0fbe198b8efb7ec228166818d2",
           "file": "src/cli/cmd/tui/component/dialog-command.tsx",
           "line": 120,
           "severity": "medium",
@@ -1514,7 +1538,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "1ec06ded06c60e21f6343808857ec82cc0c79be25ee155ac3f64832902b1baee",
+          "fingerprint": "4d4b7e51f040a000641c4bcb96c6bad25714f393bac8ddc6adc5ac20a0e023a6",
           "file": "src/cli/cmd/tui/component/dialog-mcp.tsx",
           "line": 66,
           "severity": "medium",
@@ -1522,7 +1546,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "262675062ce7dcf60ffca94650fea16d2d4f84f13a83d9442ca9a2e03573e0e9",
+          "fingerprint": "b97b9f29e6d33df6fd0e3d7a43cd436a57cf23f8943829889c47971ebe233e53",
           "file": "src/cli/cmd/tui/component/dialog-provider.tsx",
           "line": 174,
           "severity": "medium",
@@ -1530,7 +1554,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "d79908066a69b24ef5eeba0e359c90257ba9d839cee4510719c06c4167eaddd9",
+          "fingerprint": "667fad48cc4105ec032b7cda3fb201a7fbcec719103d829340198565b18106c1",
           "file": "src/cli/cmd/tui/component/dialog-provider.tsx",
           "line": 262,
           "severity": "medium",
@@ -1538,7 +1562,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "803016299d283a91ab00f03d563a45ce8e5288a1613661d45a488a70a6d04dff",
+          "fingerprint": "b8a37765a5b970d69b4ed20bcb8f2dd37aa52e0d70b5dcab07390c9c9bb310cc",
           "file": "src/cli/cmd/tui/component/dialog-provider.tsx",
           "line": 533,
           "severity": "medium",
@@ -1546,7 +1570,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "d1cad1bb9800dd87ffd7e09486ebf0ca17a4e89b4a79b1b12be42ab63396e877",
+          "fingerprint": "201e78df4d9625aae941586c378efc7541ae94f23d4de0ff7053db59803bfc9a",
           "file": "src/cli/cmd/tui/component/dialog-session-list.tsx",
           "line": 164,
           "severity": "medium",
@@ -1554,7 +1578,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "0b3facd78e6a1295e333620da2f6b18db5bbdf2a5b6f01991f5707cb25f2643d",
+          "fingerprint": "45398bc88537fe676aaa9ebbf38b8323e7a3873a96c2024245a2451e5b00977d",
           "file": "src/cli/cmd/tui/component/dialog-theme-list.tsx",
           "line": 26,
           "severity": "medium",
@@ -1562,55 +1586,55 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "5a2b7cfdb6303e8a18517c8e93570092cf18ece38469b942d8cae6c2d9c7cd63",
+          "fingerprint": "97eeeb757f34ce4d55118a56b69bd51d17ad55095c5db4eae7cfaff503359414",
           "file": "src/cli/cmd/tui/component/prompt/index.tsx",
-          "line": 203,
+          "line": 210,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "8e1420a403638fa2473db78a89f881c34a0e603c1d0f87b800d37ccc1ad24aad",
+          "fingerprint": "1de773d676be2365090c7647f381dd0317c7a70abf052e1033a11b715ac411b1",
           "file": "src/cli/cmd/tui/component/prompt/index.tsx",
-          "line": 620,
+          "line": 631,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "212c95f558ffb75a9a6b5ee33e0f0bd069f034438b8b683c3707788a453135a3",
+          "fingerprint": "60d16285c4ceca87083c78d5e6d4307a6edd56b7aafb648880a0483099f54acc",
           "file": "src/cli/cmd/tui/component/prompt/index.tsx",
-          "line": 621,
+          "line": 632,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "661b9fde16d808550633e6c3857c4caa5e054495a5120f4ab9c8021c15e23a1c",
+          "fingerprint": "16835d9246fb16d8b57c42984174d15d39508d8ba6b37a06aa5ebf1d1a91282d",
           "file": "src/cli/cmd/tui/component/prompt/index.tsx",
-          "line": 622,
+          "line": 633,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "afbdf4d713716233169391bb6d15b462c067272a31d59d70894572ef8ed225d9",
+          "fingerprint": "94835321fd4764acd5d2c20ae85163b425d19914a8b36ddbabfa6a2871e22f98",
           "file": "src/cli/cmd/tui/component/prompt/index.tsx",
-          "line": 886,
+          "line": 897,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "2d9c931a2dad6d1820b65bbcd3e54208480cda631902e68521aba578375958bb",
+          "fingerprint": "2f4fc5cf64d2ce458bf6389bbafeb79f101cc1e5f045b945f5d745710aa36c83",
           "file": "src/cli/cmd/tui/component/prompt/index.tsx",
-          "line": 1420,
+          "line": 1454,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "4b6d334bcba235ae8d797fd1981a420129784cb3459fe056fe06463b2e1f7be7",
+          "fingerprint": "d5d5a826f02ad54c0d20057b79cb8e800707bff3cf7bb611a991d0213210d6f2",
           "file": "src/cli/cmd/tui/context/kv.tsx",
           "line": 94,
           "severity": "medium",
@@ -1618,87 +1642,87 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "e32b21aaefc708a232a47fc9274d7dc90ff90aee2f0c505c633ad16921366e61",
+          "fingerprint": "ad986633c268098dcb3bc537909a73f9cbb0d5d1697db9cf6432415c98540035",
           "file": "src/cli/cmd/tui/routes/home.tsx",
-          "line": 103,
+          "line": 59,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "e9782e7c1831e4c31dba862c12844a452a4781131945452ca2bcf6f2e2a55065",
+          "fingerprint": "bd942208c15adb6cc1fab99968da6e03375bcba126ab68983731dc9cb5d2da86",
           "file": "src/cli/cmd/tui/routes/home.tsx",
-          "line": 148,
+          "line": 116,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "0d33048affd33f18aaabdce405082fe98b20a04aa93998fe4324a560f255d02d",
-          "file": "src/cli/cmd/tui/routes/session/dialog-capability-catalog.tsx",
-          "line": 29,
+          "fingerprint": "1fed6b15355b1db91ba35a0dc3290d640896c8502c383df52b61f2c230a141dd",
+          "file": "src/cli/cmd/tui/routes/home.tsx",
+          "line": 161,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "74ef7c74cfc3c484c01ec1335a9afcae71a92baf49dd89aca91b24e8a1f9b4b2",
+          "fingerprint": "5da0e23870753ff220f1e8f5e41eec1d4ecb1bdb021e74b05a0ebd18b62cd93e",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 403,
+          "line": 404,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "dc639d2305cdd857f4996b9cafc7db1b30eac58e01a73996929fd5e35ca6aeb7",
+          "fingerprint": "118d3e2f99454063417372729f558461cd075ae01cfaef93ad3e7c87dc2da547",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 446,
+          "line": 447,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "a36bb7c68b107dbb0ee58bf381804a8d55865a513b9c1d237f0b5ec510cbf42c",
+          "fingerprint": "d80f45de3e6121e38b7cc04ac30d95553aa2926161888746c21ec3b7f0b22278",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 487,
+          "line": 488,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "724169ab08764af827ccc1d64dd782bd0382b7422898bb480632c1d7a2043701",
+          "fingerprint": "2a614de4f16010568bd8b4e72bc13388b28af3943fa04304a122ed158fc034c1",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 610,
+          "line": 611,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "28ac0eb1d39fc09777fdb64a934b9c21ee3f9771d91e4a7db0941443796913af",
+          "fingerprint": "cd29900713c26f4e4dc0cf58d79a5bc7960d826846fb180d5b174bbefe44f672",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 1046,
+          "line": 1047,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "afef4cea6a70f65f6c939dd049b953e22752cde46d183542cfb7ed4687721b68",
+          "fingerprint": "6d9373a614e7a6d114635bd982b53adb764396fb7e8261cdcfc6c62e8bab56e1",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 1244,
+          "line": 1245,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "90b7ba2e2f4aeef7f5b4dddb202fcadb2f3e640f233fd987354d226b93dc3b44",
+          "fingerprint": "254bc2912354d0003e6d89bfdc990bd6e734acd9a0f3ca23d6e962e8b3b956bb",
           "file": "src/cli/cmd/tui/routes/session/index.tsx",
-          "line": 1247,
+          "line": 1248,
           "severity": "medium",
           "kind": "map_growth:unbounded_growth",
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "53a9e970882d429df7fd049539ddefaaec3f079d351848520b383e01f96c11ff",
+          "fingerprint": "38a8589f5e8b14f6e81aff0ef8503664c43ba9a41ee9c7fbd9f252aa280147af",
           "file": "src/cli/cmd/tui/routes/session/tool-renderers/dre.tsx",
           "line": 213,
           "severity": "medium",
@@ -1706,7 +1730,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "300a5600905ed561d6dd0d590da4e6967088210d3b87c6c14ee31f35ad9675b6",
+          "fingerprint": "e31a8a9b68ce8488851ca25622d4b0f25fb5b2507b0bb15103a04eb352e9a57f",
           "file": "src/cli/cmd/tui/routes/session/view-model.ts",
           "line": 150,
           "severity": "medium",
@@ -1714,7 +1738,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "98048440ed535293b03e64be9c81c394f4ed68b61c25256fb2a9d5a985d3c700",
+          "fingerprint": "3609c49ca263421cc9b6f279bb23381ae8933cef0c95e34c741cb650ad500d4e",
           "file": "src/cli/cmd/tui/util/resilient-stream.ts",
           "line": 95,
           "severity": "medium",
@@ -1722,7 +1746,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "bf73d167718ae18e57b1d2a01279f5a5134aaa4bc345806e86e4809e1b34c8d6",
+          "fingerprint": "bb460639b8b7e1d20b0673131b0eaa56537167aa12bb543832ebdcbbbeb23e26",
           "file": "src/cli/cmd/tui/worker.ts",
           "line": 96,
           "severity": "medium",
@@ -1730,7 +1754,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "f814172695eb7ca52dce333200026dede90e205af1358a30abd1356094b5996a",
+          "fingerprint": "54a0a2c5bfd9a814a1612c6691b63ef86c55b43739c6fc9b50951cea5f3d6967",
           "file": "src/code-intelligence/builder-impl.ts",
           "line": 434,
           "severity": "medium",
@@ -1738,7 +1762,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "0e7127a48f90a9c01ee132639143f5c0be0e49222f3e1768adaa1393887ff8e5",
+          "fingerprint": "bc413e0a638ab1e3240945d97d83b129eb765db589aa5e128461b1fb51886404",
           "file": "src/code-intelligence/graph-context.ts",
           "line": 416,
           "severity": "medium",
@@ -1746,7 +1770,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "395f751c620b8cbcf591a93ff36c3cfdad2208adb48757882005b972f128a86f",
+          "fingerprint": "d0dfa13378cc66f1471708395b254219720ea191386e654add49253b14e85a30",
           "file": "src/code-intelligence/watcher.ts",
           "line": 181,
           "severity": "medium",
@@ -1754,7 +1778,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "4582f3c637785d13d97e216c8733972d5dd0479a9d0ae7eaa4593aeb82b86a67",
+          "fingerprint": "e6a717514a5473b0583b5b48b1255e4c4c094dbcb8224c978f36c8d764b54826",
           "file": "src/control-plane/workspace-router-middleware.ts",
           "line": 53,
           "severity": "medium",
@@ -1762,7 +1786,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "708faf50ada65c91b6ba888d6a81930d0afb5eb6520b05318c0e01829b3bb3ca",
+          "fingerprint": "752a89b8e3eafa1b431b0e1bf2047013aba95f4d2471d337d6c35f2e4d61576a",
           "file": "src/debug-engine/detect-duplicates.ts",
           "line": 207,
           "severity": "medium",
@@ -1770,7 +1794,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "46ea9dda58b1cc764208f81de5ab58637ea9132fbb414face5fb788a3a59d18e",
+          "fingerprint": "f4e0475cbb7f17bea23127d12b1471206596e010e148b795f83eecef0ab022f2",
           "file": "src/debug-engine/detect-hardcodes.ts",
           "line": 55,
           "severity": "medium",
@@ -1778,7 +1802,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "4532e93da48569cb1c93b8fb92b9d59848f173db75673c933d7e60f295e07080",
+          "fingerprint": "3a1ff74e6fb1b1f8c42bd7c44a8a427b7012a7156f67688345afdebdaaab91c6",
           "file": "src/debug-engine/detect-races.ts",
           "line": 254,
           "severity": "medium",
@@ -1786,7 +1810,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "d8be127b12c449433e5ce8f62013eb46c14c7e6fdd0376b7a7376df237ad1baf",
+          "fingerprint": "2354435f631e1e369c7964318007b698238fc59d3b120f2585ec8b621852ff3d",
           "file": "src/debug-engine/diagnostic-correlation.ts",
           "line": 181,
           "severity": "medium",
@@ -1794,7 +1818,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "10108121aca49945844af84a39ed045fccd159fabfac554622c06087d2c90dd3",
+          "fingerprint": "16f4c0116295050d1ca792e53e1baef32eb335c2c00124057cfd71713120cca5",
           "file": "src/debug-engine/language-scan.ts",
           "line": 447,
           "severity": "medium",
@@ -1802,7 +1826,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "c01ca84b8cb496c3a962056e7b6994087c7139f2df376a14ca1b4a92fa33bcaa",
+          "fingerprint": "66a136c4937f63f1fd9fd72fda25613fa380662a0cc7c00673f01aa4239108d3",
           "file": "src/debug-engine/language-scan.ts",
           "line": 448,
           "severity": "medium",
@@ -1810,7 +1834,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "78d195f75d4b33d95ff76dd8a44e5ed448a4260a23f7af724c78ea6561d9f8d1",
+          "fingerprint": "6cd05a77bfd21214e4bdd9323222a19077f4dd4f26f7be0c7185e3c5c7aad80b",
           "file": "src/debug-engine/language-scan.ts",
           "line": 474,
           "severity": "medium",
@@ -1818,7 +1842,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "af96f8f9f14c6be114ed0751c1b2f96e5a582a476a14d05df7166a177727e89e",
+          "fingerprint": "208b3aab409cc070de4d613365e26e994dee53c5108a92820d429c88e3c25977",
           "file": "src/debug-engine/plan-refactor.ts",
           "line": 215,
           "severity": "medium",
@@ -1826,7 +1850,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "8897d20c1e94a54661f767b04b8beb56aaa48f54a8de7bfd2c00b4598fec00d9",
+          "fingerprint": "24b942c4a256ddcfca6547c8a0d2452bdad942ecd3e5870093cbf6b8ac5312cc",
           "file": "src/debug-engine/plan-refactor.ts",
           "line": 216,
           "severity": "medium",
@@ -1834,7 +1858,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "5ae55bb1801af298574825283dfabf22384756bd746c42c5e8e533d65aa612c7",
+          "fingerprint": "605e7f1179737ad9326d1180b258f678ccea91548826d01c23d1bbd7c2f0d904",
           "file": "src/desktop/webui.ts",
           "line": 167,
           "severity": "medium",
@@ -1842,7 +1866,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "1652fee9e9fb84fe76a05251c8ed4af225d7853db712eb43d1f57642a1e55f5b",
+          "fingerprint": "c184edcbd727b102ce9776481059151e738d639d52c577c7aa17a0041c5d92ab",
           "file": "src/desktop/webui.ts",
           "line": 170,
           "severity": "medium",
@@ -1850,7 +1874,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "06cb0fc4e39f0770011474b99287ad6296b997bdb707c2a4e8377aecf6afa62c",
+          "fingerprint": "42438ee34679d67311c508c63330c85aefda04c0a1699ccc971d18223993281a",
           "file": "src/desktop/webui.ts",
           "line": 173,
           "severity": "medium",
@@ -1858,7 +1882,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "e1090721b0eb32ec631de7561a7afc3f38426c820b4187614975152aa58a4bf2",
+          "fingerprint": "59d7ceef34152f5825a4dda441ba8191c80968ac7d2bc1a79ddcc11d6c6c0692",
           "file": "src/desktop/webui.ts",
           "line": 174,
           "severity": "medium",
@@ -1866,7 +1890,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "477e04c069ef698575f25a2028bfd41e582e9ca525c067ad96aec39a03dde6f5",
+          "fingerprint": "7d67c69180513e0a1ae42f301e18255a887317ae041d0d05f5187837986a357f",
           "file": "src/desktop/webui.ts",
           "line": 255,
           "severity": "medium",
@@ -1874,7 +1898,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "a523d1d4ce2ff0cf902970563427cf2793d12fc9e6e15b89cb46db8c98265f00",
+          "fingerprint": "ee173c4f2c42bbf9cba2f40117d120889f0160663a4c0f9fc3e4d2c6fb559e8c",
           "file": "src/desktop/webui.ts",
           "line": 256,
           "severity": "medium",
@@ -1882,7 +1906,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "fc3e07bf9154c35cb6992c18a3d83d8e97315b002ad00d9c1082b331cd26989b",
+          "fingerprint": "6e42c89799e69de72becd7ab430018ed5c73600d64107f3f6d4b2f03d42cc753",
           "file": "src/mcp/permission-pattern.ts",
           "line": 39,
           "severity": "medium",
@@ -1890,7 +1914,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "37125b80b109296f84b9d7be1ae350929bd2a045b499af17d40187af3fed84f2",
+          "fingerprint": "b81729b4e97190b8b9c0d98acb694ee17c4bbf2e37bea04c8438ad62f19b33e9",
           "file": "src/memory/doctor.ts",
           "line": 156,
           "severity": "medium",
@@ -1898,7 +1922,15 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "984b6c2cb2da93800e943ed878aabb1c1cc962e475dc278a03421c787434c1b8",
+          "fingerprint": "d2480049a2eb15e3eb3150047b6d5f5849cdc3bf1c1d808a5a786184f964bfa1",
+          "file": "src/mode/council.ts",
+          "line": 108,
+          "severity": "medium",
+          "kind": "map_growth:unbounded_growth",
+          "summary": "map_growth:unbounded_growth"
+        },
+        {
+          "fingerprint": "93a833f728ff5dc2833adc59e032e4a4aa2bd669ede1765b3989d1a63a9d8fef",
           "file": "src/native/addon.ts",
           "line": 63,
           "severity": "medium",
@@ -1906,7 +1938,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "7b4df80bb72906e67d6ddbb1adedf565e8b6ed3eb7c925b08c4c529820dbda51",
+          "fingerprint": "cbaffd2dbc1c5e852e440eca4cc0f69f9d7f2a52e42f032ed3f3d37f65883d52",
           "file": "src/planner/dependency.ts",
           "line": 52,
           "severity": "medium",
@@ -1914,7 +1946,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "75814cc8ae2d6b36cd7721e3d8d6e1861d9e7df372d2f47f9215e2629a96d3be",
+          "fingerprint": "da5a3ebed28b8d0a9280c912169f1cb379aee61efa9432e9bcbc3b6a3476c2f1",
           "file": "src/planner/dependency.ts",
           "line": 53,
           "severity": "medium",
@@ -1922,7 +1954,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "53a3a126fe110b86fc0e705d79d28da4a91fd756875b9e8e09af9679d95bc96f",
+          "fingerprint": "f3573779fc19882eb2428cace86be203d6a15b18d125209e09a480ab8ac3b6c0",
           "file": "src/planner/dependency.ts",
           "line": 54,
           "severity": "medium",
@@ -1930,7 +1962,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "3bd3c2b2960d9a4925b7aa37c68dc67a06548fa5196e8269e0da570af59e5edd",
+          "fingerprint": "a28ec097d2284a4ae34e58d1ed715271a62e6891a3a2f731a91b9363de53831d",
           "file": "src/planner/dependency.ts",
           "line": 137,
           "severity": "medium",
@@ -1938,7 +1970,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "684721daef4ad466dc5111d79f386db36c3cc81ade3eeaf158b0ba2633ec7016",
+          "fingerprint": "b262e087dfcc2b8b79d08e2fe761b37f6cfe0615c4ed69a85c5cb7b40921b4e2",
           "file": "src/project/bootstrap.ts",
           "line": 165,
           "severity": "medium",
@@ -1946,7 +1978,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "59b8eb4938fcd25421681f1cbbb96da2d0fbae3d81911dab9bb33870f03572a7",
+          "fingerprint": "01533b3ecd41007fd7656a5ab6d56f565525cf8b097610c22638e0d1fbcc3b08",
           "file": "src/provider/ax-engine/catalog.ts",
           "line": 72,
           "severity": "medium",
@@ -1954,31 +1986,39 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "c650fff9b5c1aba71b4f2eb4067a183fc3d332371fca5a17094d4965f60bad60",
+          "fingerprint": "18bd52525aeee67ce476a8823018f783c5f85cbaebc7cb383290c834024810e7",
+          "file": "src/provider/ax-engine/provider-loader.ts",
+          "line": 174,
+          "severity": "medium",
+          "kind": "map_growth:unbounded_growth",
+          "summary": "map_growth:unbounded_growth"
+        },
+        {
+          "fingerprint": "4c29ce91f7286aafd67c68bb387b6bbc2bd074bdc25fe9550f9c396396aaaa2f",
           "file": "src/provider/ax-engine/server.ts",
-          "line": 295,
+          "line": 300,
           "severity": "medium",
           "kind": "event_listener:no_cleanup",
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "967d842cbf4c1460c4835ff31708f608b31fdb9d7f02b906f64c98d0dcaf4189",
+          "fingerprint": "7ada331ee17778c0dab3645d5874ede6160825e83f85f9fca4689093097c4f48",
           "file": "src/provider/ax-engine/server.ts",
-          "line": 299,
+          "line": 304,
           "severity": "medium",
           "kind": "event_listener:no_cleanup",
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "a460dd7ff62956e5e62477638219a9362373c283570c707f3d893b293479b772",
+          "fingerprint": "c55c1157f2035311ffa452b6a22cd25297aed2f60dd5f2884f0520dcc9fe4cbe",
           "file": "src/provider/ax-engine/server.ts",
-          "line": 302,
+          "line": 307,
           "severity": "medium",
           "kind": "event_listener:no_cleanup",
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "0f79de2ceb8ec6b968f92f687dea6dc1c87512668e1d4839d50c839d837a0f0f",
+          "fingerprint": "e267da0add9e1f6d4dc318753dfa47706020a70c7e8f6ec4c1c175a07169a51c",
           "file": "src/quality/dre-graph-activity-section.ts",
           "line": 138,
           "severity": "medium",
@@ -1986,7 +2026,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "6f99bae1a7c65428967b24650381d549c84ff446c6c3011b0f86a09081499727",
+          "fingerprint": "0876cccc61edd71e4d43fc3eaae4d648e3cb91ebf910704b7560ee690b502f9a",
           "file": "src/quality/dre-graph-activity.ts",
           "line": 40,
           "severity": "medium",
@@ -1994,7 +2034,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "a365a0dfc51a1eef0d456cf92039857ae0f8e3fb864e582968096bd2184168ad",
+          "fingerprint": "500f6802f348f9f901265d477f2feb370711df9f080ad181fefb2cc5bdd864ff",
           "file": "src/quality/dre-graph-assets.ts",
           "line": 223,
           "severity": "medium",
@@ -2002,7 +2042,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "6e811e771b6163e7af507243d03a2915f9c3272a82b274b1e6e79d82d01fb474",
+          "fingerprint": "5a6fb62a8ad1f6c080b0b8730e0252869a575068865243eb79aed922d5844d46",
           "file": "src/quality/dre-graph-rollback.ts",
           "line": 38,
           "severity": "medium",
@@ -2010,7 +2050,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "bc724838f189679d9e5c1cb5d77a3fa44a080ff3f459c4cfdb5e7052a801c355",
+          "fingerprint": "e31e262d2e74b30cdc86c1502d5258343af575bb82f05e9580d83b9aeb292145",
           "file": "src/quality/dre-graph-widgets.ts",
           "line": 55,
           "severity": "medium",
@@ -2018,7 +2058,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "e5e79eb7490e52a77a0f101f40826525e67e6a147fd8e0e7b466cc6b77d0e23b",
+          "fingerprint": "98337fb4c5bf7b2c6da1b509cb240fda848ffdd002c027e8a365d7f6d7c50127",
           "file": "src/quality/model-registry-selection.ts",
           "line": 104,
           "severity": "medium",
@@ -2026,7 +2066,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "a93dd13bbd3b6b4064a05cfdf9f3158ab1b8cdb91a2ce5728211e095b9942ea1",
+          "fingerprint": "5441df30692af3bfaf66b71fbb419292be14bea06f52f75d51472c36ff2cecc9",
           "file": "src/quality/probabilistic-rollout/calibration.ts",
           "line": 78,
           "severity": "medium",
@@ -2034,7 +2074,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "761dda5156d50ff1360812551cd9ff77539fd6672c6d08e159c67ce5cfd709db",
+          "fingerprint": "d99cf9fb8abc096168ff3c2185e1be0b2423eb9f589b48e3e045e877c96bcc94",
           "file": "src/quality/probabilistic-rollout/helpers.ts",
           "line": 126,
           "severity": "medium",
@@ -2042,7 +2082,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "d112159330f7be2149f2b7071456e64e894a6d2707d303efd572ea811040d693",
+          "fingerprint": "006424ddeb51025d5481e5194dcdbf3ae1f96ddc698bb751c1d5fb1b20a74133",
           "file": "src/quality/probabilistic-rollout/helpers.ts",
           "line": 356,
           "severity": "medium",
@@ -2050,7 +2090,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "efe6e468357e2ce6cf8cb3737b6cd8f2dc5112a83195bd37a357111ea19f37e9",
+          "fingerprint": "67733510e23acc12de4f1fb64500e5813af40add4a4d3fa01fbbeed5c171cce8",
           "file": "src/quality/sort.ts",
           "line": 16,
           "severity": "medium",
@@ -2058,7 +2098,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "dff22bd9d3f196cb02c22ddcbea4dd93d26c99cff2998a97782d131e13349628",
+          "fingerprint": "fd7c872dffb9693a4276b30f47005479565969b97ff07d3723f35a512808d125",
           "file": "src/runtime/headless/runtime.ts",
           "line": 43,
           "severity": "medium",
@@ -2066,7 +2106,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "2f74a90022235926808109318928a8335a20a3638022b9a1370b55985e47657c",
+          "fingerprint": "ebb0248a2aab70c8e88ab2509774970f72aa567f9c61d5b65c4bb614e8033b4e",
           "file": "src/runtime/service-manager.ts",
           "line": 120,
           "severity": "medium",
@@ -2074,7 +2114,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "22f5e7ddd64a090b075b43a7070dcbe981c4c353615ea473eda4b1522493d922",
+          "fingerprint": "ecdb7ab4ab0f6c5ca3a94aab41600a74cfe0dcff383a711a8dddf4aed477b4da",
           "file": "src/sdk/programmatic-impl.ts",
           "line": 214,
           "severity": "medium",
@@ -2082,7 +2122,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "1f6ebfd3e2e61d50e12a567245bb743cc95d4825ae63d341bbacb84e93b3012b",
+          "fingerprint": "8d87838470f413e669c8501615145d4e791e1f9187675bb7af4675fef88e2f90",
           "file": "src/sdk/programmatic-impl.ts",
           "line": 791,
           "severity": "medium",
@@ -2090,7 +2130,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "ab78fa51da1b0126a078d6a0d8883d92939c404fd9a7200388e8e033e579d020",
+          "fingerprint": "0fe2a44e1e98195e05dc0cb93f8763da6695d61227fbcb07690af4f5ebd36b8c",
           "file": "src/sdk/programmatic-impl.ts",
           "line": 839,
           "severity": "medium",
@@ -2098,7 +2138,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "697d61ec6e9f5c15cf9c38b6556e8d1a665f3ed83064c4bdbf7226c6678b44a9",
+          "fingerprint": "5a82f06c1602ea43e591e98606485fc4a7c2ab4dc3b9a6f473542215d250e29a",
           "file": "src/sdk/programmatic-impl.ts",
           "line": 1134,
           "severity": "medium",
@@ -2106,7 +2146,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "18de91d91035f0c21765b39eec5a405673e58119fd0e99776d411feee059eac3",
+          "fingerprint": "4204858ff5004656465bd08954924ccc43e912d4106d8ec218a44aa496f6bef4",
           "file": "src/server/ipc-protocol.ts",
           "line": 43,
           "severity": "medium",
@@ -2114,7 +2154,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "8430d6b26ba10ec228687b41f49b545ebbeeb318df514c925697e618f2db77f3",
+          "fingerprint": "57277867f65c21efe3d7848fa9eee525ec05d6ace7027b69458f88a0cd5356a6",
           "file": "src/server/routes/autonomous.ts",
           "line": 102,
           "severity": "medium",
@@ -2122,7 +2162,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "cd04c7e6502d7292c1a8f5939cd9c251652886fd07750b912ad36e10cad15464",
+          "fingerprint": "776c346a764d20a0732a9f8e16e56ec4ade52b91c8b29b4823ff7e8228999210",
           "file": "src/server/routes/isolation.ts",
           "line": 63,
           "severity": "medium",
@@ -2130,7 +2170,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "cdca60b51c31891b566f0eca59419b72641036aed4a86b0b88de2dc7038addb9",
+          "fingerprint": "fc2496ffb9f48e2c13d8af1ff358bf61130289082962c0cc066c76d1be1e1e16",
           "file": "src/server/routes/session-impl.ts",
           "line": 1080,
           "severity": "medium",
@@ -2138,7 +2178,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "ff8b2784fc6ae27ad8159bf28b1a463ee9a80a226d2e16b47a29ca57de615a72",
+          "fingerprint": "f6ad45e2d8af058cd8a26624767b43e853a7aaadd7495e2076838dfda21fdd99",
           "file": "src/server/routes/super-long.ts",
           "line": 248,
           "severity": "medium",
@@ -2146,7 +2186,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "9a03232205dfe1c0a9e5cef7a55c6ae57f39f957520eced655ebd2d12369b691",
+          "fingerprint": "77fac3dd0860245b665767fc1f0d8460e454cc7079afaa5bc11acb226acb89e5",
           "file": "src/session/prompt-run-state.ts",
           "line": 81,
           "severity": "medium",
@@ -2154,7 +2194,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "f68bbf351eb845c319d11595bec76e4674746d1729f072cdac23eae6b6db33ac",
+          "fingerprint": "7158a1549c23314dc12a89be50bc9598db88604be8bb39d01d119e809fc3e5fe",
           "file": "src/session/prompt-subtask.ts",
           "line": 40,
           "severity": "medium",
@@ -2162,7 +2202,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "6f47a0bf31e10ebddea4a7f9cd4cad4f335a58f335edf5be42ee16e95eb81fb9",
+          "fingerprint": "498ea1497c84f20fe24ad02470c1906fbb6234e3684be68eb02c15d33e7206e6",
           "file": "src/session/task-queue-executor-impl.ts",
           "line": 375,
           "severity": "medium",
@@ -2170,7 +2210,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "55004d71a0c77baf01186084daab7ec2c3947b456e27dd83833f0e951db978be",
+          "fingerprint": "de23f3d5bd3b482a94354d93e626e8756b866e8221f5a056453274a0b2bd3d88",
           "file": "src/session/task-queue-executor-impl.ts",
           "line": 378,
           "severity": "medium",
@@ -2178,7 +2218,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "ef43335eaf1912743e9049c561361315cf9113dc4e29ec31215133f94c18e463",
+          "fingerprint": "eee8e0c7e90a2e628105e73e737a5d2192e8a5bd57d5a46787190735e2435977",
           "file": "src/session/task-queue-executor-impl.ts",
           "line": 381,
           "severity": "medium",
@@ -2186,7 +2226,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "983d0282d5e9775fee33df9a843d0b58d148f33584fbd081739a716a0816364c",
+          "fingerprint": "06d565d982ec87e206c55908ff4acefa5ca1ee99037401d4ee06f95febedabe8",
           "file": "src/session/task-queue-executor-impl.ts",
           "line": 384,
           "severity": "medium",
@@ -2194,7 +2234,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "9d0e2d4f4090b54d5bdc5388bb111791f36b7daba1c30b0ac881de33481f2078",
+          "fingerprint": "c209c1ebf5a1efbe2b8c9b437d9cd4f3d6d616a3acac906dbb7d7156cdfd17bc",
           "file": "src/session/task-queue-executor-impl.ts",
           "line": 387,
           "severity": "medium",
@@ -2202,7 +2242,7 @@
           "summary": "subscription:no_cleanup"
         },
         {
-          "fingerprint": "258eb42205a037e12ee5c793a00a99288d7df7e203d9146f4d26012f07044781",
+          "fingerprint": "727d0ba9fc5d63c5a2873b7d283d006d3f3d55c1449f85802b34e892d5ca958b",
           "file": "src/skill/authoring.ts",
           "line": 140,
           "severity": "medium",
@@ -2210,7 +2250,15 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "2fcbee83db1553f65233e195de47a8b7914715617111f4a563a0670f40465ae4",
+          "fingerprint": "387b90ba7b251b162c80bef3e13fe9b18a9ebd2a13d6a410df56e2c713f4b3d5",
+          "file": "src/tool/arena.ts",
+          "line": 516,
+          "severity": "medium",
+          "kind": "map_growth:unbounded_growth",
+          "summary": "map_growth:unbounded_growth"
+        },
+        {
+          "fingerprint": "88178a11918cf1d7ab8a9b04efd95e83e18dbeb179034c5bf3117eeca49ca6e8",
           "file": "src/tool/diagnostics.ts",
           "line": 141,
           "severity": "medium",
@@ -2218,7 +2266,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "2732216ff102b77eef47d2e5af521f1174dd7da357a0d9a85035255a7bae248f",
+          "fingerprint": "a9f867e5661ce93894d1d55b04f74e9b2cb8d5119e435685b31a5903e583fab6",
           "file": "src/tool/grep.ts",
           "line": 234,
           "severity": "medium",
@@ -2226,7 +2274,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "19b3a78fcdca9b455680cddc589bf0f841164d58d68ee5343e93098e99cb0ba0",
+          "fingerprint": "c0ce8c1d8cec79fee92471f0828b05ec6f5e4fada0396df49b722563911c5801",
           "file": "src/tool/ls.ts",
           "line": 136,
           "severity": "medium",
@@ -2234,7 +2282,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "9cf5468f1f151f61276be34a760f3c76161844789acf1cdd1573aed4880ab4b0",
+          "fingerprint": "9c29ec294322c04d7735171e67bc17c61a0329ec83ab8f2650d6fb243999fb95",
           "file": "src/tool/multiedit.ts",
           "line": 74,
           "severity": "medium",
@@ -2242,7 +2290,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "47aab1692a5cd828bc51494441b492bd54298a75052f82cd16873b38c8e1b746",
+          "fingerprint": "9e19b7ac9faec94ffac033b5a429687ec6b3a037d8a1fcf06ae00fe1216d0298",
           "file": "src/tool/multiedit.ts",
           "line": 75,
           "severity": "medium",
@@ -2250,7 +2298,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "b86ad29129405f251d77278f0a4efd565140280dcb8f03a70d366310dba2a9c2",
+          "fingerprint": "60c2a8c23f544a2a5d79018ea19ba3d29c2c5082d0a1cdfa931f4c72926ce9fb",
           "file": "src/tool/multiedit.ts",
           "line": 141,
           "severity": "medium",
@@ -2258,7 +2306,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "810b38e6b7d5dfbe02152505263547fbf1cb139264fb18873b00654a7d2fdf1c",
+          "fingerprint": "b8f3d47b3bd477c1ca1f2829f4f9e086583828d29862a28e14ab4d9ac1fc9343",
           "file": "src/tool/webfetch.ts",
           "line": 174,
           "severity": "medium",
@@ -2266,7 +2314,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "9c31571a9ac5772a8e74e0557020fdfb84413552692ee6abdb6f8db009b3ba93",
+          "fingerprint": "bfad7976634c37c2401cf3387e18e1348585840caade0f617f2443e8c96c2969",
           "file": "src/util/log.ts",
           "line": 275,
           "severity": "medium",
@@ -2274,7 +2322,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "54bfe22cc8e2058210d57eb8c4c6d1da8fffad21b764424a12181beaa66d0418",
+          "fingerprint": "cd25b053641c24a7e79247da1f07f90a27dbceedf0e0378c9eb1d7b06847c326",
           "file": "src/util/log.ts",
           "line": 459,
           "severity": "medium",
@@ -2282,7 +2330,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "bb0e283dbf0f642db4920b3ede4af9b92becb64908774faddedb94770a0cf759",
+          "fingerprint": "331e3799e60c736130bbf0934fe637e6ff6f7c4baf30e467399c501c75ad78f4",
           "file": "src/util/process.ts",
           "line": 17,
           "severity": "medium",
@@ -2290,7 +2338,7 @@
           "summary": "event_listener:no_cleanup"
         },
         {
-          "fingerprint": "c3c04e2575bd2a293af0c685dbc75d06be0565c8c9d3778edf0cc2af7563b3c1",
+          "fingerprint": "4816094bf3697238d4846c560e1cfa573d382959bf315c39e48e4b868e7d9307",
           "file": "src/util/which.ts",
           "line": 38,
           "severity": "medium",
@@ -2298,7 +2346,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "f01b5847b60f8c73b5dda70d26bf1aa7578e046bd7e5908d0d6d4bd7fce3fb3e",
+          "fingerprint": "2427fc885c05c16dfee63693e61fd1187c8515d28c790960cb6bb39beed28e4c",
           "file": "src/visual/compare.ts",
           "line": 52,
           "severity": "medium",
@@ -2306,7 +2354,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "17307467b71cf9f067720d3a32a2dd75ca534c14e2f2289539e186bec504d718",
+          "fingerprint": "c7fd32e7d565a8796e3fbdd8f1129ce706cec6bf60a9635cd186d6143652d190",
           "file": "src/visual/compare.ts",
           "line": 59,
           "severity": "medium",
@@ -2314,7 +2362,7 @@
           "summary": "map_growth:unbounded_growth"
         },
         {
-          "fingerprint": "0409f5d297010ce6b919ed109484eb3fccf9586bae547f5a0b709b38dfce33ad",
+          "fingerprint": "70c6571d9b7064cd2d85934641f3d255ba2a3510e4188eec63a12740db30d9eb",
           "file": "src/workflow/eval-corpus.ts",
           "line": 222,
           "severity": "medium",
@@ -2324,10 +2372,10 @@
       ]
     },
     "security_scan": {
-      "count": 460,
+      "count": 480,
       "findings": [
         {
-          "fingerprint": "a169fab27ce68be9379e227effc85475c00ad6e1b28edc6cf7505c9f9b7870d8",
+          "fingerprint": "5408e4d4e3ebb995a544fa9cf884f57c72d8f2ce3470fe51fc3889c2ad26d767",
           "file": "src/agent/agent.ts",
           "line": 83,
           "severity": "high",
@@ -2335,7 +2383,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "bccb96f69134717620106a5a78aea90c14f45f3b4ea351be3f19bc836f2e360c",
+          "fingerprint": "bf687514168e9e8554765ef2333df1251b2176219fa810c11131da3ccea04337",
           "file": "src/agent/agent.ts",
           "line": 153,
           "severity": "high",
@@ -2343,7 +2391,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "06b96034eda595754c4ec5c85ce43e3b32991cfd2bbb1bdd8aef94be33943496",
+          "fingerprint": "f085470f92d72b72647c71b0b7242b1ffe11f99ee348662b3a4ecc2dd6a0fc10",
           "file": "src/agent/agent.ts",
           "line": 179,
           "severity": "high",
@@ -2351,7 +2399,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c8d265a252e9d5bee6c5d20ba6058c7a7b7ae87bfb7e91d633e30fea3632e8d7",
+          "fingerprint": "aa0287bb13256b6090a6ec1a6f1d23ae58de910950d2cd4a3225bd99ee654932",
           "file": "src/auth/encryption.ts",
           "line": 66,
           "severity": "high",
@@ -2359,7 +2407,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4626662ecdc04b3f7896e6642fb928c07dd59f240ade84670de362826f545b45",
+          "fingerprint": "b033cae0ed606421a7d4ab6308f392af60c94a0f697ed2bd908cc37d39e3a8dd",
           "file": "src/auth/index.ts",
           "line": 22,
           "severity": "high",
@@ -2367,7 +2415,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "1aa78bc0c34968e15fb5aabb07b53d7382b05c1259ae60ff3c78184edcda4fa9",
+          "fingerprint": "04f398e7f7ad429ae1f4d47e7aacd520e267109c734f49c084d936b8af218852",
           "file": "src/bun/index.ts",
           "line": 56,
           "severity": "high",
@@ -2375,7 +2423,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "bf01c58a98650b00cdbef04b45cf03beae9c38ae4c3e5e06f47ffb85673f8e3e",
+          "fingerprint": "f64a4b0364b96cb4d86e1479105a4d13cb0d2eb6d9b5a8352da1931e7fb75265",
           "file": "src/bun/index.ts",
           "line": 122,
           "severity": "high",
@@ -2383,7 +2431,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "9f70669fa806e5904f7fffae8160d33a6e8afab2c6588357b806501b12eb9c99",
+          "fingerprint": "6a12ef65a92f36cba17eeb2493bdc766afd7fa187965ff90483cfd71f6893d44",
           "file": "src/bun/index.ts",
           "line": 153,
           "severity": "high",
@@ -2391,7 +2439,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "46361de54054ffd52f0b3baee223552dcaa8d825fee1c17305f4026fe0f4ad59",
+          "fingerprint": "b3dfe59c1a484a4a216f571b8f851a0f46410f51cb0d1aec50943b7a4a9b45db",
           "file": "src/bun/index.ts",
           "line": 154,
           "severity": "high",
@@ -2399,7 +2447,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "fbc3dc2c457edbb263554650bc314b26edb4603df1b56a3cd5137987b13239de",
+          "fingerprint": "8917a39c14850bdd7f983e21d224b5ea22915db3aedc010cd0483823c3429e82",
           "file": "src/bun/index.ts",
           "line": 228,
           "severity": "high",
@@ -2407,7 +2455,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "83be148c736eeec5a65a81f5342393a1c51e0339c4a38a8b993bab4839c6d310",
+          "fingerprint": "ba8fe02a829d1fabe2e3aa1b9484d841e03f155690f0105d7666dea2bf890c8f",
           "file": "src/bun/node-compat.ts",
           "line": 189,
           "severity": "high",
@@ -2415,7 +2463,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6abb854e21cbba90c1957fd873f60eadd00c8e0830b66466bca4a3b9fab297a9",
+          "fingerprint": "ba8fe02a829d1fabe2e3aa1b9484d841e03f155690f0105d7666dea2bf890c8f",
           "file": "src/bun/node-compat.ts",
           "line": 218,
           "severity": "high",
@@ -2423,7 +2471,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ed0cc6169c21c49dbee7d580c8679984c427098a3955df0750af385d32ffcb49",
+          "fingerprint": "f22e63f6deb1b20815e98de628528654d40d487f8294bd6f1e95c7ea01a1a2d4",
           "file": "src/bun/node-compat.ts",
           "line": 293,
           "severity": "high",
@@ -2431,7 +2479,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "36a8b977c8fad12a82d195ed0850dfeb6f736ccb113d5a4681e49e7fa0e54bee",
+          "fingerprint": "8b1839ee51f3557a2524a150fdfc5842012fe3d258093611105a75592e448333",
           "file": "src/cli/bootstrap/env.ts",
           "line": 75,
           "severity": "high",
@@ -2439,7 +2487,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "89b808b89875df0c699bb7cc020ce5fc2429af21ef3852872d6e1e2975fa6222",
+          "fingerprint": "56c0da75562a33c7bd3891ac49fd4357008833d0d4b1bfb56891d8dca8b8ccd1",
           "file": "src/cli/bootstrap/env.ts",
           "line": 90,
           "severity": "high",
@@ -2447,7 +2495,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "cab9e680c43f16b46d722595ee026d3f801216aab1b4c92984d04ce77515cd75",
+          "fingerprint": "725c0cc32d53dc9a3e5299ccf8c362ef27bbebd136bdd62471554f4bc218d0b7",
           "file": "src/cli/bootstrap/env.ts",
           "line": 100,
           "severity": "high",
@@ -2455,7 +2503,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "fb3a9d9ee4160369c966fe383e901188d0b861056e9910e049dfd954f714daae",
+          "fingerprint": "3a1c5ed8893ce3d5493ff0a69f993f7764867311e31c9ca4165b3798b9d38dad",
           "file": "src/cli/bootstrap/env.ts",
           "line": 142,
           "severity": "high",
@@ -2463,7 +2511,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "06058a3ca13cbd83233a2ad689cb73a994267a2ee82ab6cc3fbed703acf4a1e9",
+          "fingerprint": "2d4c7fa6383b9e2ef8e124cf00d106917c37c062cc444d3a33ad68ed347abbde",
           "file": "src/cli/cmd/agent.ts",
           "line": 107,
           "severity": "high",
@@ -2471,7 +2519,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a3adbab2b3d8c62166c22389219cb4f604c950ec3bd874b604dc09c180f37db3",
+          "fingerprint": "bbcf518ead336ac74b8a1501193afb4699557b67e57986d9bb3092aa71699276",
           "file": "src/cli/cmd/agent.ts",
           "line": 130,
           "severity": "high",
@@ -2479,7 +2527,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "615a69a45c534db768ffe24f7d0fba7a6cf35f839cffdceeaabba66617ec6a8f",
+          "fingerprint": "1189296431d4e3801da810dba113a58d061f479f0985ddd0d657d9cc17a8818a",
           "file": "src/cli/cmd/agent.ts",
           "line": 216,
           "severity": "high",
@@ -2487,55 +2535,55 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "18b7b389b987cd7f1e9a4d61fea2a45dea248a675d393e7dcd85e221d859dd53",
+          "fingerprint": "6444aea85d05b49d571115b2b34182d850f2b9c17c7a4c453c440f47df425cb7",
           "file": "src/cli/cmd/debug/explain-impl.ts",
-          "line": 1009,
+          "line": 1011,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "50d30b68e9c642c46d108d6c119c001aa14d19368e3772067c9f965b971a0638",
+          "fingerprint": "9748017052c91228c4a898f7e1ea90799b2be288a591e9a45f5ecfdc20a4b753",
           "file": "src/cli/cmd/debug/explain-impl.ts",
-          "line": 1022,
+          "line": 1024,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "d6cacdb066da89efdf403dc07ce5cb3e6101eb4c30be6e0d5b95538bff1c5a35",
+          "fingerprint": "b7e7f4c10b5f3d9d8a16c7620b4f2d68556423c243c467d12184da8858f3abee",
           "file": "src/cli/cmd/debug/explain-impl.ts",
-          "line": 1030,
+          "line": 1032,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "3f97204a13694aaef6bf286aaeb03d39ab93af827e78086e9eb27e4c690cfcef",
+          "fingerprint": "98bf748eb798466c05fe6c153da3550e51ac949aa810a0fea3dccf507be136a5",
           "file": "src/cli/cmd/debug/explain-impl.ts",
-          "line": 1034,
+          "line": 1036,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "56206c403d839b4ca03652d42082dcbf4bbbaa51f6c1a705e6763342325889a8",
+          "fingerprint": "2b3e097f23b8ca8191c87c3dd6cfbf9e9f45b7a88ca124b263bc6f15d168ff74",
           "file": "src/cli/cmd/debug/explain-impl.ts",
-          "line": 1080,
+          "line": 1082,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "93a8b2c64dc32ecaba44b6f957599e02a27775aaf7a92253a3f402291e217d54",
+          "fingerprint": "31af930770b13fc176d0d7d904fe4b743722e8ad7c873c85e1934be2c8d6fcf7",
           "file": "src/cli/cmd/debug/explain-impl.ts",
-          "line": 1092,
+          "line": 1094,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4b1c28015fee581f80e27049612d58ec280038743ca67f7e7d333082393ba4ed",
+          "fingerprint": "7581b2c8269cd81832dc15190848c7c29444a4a918a627f7711adcc114ccabbd",
           "file": "src/cli/cmd/debug/perf.ts",
           "line": 298,
           "severity": "high",
@@ -2543,7 +2591,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "15b362396bdce827fc4e5de3d68decdc84c68ea59d498776cbb3aa2968fd00b4",
+          "fingerprint": "225df3dace7c7d535b0cfbef00259a5b91cd138ef07963bafe460a20926284e1",
           "file": "src/cli/cmd/doctor-health.ts",
           "line": 89,
           "severity": "high",
@@ -2551,7 +2599,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "06bb9f219017a872345082d69facc52310939520b48d88049886ab925012bc52",
+          "fingerprint": "d92654e7134a40c7ef0304de18a70498c37a32f5e4bd63404927282b0bfbf027",
           "file": "src/cli/cmd/doctor-storage.ts",
           "line": 29,
           "severity": "high",
@@ -2559,7 +2607,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "15f2012adb05157abaaaff648d29fa28de0da54beea62db21a5fc9e6876d28b4",
+          "fingerprint": "e227cdc5ac27f461c6e0c41db614350e7dfc3950b3a19179cc05c83d0c2167c3",
           "file": "src/cli/cmd/doctor-storage.ts",
           "line": 30,
           "severity": "high",
@@ -2567,15 +2615,31 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a28332ca97262dc740a8b0aa56ab35314c617cba9ba87bdbcbee3fad7e9934b7",
+          "fingerprint": "0e14ce7ea38fe85be3fcfc04759ef7a550ac0bb1bcb77320e9e759bd27e0f9a1",
           "file": "src/cli/cmd/doctor.ts",
-          "line": 154,
+          "line": 148,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f71485d8c40063a979596ef3dd709edb131b78e6e3302a3c3182e1c556e71f3b",
+          "fingerprint": "b31a047cef9da3b20b1a673111822cd5ac54f34c1fd0efe8824963eb01165079",
+          "file": "src/cli/cmd/doctor.ts",
+          "line": 197,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "ef008f3e60995b2a6b21d856a7e9ae4536b541c147070be49c7467ab870212e1",
+          "file": "src/cli/cmd/doctor.ts",
+          "line": 199,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "3cff82c78bf2abdc178e5b5bdda41e631ad4abd6e5fa3e81d5996bebd91c397c",
           "file": "src/cli/cmd/doctor.ts",
           "line": 203,
           "severity": "high",
@@ -2583,39 +2647,23 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "1e4f1e23bd7ecb9d67fe191a42c189673fc4e3cf8e0573d97f8e069f4c04c2f1",
+          "fingerprint": "81665038bceb64b8202c9c465695c93d4614cf2048fef06efa08a21dbcf3afd1",
           "file": "src/cli/cmd/doctor.ts",
-          "line": 205,
+          "line": 335,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "03ad9e1f9656453cff9e604ba10474113ea83d5f83ccf9440502b93ac3823c18",
+          "fingerprint": "286ff3a6171aedeee53d053e7aad686404a1f797803f3791a220323ca13cbf57",
           "file": "src/cli/cmd/doctor.ts",
-          "line": 209,
+          "line": 470,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5432f39d65781119e72732881620e8ddd8b15060c505dce48e8925b99663b289",
-          "file": "src/cli/cmd/doctor.ts",
-          "line": 342,
-          "severity": "high",
-          "kind": "path_traversal",
-          "summary": "path_traversal user-controlled"
-        },
-        {
-          "fingerprint": "9060c131a67c66086eca01386e988ef125313f5b1dc72928018a42e0ac11e881",
-          "file": "src/cli/cmd/doctor.ts",
-          "line": 477,
-          "severity": "high",
-          "kind": "path_traversal",
-          "summary": "path_traversal user-controlled"
-        },
-        {
-          "fingerprint": "095da37bda82d27d2340415d471138990ac9acfbaa9944fd0f9fcd50205a7301",
+          "fingerprint": "17413714c86bfab0f54a59528bb547fde3a45e201297909490ff23abe3cddf86",
           "file": "src/cli/cmd/github-agent/install.ts",
           "line": 188,
           "severity": "high",
@@ -2623,39 +2671,39 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7263294cddd2e207f1c847087c8016f054e1eba71db79680c09e4dc25cce4a9e",
+          "fingerprint": "4d2ce3765336159dc32f1a51fafb32aab728d800690070e090ee19a5bd866d30",
           "file": "src/cli/cmd/headless-run.ts",
-          "line": 123,
+          "line": 121,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "47bf3be4804f3803867753a95a10c7509042ef8af70cd33619b4ff11ea8abfef",
+          "fingerprint": "b2ae1d9c8f2ddb83e2114d4bb0423673b38baecce09c274e651a8f6fc44c8ceb",
           "file": "src/cli/cmd/headless-run.ts",
-          "line": 211,
+          "line": 209,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "acd79c8f483c083ad18962513b56bf98c905780d18873f329a092eb28789805a",
+          "fingerprint": "15a83d1e9814261e92f3033e3a6882e605282e1544860351f66f7517bb8cf97d",
           "file": "src/cli/cmd/headless-run.ts",
-          "line": 259,
+          "line": 258,
           "severity": "high",
           "kind": "ssrf",
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "780c205a00cc0fed353aa3a5c33d00cb35070fb15d95f5c32514eaf0ba588fb4",
+          "fingerprint": "f575182d93bc6ad72c31971c6e7e2da500a2ad0003d01e382a4f0991641e7bd3",
           "file": "src/cli/cmd/headless-run.ts",
-          "line": 267,
+          "line": 266,
           "severity": "high",
           "kind": "ssrf",
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "4e722afefa78ed5f0c4c3dfff3f825e1892fe0f04ba3f364df859ff41ec249b6",
+          "fingerprint": "e5e8c49db35a00d3d9f09e705cd7269ea8f04354fc4e18a5aa81ba4fc5b6e70a",
           "file": "src/cli/cmd/index-graph.ts",
           "line": 342,
           "severity": "high",
@@ -2663,7 +2711,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7e2bfc85c3bce446838c9914389a5e876cab63bbbaf92644424a7993291c26e1",
+          "fingerprint": "0bd9b463f8492083fa7b6453b3f15cbf52a5659d18c2026d9a56210e00689b4f",
           "file": "src/cli/cmd/mcp-impl.ts",
           "line": 563,
           "severity": "high",
@@ -2671,7 +2719,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a242a91ca1c4e9e622ea226554500f4bf422eb59df2efc5b64632124c5f821c4",
+          "fingerprint": "b95d768eef88571813389e3df6987e283c09778cc24b9cd64698d0b95d4cf592",
           "file": "src/cli/cmd/mcp-impl.ts",
           "line": 566,
           "severity": "high",
@@ -2679,7 +2727,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "3019c7da673cc54fecf4b2ff867ebf6e28989c29296bf1d0f89be0ccc4389ca9",
+          "fingerprint": "34af0ca9abedf5e0a3675d6ad34265ee12f06dd432f5dba35031950a57bb836d",
           "file": "src/cli/cmd/release/check.ts",
           "line": 105,
           "severity": "high",
@@ -2687,7 +2735,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "745afaca61bf9651c18b4ca4bac6f46d5bbb8312f4a7240b9adf96a007a89332",
+          "fingerprint": "3985889cda1306c00ae7e2fc6b55515142c523f3e0ab9822236ffb47a5fc550b",
           "file": "src/cli/cmd/release/check.ts",
           "line": 106,
           "severity": "high",
@@ -2695,7 +2743,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f106ff731abe6699442412031647fb61304817b55f2f19e2e643c2d4471a9aa0",
+          "fingerprint": "17efd3c161d6f42ebbdf6e2b54310ebc17f16029aca7664400c44e80f765b539",
           "file": "src/cli/cmd/release/check.ts",
           "line": 107,
           "severity": "high",
@@ -2703,7 +2751,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6aee9af5bdb3e13c795a65bb12491dfb171ac6657c96abf28f4bfcda66df4327",
+          "fingerprint": "0460de992d58e4150b7f00247451e5f92b6a887b4c704d3b45d0915e238a40fc",
           "file": "src/cli/cmd/release/check.ts",
           "line": 183,
           "severity": "high",
@@ -2711,7 +2759,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "bfc93c684888188c8c3b8373dddbfb08aaf971141a01b8f882305a7962854e77",
+          "fingerprint": "b91d03f82e1f89be7b9e1a309a521cd8fcd1a27bc3d8cac52ababb7fb11f3399",
           "file": "src/cli/cmd/release/check.ts",
           "line": 422,
           "severity": "high",
@@ -2719,7 +2767,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4b885de69c400cd57f09501e8647a1e24db6f8bc8d867c29bcc33133d13c7cd2",
+          "fingerprint": "9557b0afe39ce7b22c5b9e8434c8f6bc38d18e63b4d63def3201660923a7dd51",
           "file": "src/cli/cmd/release/check.ts",
           "line": 423,
           "severity": "high",
@@ -2727,7 +2775,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4df5b06bcf9fb97933bc58ad2b75021d58e3e0f673a699c2ba319d72b192c9b7",
+          "fingerprint": "bd133ba03fab7633d6a654e4bcd397301c3e6d8eb4dd9c3428c5cc8139609429",
           "file": "src/cli/cmd/release/check.ts",
           "line": 468,
           "severity": "high",
@@ -2735,7 +2783,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7670771d5d65a930ecbd6ff4e403e1da6e4dd92ca0a9b929fa1efbf372186a8b",
+          "fingerprint": "877f00cd6d9cb6fda448cf7050d47ed05481ccb14b97fb6e7e30e7ec89111d39",
           "file": "src/cli/cmd/release/check.ts",
           "line": 469,
           "severity": "high",
@@ -2743,7 +2791,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "112a8f148f37e23556a8883f970b9fc3f002dca765073fdc764964d77f388439",
+          "fingerprint": "138ae6fd3abc50ef4f7447db812eaaf72b9f48af484132156e3eff7c1aa6775a",
           "file": "src/cli/cmd/release/check.ts",
           "line": 470,
           "severity": "high",
@@ -2751,7 +2799,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ad7f3c5aae977eb288421b4c06458789e2b687620c825d8fb1174aedd34ad696",
+          "fingerprint": "4397c0f73e1090ba091c8b79633306ed0f6e142833026f5dce0605f81f605e84",
           "file": "src/cli/cmd/release/check.ts",
           "line": 471,
           "severity": "high",
@@ -2759,7 +2807,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a078cea3dfc5d885fba1db04822f911203642b9305e09d0af6fa9645ca6d359d",
+          "fingerprint": "a35acdc67754f052296025bddbdb25a6281a5d71cdce6284b6d6e79f6dd7b5eb",
           "file": "src/cli/cmd/release/check.ts",
           "line": 472,
           "severity": "high",
@@ -2767,7 +2815,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f9968a4728de89b726734f22bb605b3530007a17920efe15dc034dd8ef11a1c8",
+          "fingerprint": "ad580a938fd3d8fc800239d30891b9df8e8377295d19dba149c49b4631bf7ed9",
           "file": "src/cli/cmd/release/check.ts",
           "line": 473,
           "severity": "high",
@@ -2775,7 +2823,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "fb591d3149c3812715086560c09bafb6182072b7c232045e5fc964c1f73aeeb9",
+          "fingerprint": "a77c1f150c86240716d7fcd09899c5d1799a0401feb70ad1a2e43a8bf5196f15",
           "file": "src/cli/cmd/release/check.ts",
           "line": 474,
           "severity": "high",
@@ -2783,7 +2831,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "173eb0e97ba4cb1b8f88cbbfd149f38113645da59e8a8f6cf5b0f33c314ceb6e",
+          "fingerprint": "6e86c2edad0f83b1684abe6e22dfdfe39ee0744c7db054c924034bc120ab2065",
           "file": "src/cli/cmd/release/check.ts",
           "line": 475,
           "severity": "high",
@@ -2791,7 +2839,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "22a9aaa73463f9cecc68cd6a624bcc6ec76fd4f7839fcf2c8579ff385545a1bd",
+          "fingerprint": "efce61e43f72a70bed27652d0e136aa58468187eb44aa5f55593911ebc0ff89a",
           "file": "src/cli/cmd/run-output.ts",
           "line": 33,
           "severity": "high",
@@ -2799,47 +2847,47 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "9771a09df32a495413f9bff862ffb4a1db8a52c213b34b04764c7ed9559f013a",
+          "fingerprint": "786818011076354b7288add6e57f278c94648d9e37d3d720215870c5d686d001",
           "file": "src/cli/cmd/run.ts",
-          "line": 179,
+          "line": 180,
           "severity": "high",
           "kind": "ssrf",
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "0ef4360f034fff769a8d138483f468cdd866db45d3465419871742e36fb7625c",
+          "fingerprint": "442ee2312509ba0fe70e7ee5038e3d4ff105e2f0affe0c18516ba081097e1e67",
           "file": "src/cli/cmd/run.ts",
-          "line": 388,
+          "line": 389,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "48a889b73db4438fb5eb7f2307e56b15cfc7c13cdd28022486b6196d5c5469a1",
+          "fingerprint": "fb903ea4341eb9ed37008087d84a22583a407faf3d79608a906d19815142fa07",
           "file": "src/cli/cmd/run.ts",
-          "line": 395,
+          "line": 396,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5ae7dd90436b26dda688867d7c10a8da23ca4b94b5077f872154239d8befc688",
+          "fingerprint": "34468be575e7453aab6bc2c76d99a7fcae2984bb575c7d2576e4eadd934ba870",
           "file": "src/cli/cmd/run.ts",
-          "line": 512,
+          "line": 513,
           "severity": "high",
           "kind": "ssrf",
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "2a0bc2b7cf00a8c1c73506764c379e97714458f04c127c5965283e92cad2b384",
+          "fingerprint": "c8611293792601567cc9a61b5199a2a79ac88e15bafec36dd1dc6c2d66f47602",
           "file": "src/cli/cmd/run.ts",
-          "line": 827,
+          "line": 829,
           "severity": "high",
           "kind": "ssrf",
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "48c7fc0bd86b17752882a79aed589568f47e156655c7279975df8264f628493b",
+          "fingerprint": "84e397a5df4ca86c8ea42c2e08ba8ee7428cf0f75463787767b78995286d51ec",
           "file": "src/cli/cmd/runtime/restart.ts",
           "line": 26,
           "severity": "high",
@@ -2847,7 +2895,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "7837713eee22fb9e60b3c8219165c3d5273259c87b6faa65c1879261f9f76ca0",
+          "fingerprint": "5a6ffe0939429724b505fe7b4120509e4bacf824e883edb16e565db60f0844e5",
           "file": "src/cli/cmd/skill.ts",
           "line": 128,
           "severity": "high",
@@ -2855,7 +2903,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "cde75a3aca130ee3a375c0b104bd2b76f9b8aa2d251d26608276febf2ac463a9",
+          "fingerprint": "338775051e63d6c6b2b2127d766326b108fe95b4e19259843f45edabaf2819b0",
           "file": "src/cli/cmd/storage/session.ts",
           "line": 40,
           "severity": "high",
@@ -2863,7 +2911,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2a72c4cf6abde101e118a1b54e27136417c57d88c61aa5e8bca6da448ad76d33",
+          "fingerprint": "5073adf77248bf9272591b2e634fbe367a5ca61ca1f5a928a2895056d2eff3c3",
           "file": "src/cli/cmd/storage/session.ts",
           "line": 46,
           "severity": "high",
@@ -2871,7 +2919,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a887c2fad70d353a63d899cc1239e43ba93d3c35ca6edd571578d08542157e79",
+          "fingerprint": "e0b5cea4bac97d818e7ab87b303ab2b7b885ee0d26d38cae95bc4b9441bc2fd4",
           "file": "src/cli/cmd/storage/session.ts",
           "line": 139,
           "severity": "high",
@@ -2879,7 +2927,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5bf9cee53942d9197fe2cebf91b76bcae62a87545c5980dcddc5f9ecfc7f1ee8",
+          "fingerprint": "d5d3e85874a0ec0a1abc81bf72769563679e412553a2d6a34397e9038420a6ea",
           "file": "src/cli/cmd/storage/session.ts",
           "line": 140,
           "severity": "high",
@@ -2887,7 +2935,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "8416277747c4fe9eae80fc639241976aef29c0bc89daa28ea912e49e18725faa",
+          "fingerprint": "6f41075057eeb56db1fc6215f6ec0f7bbd948edeabb58be41535c474a6e7152f",
           "file": "src/cli/cmd/trace.ts",
           "line": 276,
           "severity": "high",
@@ -2895,7 +2943,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b740fb665ac3ccf4bb3329b114d907d45ed30d07cb7e41375c71dd74722ab0c7",
+          "fingerprint": "3267fa61523c716f17d8cd54219a04e3150294a20b536526378f191b74f8aba7",
           "file": "src/cli/cmd/tui/component/dialog-provider.tsx",
           "line": 106,
           "severity": "high",
@@ -2903,7 +2951,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "80feb1809f24cdd1753836f24dba2179fd177744afe41ce47070051cc5ba9ac4",
+          "fingerprint": "b68cbee8d18b91d300de146d7ffd04debf4e4505a232cc9e371966e1f8398e08",
           "file": "src/cli/cmd/tui/component/prompt/frecency.tsx",
           "line": 30,
           "severity": "high",
@@ -2911,7 +2959,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "cec82c026fb4d2d9038d8016ed3eeff8bb282908d74093730989c709b82ddedb",
+          "fingerprint": "1da7e562e3c7c807e87d7b0f5d95342b57e6fbd16492cf903de532503e8b4604",
           "file": "src/cli/cmd/tui/component/prompt/frecency.tsx",
           "line": 137,
           "severity": "high",
@@ -2919,7 +2967,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "dfbe059dd8ccc3a6484d5f610a57892a94a39f16150eddc8c05917efa2165051",
+          "fingerprint": "1b2cb3ca3183cf1b8739516150af5315a98692cd7678eae56bd592b80ca0d1b6",
           "file": "src/cli/cmd/tui/component/prompt/frecency.tsx",
           "line": 168,
           "severity": "high",
@@ -2927,7 +2975,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "71098796aa316d10b78b8a85ee799e57d815dc59bbf95a4ae48dbac6d7459c0c",
+          "fingerprint": "b06a16aefd760be357a31fcce5320cbcee3515d1a13143750ef6b72d85d891a6",
           "file": "src/cli/cmd/tui/component/prompt/stash.tsx",
           "line": 27,
           "severity": "high",
@@ -2935,7 +2983,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6a15336841d6eb847cff269e693fd7dd2ea9819715d48340c1dcd51a6f6ebf2f",
+          "fingerprint": "fd27d196beff4989319c1df11164a7d33f1290db936ded4380c90c31e530df7c",
           "file": "src/cli/cmd/tui/context/kv.tsx",
           "line": 21,
           "severity": "high",
@@ -2943,7 +2991,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5a9549e5f9cbd973b2b5b61365e127c0c5a8d86fe84edfb93d5293c80c36e298",
+          "fingerprint": "19d5249ee6b479f574ea2f66ec81202e4d59337925edb6027277aa2ecebdb785",
           "file": "src/cli/cmd/tui/context/local.tsx",
           "line": 178,
           "severity": "high",
@@ -2951,7 +2999,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "8fe9388b2cd030e72864a2d15749452e251fe47b0d1205f669a23779d5ded432",
+          "fingerprint": "78effd5728d7056ddbb893ecc40b0c8464731dfe024c28ebd508686e0a4e26fa",
           "file": "src/cli/cmd/tui/context/local.tsx",
           "line": 532,
           "severity": "high",
@@ -2959,7 +3007,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "8184122613993d80267c8f5c0f06bf5f62e56fcc77ee78488a579bc46767e5c9",
+          "fingerprint": "f49d741da7cfafd6edac93075505a084cb52ac4a2f6160d56e99886c78e8241e",
           "file": "src/cli/cmd/tui/routes/session/dialog-capability-catalog.tsx",
           "line": 30,
           "severity": "high",
@@ -2967,7 +3015,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "8b03c1c675e18efc43ff1423dcdd34fcdd9ffebe865d73513a82e95122986b61",
+          "fingerprint": "47d9ee53d5297f6d6198f2d29c78ac17db7030be89fa5ddef6f65f5b220fb6e4",
           "file": "src/cli/cmd/tui/routes/session/permission.tsx",
           "line": 42,
           "severity": "high",
@@ -2975,31 +3023,31 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "8d76b29e84eee8b0b94d7aebcac9f6b9a914b4d7ed781d083070268dc2713512",
+          "fingerprint": "6df67c84df881ddaec85d73b36829aaf9ba170bb6ea61be14c4630cb44d320b6",
           "file": "src/cli/cmd/tui/thread.ts",
-          "line": 126,
+          "line": 133,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "741eac1fc96e254eb37b94b7e4eb47b44b35bb842c3b102a41359dcb8f1499fa",
+          "fingerprint": "245e3bc8d83e859251b96b14500a0aba283751574525389145cc2397c82a4827",
           "file": "src/cli/cmd/tui/thread.ts",
-          "line": 175,
+          "line": 182,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b80a98d5f41d12fdd246831195ab453f4259b8fcf25f8afcfcad8e565b182263",
+          "fingerprint": "1db1d5d3f9fb2cdb8f6558b16a6b8b2aa7c9984bfc475319823f69ac11dcc507",
           "file": "src/cli/cmd/tui/thread.ts",
-          "line": 654,
+          "line": 684,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "243959c9ace6abfa65762ae2515f71eac895c97299730bb619c05a79cb14b931",
+          "fingerprint": "232313ef304e0cff7560d32cdeb0e671076ea70d6791d28d7cfa5c447a23e089",
           "file": "src/cli/cmd/tui/util/clipboard.ts",
           "line": 170,
           "severity": "high",
@@ -3007,7 +3055,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f7aeea09b028da786a20f01bc50098a0a24d46c3ee99ea30ca43bff01e550ae5",
+          "fingerprint": "4f9ab8523f395c0ab03ed33d2fc8f37f9b2db1bf6377677ea50653c87f5d399c",
           "file": "src/cli/cmd/tui/worker.ts",
           "line": 35,
           "severity": "high",
@@ -3015,7 +3063,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "75e9cf8ad4503c6900f6b2f0a13c2e7c904344df172e31368020dbc0d46eb930",
+          "fingerprint": "a533c45afeed401715731659f9cfc3a113ff826789a1ca15a6d3e442381fc6d1",
           "file": "src/cli/cmd/tui/worker.ts",
           "line": 136,
           "severity": "high",
@@ -3023,7 +3071,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "8818eaec8f8f3d8e81565cba2ad01ec091389eb62d2c2c7a18175d3d99c41515",
+          "fingerprint": "0be7d9847f86419261d311f45082eed7fb2a932e72e25cf492848c49124304f1",
           "file": "src/cli/cmd/tui/worker.ts",
           "line": 208,
           "severity": "high",
@@ -3031,7 +3079,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "dde3bc1fd68e3df65c70abe29d6b4d597decc04a1a08c0a557daa286bde5c13f",
+          "fingerprint": "1167390a61d05bf4bd9c9b2e369bec5fcae2f947b27fba7ec346a8dfb95bed22",
           "file": "src/cli/cmd/tui/worker.ts",
           "line": 222,
           "severity": "high",
@@ -3039,7 +3087,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "ac9ea591b1d3c1466ed2b8628a30b79a7d11e14257c409731c7d284d6d586272",
+          "fingerprint": "446b89f2eac31932faf9d4c11e10e00b2b10b3382cbbe6547de0fb56c439333a",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 220,
           "severity": "high",
@@ -3047,7 +3095,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4a62e2c4396ef9e67bdd92a15294405443adccff9d21d819591f9921e0de9983",
+          "fingerprint": "b479e48d76140a6703efada19d260645b71ffd0da1f6eff7591d70ffaa512fa4",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 223,
           "severity": "high",
@@ -3055,7 +3103,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "8acb2e7753f2c4d9465f8122e93c6adfc3a03fcf19aef92772d9be02b9c45a4f",
+          "fingerprint": "cf16bfa0c772f3f90dceb4a481e4a75dc23f05abcf420cacef8f6636d8f603a8",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 225,
           "severity": "high",
@@ -3063,7 +3111,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "708c04ada1a96e965113eecb987da4f6c419528cb89f36cfcae677f29fdb1ca8",
+          "fingerprint": "28d33dbce8289b912b4ad66f361433032e266f2ea64d720ac36f446c08421009",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 226,
           "severity": "high",
@@ -3071,7 +3119,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "738ea9d6eff8c258263b47921689b656837a03dbcd4d682db9ce5239e2861948",
+          "fingerprint": "fde9c5ab42bfd723ef2d0b3c455d3679420f77eade2f7994c4f750187b617db7",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 227,
           "severity": "high",
@@ -3079,7 +3127,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "9d9166fb47a363d787d07191499fd18231f229d60ef358aa65728b46bf841252",
+          "fingerprint": "18aa7fcd8950412670252a98f5cbac9455772f5f586105869b0e1a3bfcfba2fb",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 228,
           "severity": "high",
@@ -3087,7 +3135,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ca50c7c2286a2648181b6106f52124328887068be112640d8e19a70443ea9716",
+          "fingerprint": "c300af69fdccc1acc74c1e9b066934e6782e48a7ca20f6242107cb116e3b7bc1",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 231,
           "severity": "high",
@@ -3095,7 +3143,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "801e203361d4e2ec58c4893cb28c0da637d60156ab8344fc559bcdf48735881d",
+          "fingerprint": "8779082dd62199715d6d9775861c24a2533adb4d9882f7900fbc0483dfab5338",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 232,
           "severity": "high",
@@ -3103,7 +3151,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "1d3540c37869557469795efa9fa9a72290d5f938f9c5d397c16d927a651e50d5",
+          "fingerprint": "54000f86ee8a9795d4d6142035959ea3e3184aa24e77586504c8fb3ecd58d77a",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 233,
           "severity": "high",
@@ -3111,7 +3159,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "91bc443ad2551806d39f4051366f9c304070c6ece07387877da67f385b243b23",
+          "fingerprint": "aaf506e1f4c181980e73b1b2c3bf9e2bb4e4ef806ab3d3c0338615f262758636",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 234,
           "severity": "high",
@@ -3119,7 +3167,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "42e167f5fe488cb9bc7050fa1464ec42702cbca4d445fb603c8a7a478dbf743d",
+          "fingerprint": "dff266c262246459c2952eb3d7121c23742218ca5524859859a3a7edff9a9c1f",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 235,
           "severity": "high",
@@ -3127,7 +3175,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f31458ec93541fc6178a3fd26d56f78bb4902820f80b21e9970681602e0332de",
+          "fingerprint": "e70469e9f42cb690c02576b994547b753061a54f6c8853d071b044cfb4c92c69",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 237,
           "severity": "high",
@@ -3135,7 +3183,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "26451fb4d5739f7356b244ad0cc2e63e2872c5ac41e4942f64025f6aa8c399d8",
+          "fingerprint": "0af018dc8f3be88a0db776e39f3bfb270775dba098946f1edf559d739d67e174",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 238,
           "severity": "high",
@@ -3143,7 +3191,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "66f0a022b5cd5a1ac0f5cc50d413f9ff1240899611af623da29f293df7ea5aeb",
+          "fingerprint": "7689a58f80be05827e0683fb1648052700b27430f7de11e6e911ac499c1ec337",
           "file": "src/cli/cmd/uninstall.ts",
           "line": 306,
           "severity": "high",
@@ -3151,7 +3199,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e25b42aa15465bb1fb648a417c98f98d7b929d8397b10fa818178b4287bf56b9",
+          "fingerprint": "5eaf1acbfb1780978a6df939d729be9ed26bacb55ab63905c7ae14cb739857bc",
           "file": "src/code-intelligence/auto-index.ts",
           "line": 317,
           "severity": "high",
@@ -3159,7 +3207,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "d026cc38676f930992d8b97eb9639a96fd5fef54b97326793b10744eea53f7a1",
+          "fingerprint": "fbc26c2eb4407eb7f96552bbf44550e45f28dbfd600524e62bb53ca83ac5f6e1",
           "file": "src/code-intelligence/builder-impl.ts",
           "line": 140,
           "severity": "high",
@@ -3167,7 +3215,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "391608bef3a76802e61403bd38d65a5cc285d2d6ba38d8944295d6997dc10467",
+          "fingerprint": "98007978cd7d569be7b82b03b5c3c30c6639635855ef0e4e8e8b7d7c85c32ec6",
           "file": "src/code-intelligence/graph-context.ts",
           "line": 193,
           "severity": "high",
@@ -3175,7 +3223,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "9e0f45865413ec30e618a48c471d09ff8c251de880607e3ef24ce632ad4a0985",
+          "fingerprint": "3eb7ce0596173ce8c60288657835cf1d09dacbcb68d0ab9b274685530314013f",
           "file": "src/code-intelligence/lockfile.ts",
           "line": 59,
           "severity": "high",
@@ -3183,7 +3231,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "41ecb76579dabe7ba06fda89e5cff752a02bd88ca5efab495f5b7b88abbac4c9",
+          "fingerprint": "551144d7f7e0d4e43dc4df313e52488a95b9dc59afc25ebb82c9761ff72d09fe",
           "file": "src/command/file-command.ts",
           "line": 154,
           "severity": "high",
@@ -3191,7 +3239,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "9c70715a80d0dc95d218576128c05868361426fb17fe07d499ca2b7e062515c8",
+          "fingerprint": "f4c006e18f09ce0716278767d75f4d5b54a8a042121f9aa1676899f991233158",
           "file": "src/command/file-command.ts",
           "line": 155,
           "severity": "high",
@@ -3199,7 +3247,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7f304cff9f511bfcc7f97424a313bcad9b1f5aeca34c4a0643da0a042c315ebe",
+          "fingerprint": "65c8016b0957b80d56072b41f345533c80929db3361b019eb9a020f0e6beaba1",
           "file": "src/command/file-command.ts",
           "line": 156,
           "severity": "high",
@@ -3207,7 +3255,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "204aeeda1b8df8a89e6e539d0c8943dd15d62acd5b87f0c9354e31d24efd35c2",
+          "fingerprint": "26a80ce953c9d242c7855610ecbccee6a1312fc6b186f8daafbe8afa3845eec6",
           "file": "src/command/file-command.ts",
           "line": 211,
           "severity": "high",
@@ -3215,7 +3263,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "12c4fd3490f9d9164ccf43f17445adcce9b03bdaad0c93c3152fefac19a68b5c",
+          "fingerprint": "24fd85a130c9f67e87d5e82be8daf898cd0f38be4a3f2ef35e5e74e9b1fe2a40",
           "file": "src/config/config-impl.ts",
           "line": 155,
           "severity": "high",
@@ -3223,7 +3271,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a0b5ec7953f35465637c30a30be948fe0b31961eeb4839c6e9513f8c97441229",
+          "fingerprint": "9b2c3304a04883f351de0a6b2a9a7513a91e1899709b1e3d01282b9e71b9fd36",
           "file": "src/config/config-impl.ts",
           "line": 397,
           "severity": "high",
@@ -3231,7 +3279,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6068bfa67a40f511bbcb23d1bff0eeb9aba83022f9f6a56d7264d7fb4f109e0b",
+          "fingerprint": "dec8f08c4c19ec4e1495b2526a37a8ec2a7d8770f7cc9bfe3775312c8bc06011",
           "file": "src/config/config-impl.ts",
           "line": 398,
           "severity": "high",
@@ -3239,7 +3287,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f0433a69bc7458772b9d6b09ced17e997f619462faae538ab583bc8a5c5b1da5",
+          "fingerprint": "141dc0b269075bd172b73a3e52a72bcd96579c1e6c81fb887f1d2a4e8a2f186f",
           "file": "src/config/config-impl.ts",
           "line": 538,
           "severity": "high",
@@ -3247,7 +3295,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "582329c93f273cbcd62f3dea8d6123c0edd93fda03c7427ffb41a6aa99b4ef5f",
+          "fingerprint": "970202e83d63974dd67bb0227e70a6aa11abd7d2837f5d84e7415b59681006c5",
           "file": "src/config/config-impl.ts",
           "line": 635,
           "severity": "high",
@@ -3255,7 +3303,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "1117143dbfa9c3455209fa3909e279860452a87363ebff95a8ef6ed9ce429562",
+          "fingerprint": "61744ac4aa1a5b091ca953cdbc0f233a101d6022808397b08a0ecb6112faa8eb",
           "file": "src/config/config-impl.ts",
           "line": 652,
           "severity": "high",
@@ -3263,7 +3311,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6fa8c2280df6fa1a6e75d8dc5c9f81d27b3f1e3f425281fe81b93809978c1f80",
+          "fingerprint": "2440cbe37b3873f7d584769971e7b118d1e6ce7aabb7ed044841239989a7eeb7",
           "file": "src/config/config-impl.ts",
           "line": 706,
           "severity": "high",
@@ -3271,7 +3319,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ad3ab73060df1ebf304167dc73a1392dc46d0d199f57703be6de6bb4ca2ea0e1",
+          "fingerprint": "90223446a5dbc9576cb9ea5db23da18eb6aa019c2df36c9c39be1e9b17d7a2aa",
           "file": "src/config/config-impl.ts",
           "line": 709,
           "severity": "high",
@@ -3279,7 +3327,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "35463b2d082ce5bedcd2d03d33b0814e3708db567a1876f1b598cbe74bf855e1",
+          "fingerprint": "966c9343fe7d0e955f1b7470fb905df74f6c838d1b7b0ee1a067825911b6fe22",
           "file": "src/config/config-impl.ts",
           "line": 887,
           "severity": "high",
@@ -3287,7 +3335,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "94376c7c7a8c712e01296f3373704e0b27fc7380759b4e3eb10e9facd776e0ac",
+          "fingerprint": "8b832f096377dc8bd28171df20be3d92ee49fdc643cebe3e020e2da018a3629a",
           "file": "src/config/config-impl.ts",
           "line": 1050,
           "severity": "high",
@@ -3295,7 +3343,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c4d3d305ac85e4ac9f6b186363b84cc2cbd4db87ca371d6995a88065bec97251",
+          "fingerprint": "7e745ad8fab42df26795b1e7e26bc0bf3409f7150cf25700e38adf74ce34b8e9",
           "file": "src/config/config-impl.ts",
           "line": 1051,
           "severity": "high",
@@ -3303,7 +3351,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "8c56a0b7ca676b30cca5dfb7b07d955dcee8f9c6086b4f9684fc950007401537",
+          "fingerprint": "1d6b0110f81f38d8fa0388aed4c4c2c787a954390580fe622aeffed96e9bf0ad",
           "file": "src/config/config-impl.ts",
           "line": 1052,
           "severity": "high",
@@ -3311,7 +3359,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "312d88370994420cf63558f17ded428cf0e3c3c8a45ca0052d84d1f8e440e48c",
+          "fingerprint": "c8879f2b11ca1d9744aeb382abd29eed1d4c337771d855a689ae954187299e8b",
           "file": "src/config/config-impl.ts",
           "line": 1055,
           "severity": "high",
@@ -3319,7 +3367,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6f313cdd14727799b8799ce9e7aa66d1a1d7ff35b4db398351e3b09c4d5823bf",
+          "fingerprint": "b425d379a2ff16dbc3497514716484312fe3d883e07e3563c40382341782192c",
           "file": "src/config/config-impl.ts",
           "line": 1067,
           "severity": "high",
@@ -3327,23 +3375,23 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7427d68273449144c753f77fd3596bce74906528c30ea62cd7334d616eeb2810",
+          "fingerprint": "a0a8c47e15cda2bb8e51b8267b8b8c3c2cec4d42b2b7a8a46115c2502338132a",
           "file": "src/config/config-impl.ts",
-          "line": 1195,
+          "line": 1214,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2edb17a9e978a7490f441e98cd37384e4a3bc33bf75068fcc46e5f539ebf6438",
+          "fingerprint": "79aad6baffef594fbc313ba85cf3f098c14c1d1e3178b6c196cbe05556d3441e",
           "file": "src/config/config-impl.ts",
-          "line": 1209,
+          "line": 1228,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "1811fccf0ed12f9ba807f87265c8538fa49e1dc5391ab7eb8b18dba91eb954ef",
+          "fingerprint": "ffd85d788f80da7f6b691abf8e21e4eadf20376e45422c07b5052c0002e5d53a",
           "file": "src/config/migrate-tui-config.ts",
           "line": 65,
           "severity": "high",
@@ -3351,7 +3399,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "cd9418f9c571bf389bb0f26790e23cf1ce476247272428d73597aff5088d9f72",
+          "fingerprint": "b059bddb65d3c911f788537758afa1b91f1e81652277905feb6cd2d47c242465",
           "file": "src/config/paths.ts",
           "line": 50,
           "severity": "high",
@@ -3359,7 +3407,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b26a310691b12ffce0ec05e6abd6320498867a7b05cc644b2fb0353206262a22",
+          "fingerprint": "776f0261073f2abd49c92223e229730c842a2d6526ef6d797a7a0b23c3150b5c",
           "file": "src/config/paths.ts",
           "line": 68,
           "severity": "high",
@@ -3367,7 +3415,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "918ee1eb128da867343f3921cb2c6d979e39f53bf2dbf37bab9740f53a4b13a9",
+          "fingerprint": "26e7dc14e30d3298c7b069ffb4c066f8150f78d83c739c2baaeda8b82c0cc9d8",
           "file": "src/config/paths.ts",
           "line": 146,
           "severity": "high",
@@ -3375,7 +3423,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ce89c163507453684ab6a125d22644eedde8ce7baaefdc8f4728f0e0312de9fa",
+          "fingerprint": "a22ca7cda437d6e81c74314bfc5f695b235d2ce3bdb49c366035d58b9e5bd367",
           "file": "src/config/paths.ts",
           "line": 175,
           "severity": "high",
@@ -3383,7 +3431,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6054fc507df2e5e978764d4cf924e32e182a935bafe9b77e5841e56fd513b55c",
+          "fingerprint": "d4548b5e4caacba01af54fe8863ccfd33294b62fbe78c761878ccb4ab4d8fb19",
           "file": "src/config/paths.ts",
           "line": 178,
           "severity": "high",
@@ -3391,7 +3439,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "707da2408be4b90af1e5dc94529253cb9dd0f71682b5815a6aacf0c30269583f",
+          "fingerprint": "8f0b0fcac14d2f1054c2cb9ae36b1771d049be164220ce548547e9b394cf7ecf",
           "file": "src/context/analyzer.ts",
           "line": 93,
           "severity": "high",
@@ -3399,7 +3447,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "dfe8256454ffbfab0bb62de46c92f9ddc794b09b1986465b85bf8796297f1966",
+          "fingerprint": "c71cd132767884eb9e46a7ca91ed770f73c1220aae5a4762050c0480f5d4a5cd",
           "file": "src/context/analyzer.ts",
           "line": 171,
           "severity": "high",
@@ -3407,7 +3455,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "456d5d684ebd50c4398cd73fbc482bddd4b720da3a0c57a43829bdf14a2c8b81",
+          "fingerprint": "75e3b096c2ad8806a35658e8bee4bafd3ee91193b5274eb10e5e6c144c1a3b53",
           "file": "src/context/analyzer.ts",
           "line": 410,
           "severity": "high",
@@ -3415,7 +3463,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b2030b4face2e42da21a1a56b95c40fb0542282befc2526b77890cd1b7c8f776",
+          "fingerprint": "6c9d5340e0496623ffdef213db29e966a02e8ff3e4a7ef423917e930221bfbaa",
           "file": "src/context/analyzer.ts",
           "line": 416,
           "severity": "high",
@@ -3423,7 +3471,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "0017179bd31a1786cb1fe094fc93283eab10d9cdda7b546b1a2552f4a74cbca2",
+          "fingerprint": "6aaf72fd5cbe64aef5acb6470e8c712cf31295f6aa0e22bf1926b3b656ba5785",
           "file": "src/context/analyzer.ts",
           "line": 428,
           "severity": "high",
@@ -3431,7 +3479,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "15dd20f734d9f798bdc707077740325b259e268a3186b71ec2b7968b07c83437",
+          "fingerprint": "89895ae79be976a5e7046bd9bd9e1f76c85e4485b84fbfc913d90fa7f2294a6c",
           "file": "src/context/analyzer.ts",
           "line": 443,
           "severity": "high",
@@ -3439,7 +3487,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "dcb4966cb299f5bf461e0dcefcbabf8b08ba5cb888414f1b48e9997c1dd719eb",
+          "fingerprint": "c3c6a99dbd2a368e1de91c4eff015b57fad8532a2b049c88c812c548f97f66d1",
           "file": "src/context/index.ts",
           "line": 39,
           "severity": "high",
@@ -3447,7 +3495,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6ed6efeea7a8b52cd18737c6d1ab25c56d3ee243fc1dc155a70d343423e10a0a",
+          "fingerprint": "227724f3f9326c3572dc2a3ecdc11a7a6161d7597370e36a38048ec0a7bb1a6d",
           "file": "src/context/index.ts",
           "line": 85,
           "severity": "high",
@@ -3455,7 +3503,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ec6c88e075635d628a0b39146f37a49cc7cbdc9f56655320dd596bfa684324a5",
+          "fingerprint": "868f2df6a9efbfcd5f5c274e779ec9ca2beb4aff80ee40adbba8a8727d2cdf1f",
           "file": "src/control-plane/types.ts",
           "line": 5,
           "severity": "high",
@@ -3463,7 +3511,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "8ba8899f4d3e900633e176faa7bc081edcc36adabeb0a6edf8a7bd7bc4008f5c",
+          "fingerprint": "79aa5bcf3d27695e94b909112403e5f08b7f38ba3f5eeadf4402ea4dee6f5ac0",
           "file": "src/control-plane/workspace-router-middleware.ts",
           "line": 125,
           "severity": "high",
@@ -3471,7 +3519,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "3ac89f65e3f11d3427a10cfd4e41167d11fea6b575defaf5a9442519479672f9",
+          "fingerprint": "ab23c484fc63e26eed76f5e21877bc12f43cf4ab70f317c4d2ba78835ace48ae",
           "file": "src/control-plane/workspace.ts",
           "line": 144,
           "severity": "high",
@@ -3479,7 +3527,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "38042fb6ef75db88c2b52233db0909ba94be2d8cac519769ba833baacd1164ec",
+          "fingerprint": "e60c0fe5f87ff0737eb1c035baf6cfd16d4c877c271a3cc1ef77dff00a0b7809",
           "file": "src/debug-engine/analyze-impact.ts",
           "line": 80,
           "severity": "high",
@@ -3487,7 +3535,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f94532ac5a1dcc8cb676f083f2e1732cd6f4e691acfc69acd9198edd43d47fa3",
+          "fingerprint": "4d4eff6f5f24b7c58c62e356587a09f013178b30ec5f8048ffc6ca933f6d3183",
           "file": "src/debug-engine/apply-safe-refactor.ts",
           "line": 192,
           "severity": "high",
@@ -3495,7 +3543,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "77d8036090eb37de50c64e5aa8e9cd499b09cfd450104628fd58aeab93634e12",
+          "fingerprint": "73e47e256fbbf0e45b518bd52111e1e2c472d80f09104bf5699f27caa0a3d948",
           "file": "src/debug-engine/apply-safe-refactor.ts",
           "line": 193,
           "severity": "high",
@@ -3503,7 +3551,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7a815f059f6c8ab8be88bbfbf61a4b47aa94acd1c8a97633415be44342d77dbc",
+          "fingerprint": "f7ed8e760a64038c85dfb7aa7ae70fa19fb12ce272d83d41308c7c37ffcf5cd6",
           "file": "src/debug-engine/apply-safe-refactor.ts",
           "line": 212,
           "severity": "high",
@@ -3511,7 +3559,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e215a9cf4d4a82afa15db3cc7d1e01a3094cbe8f4f4806b3539a47f2a91bf99a",
+          "fingerprint": "a51e8d4d3fda60b53717d46286f885c1404dafc1393ed7135adefcc6952b20bd",
           "file": "src/debug-engine/apply-safe-refactor.ts",
           "line": 304,
           "severity": "high",
@@ -3519,7 +3567,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "28af5c20ede80ca0ce7fb60d56b686abd78f1f68bafbbd6788e5bf8f678e5cbd",
+          "fingerprint": "9460021c0f28df1154018934eb336a7a17f0b37ab8a304fcaf6b2c83f30492da",
           "file": "src/debug-engine/scanner-utils.ts",
           "line": 174,
           "severity": "high",
@@ -3527,7 +3575,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e38bc8d8cfa9371ce6ef3f4c8d3f0c0133409d42686e3483bbe630cf0d3179c6",
+          "fingerprint": "db3ac74bf8abe70fc424a478c43251c4f2cd4c0e20e87968c292db778f889796",
           "file": "src/debug-engine/shadow-worktree.ts",
           "line": 151,
           "severity": "high",
@@ -3535,7 +3583,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "1a7274d79753d49d35cbb2d3580e24d4d3b38b8f7ff967a5b8a0ca5e4abf911c",
+          "fingerprint": "9667ceaf9b12b0d9e61a2e3b5ebd512f934fd56adda28c4f84de66945a3af707",
           "file": "src/debug-engine/shadow-worktree.ts",
           "line": 153,
           "severity": "high",
@@ -3543,7 +3591,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4533273bae1d4d4924f5e4d361670272ab231fa9f6d8ca8d55b42fe9a5d88537",
+          "fingerprint": "c04ef21805c1c9020879a6551a48512e521eb364fa1f34aa8ae3fc41b760b2fa",
           "file": "src/debug-engine/shadow-worktree.ts",
           "line": 249,
           "severity": "high",
@@ -3551,7 +3599,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "8c29280034d1159067c67203139d20de1bdeb30940111d069eddd515cd4571d6",
+          "fingerprint": "adb70d9e9e744b4ae04cea65ebdfc8d14b92a058641d34e64d7a7c4472a59884",
           "file": "src/debug-engine/shadow-worktree.ts",
           "line": 261,
           "severity": "high",
@@ -3559,7 +3607,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "57eca957a05f9d914d4d205cd80cf414e4ae44e5d746cf30c9bc5a4ed880c4ec",
+          "fingerprint": "face7fe14666a6a4bbc0f238944f1c1fd20f91d1b9811364dc528acd9a6820d5",
           "file": "src/debug-engine/shadow-worktree.ts",
           "line": 271,
           "severity": "high",
@@ -3567,7 +3615,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2dac5c014e3b75dc1773d6a734d4440d9959a3ad3380a9c0fde853f30d369a85",
+          "fingerprint": "e96d16de2b0d734fda382cfc1f2ec20cad50a849bd7728ff71f901b65e6d3691",
           "file": "src/debug/diagnostic-log.ts",
           "line": 80,
           "severity": "high",
@@ -3575,7 +3623,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c88e20e43f3a16afd8d5bfc12cd7af2b81870a957a2e2108e3c7fb03f284982b",
+          "fingerprint": "d2ce6223d3e7481193243d5a0e2dfc8d8fde40cc1e32cac59263ce1c95f6c189",
           "file": "src/debug/diagnostic-log.ts",
           "line": 93,
           "severity": "high",
@@ -3583,7 +3631,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "46a965375a576ad9a04f9fdf2e824c7dd04334ad6d350f0613a11f3803a1e89a",
+          "fingerprint": "c6faf476ad9b350458428dd54053a181ca8b445f378e726da38c77e313ea5499",
           "file": "src/debug/diagnostic-log.ts",
           "line": 94,
           "severity": "high",
@@ -3591,7 +3639,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "52fc7b95cb69b286a12a9372fa88e5920f8a28a1da26201550a6fb5f41068d8e",
+          "fingerprint": "127159c23f7d7b65f778f5112fd7ad2b7b5b348283679f1bc1f90ec4cce5afb1",
           "file": "src/debug/diagnostic-log.ts",
           "line": 118,
           "severity": "high",
@@ -3599,7 +3647,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ef6acda339ced1a694683ccf87b087466f8ef9254a6663f60177e274d9bce264",
+          "fingerprint": "40463b15f1a79078543b52a6b1d96f63a73b484703dd048ca69eeb978111dc0e",
           "file": "src/debug/diagnostic-log.ts",
           "line": 119,
           "severity": "high",
@@ -3607,7 +3655,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c66bca39c08e47e52acde1b9af66d4e70b3f134761d45d810f27471f71454012",
+          "fingerprint": "641c2eca870b8b1dd2be9521c7fb1951ed31c6412f52376db6a9efcd14fa6b36",
           "file": "src/debug/diagnostic-log.ts",
           "line": 120,
           "severity": "high",
@@ -3615,7 +3663,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a8a7a6c67df91acfe60b246ef22eb9f1b9ff3e5d00a80897517144e505843199",
+          "fingerprint": "6b2fa23c511bc311da3913384e65eae75a07fec9c44e0f46131805773201cf21",
           "file": "src/design-check/index.ts",
           "line": 40,
           "severity": "high",
@@ -3623,7 +3671,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b46b3fa567b25f7694b146e89dcf66ff55ea0c6e4771a9c856b9ef85d9252bc9",
+          "fingerprint": "507f90f5e41e3cc6b02052900e92f4a4d115102638b7248619f2388ee3830b73",
           "file": "src/desktop/webui.ts",
           "line": 58,
           "severity": "high",
@@ -3631,7 +3679,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b1f64e9333a49b8795e552e8c3166ec470cb331bc304cbe9a3cb4546a489d9af",
+          "fingerprint": "37e5bf2478b8110ee3423f88c66d2a14f3846b983ba5a1afd39e76412e122a66",
           "file": "src/desktop/webui.ts",
           "line": 60,
           "severity": "high",
@@ -3639,7 +3687,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c9d0ae301be9fe86fd8e75842ffd1d0c9c8de5e27e942597f5b7e8f7e90e9629",
+          "fingerprint": "20cca65b9ad810b2fcd399d95f9584b5ba421e749e0201fb71c15dd3f06f1d8f",
           "file": "src/desktop/webui.ts",
           "line": 78,
           "severity": "high",
@@ -3647,7 +3695,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "0f0390ca9136060b655fd2e0fec2e420df195198304b2f93ebcd80921a0c8284",
+          "fingerprint": "2b2c67367a3c208fe840ef5a5e04b7a371f5b55d2e4b854b948de0b85fa7acdf",
           "file": "src/desktop/webui.ts",
           "line": 83,
           "severity": "high",
@@ -3655,7 +3703,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "af8a377fac9092c0cae237fbf35b6b312ac2351379f7619807930ee1613c3251",
+          "fingerprint": "22fdf8fe3af73fa26d9cd65ca3b0046bbaf9c5667502ab9703801a588add3f00",
           "file": "src/desktop/webui.ts",
           "line": 84,
           "severity": "high",
@@ -3663,7 +3711,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "9bcbfb00205035f4a4f580b36f735031298d4a8ef90a7d3eef9593fe9ac27620",
+          "fingerprint": "f89a057598d20217aa65b97bc619b8cee67d26fbb59fa5e4eb759f42dd186fb9",
           "file": "src/desktop/webui.ts",
           "line": 85,
           "severity": "high",
@@ -3671,7 +3719,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "43d823ab1997f56484c3bf9cd488d0cfb80188e6153b4ecc3856abd0945608d3",
+          "fingerprint": "e8c04adf49ae6280bd5787f1d6075b57bbad26abfa6db0501c1327ffe6bc93f6",
           "file": "src/desktop/webui.ts",
           "line": 86,
           "severity": "high",
@@ -3679,7 +3727,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "13f9a9dba26a7f32c6849616e4321b6a0deadb203330a7d07129884dfe9a1e5c",
+          "fingerprint": "346dfe2d255a2d1eff2084970a0d63cc150f996b523adfb49a1046a7ef2f048c",
           "file": "src/desktop/webui.ts",
           "line": 87,
           "severity": "high",
@@ -3687,7 +3735,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "77f59e0eb9bcc6f6da66ca8d86bb24096cd410b7c0e4bc9bdd1303401731bb81",
+          "fingerprint": "a423ab196cbd13989978a0fcf8c10401dba76758110371d5daa26e52bae1ae2e",
           "file": "src/file/index.ts",
           "line": 354,
           "severity": "high",
@@ -3695,7 +3743,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "1862ae7a583052dd39da59dcebae9c15baaa14c491cfe1c0404f94d9bb2e347c",
+          "fingerprint": "7fd8af686c9591e366607ffeb4f3b7b42d374511c1e2e881988256a34a463248",
           "file": "src/file/index.ts",
           "line": 379,
           "severity": "high",
@@ -3703,7 +3751,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "3eeabb1e9cfa3d7e5d4850c841055dcc8d92ae99656a5979c7cc563711e4641a",
+          "fingerprint": "9c19b5f9e669df3b6f14262a2b87695b010f5f474899a4a31b3bd6d68a2a4dd6",
           "file": "src/file/index.ts",
           "line": 438,
           "severity": "high",
@@ -3711,7 +3759,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "59f140c5c14c5c3660a648ae5c5c82851c6caa487ca893167c3d22f286252628",
+          "fingerprint": "a09a1f458c7b40993d1cba57fd73f409dcafd286bd35853659f81af3e5953ff7",
           "file": "src/file/index.ts",
           "line": 482,
           "severity": "high",
@@ -3719,7 +3767,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a85b58bf8e714ca75a2c97e57e7975177e797fe09bcc4f17f063684fad32c918",
+          "fingerprint": "4a72fa216c7e58f08b1187b0c86c7de720814576742a000a2131d72b22fbcc78",
           "file": "src/file/index.ts",
           "line": 494,
           "severity": "high",
@@ -3727,7 +3775,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "0b951aec3a32a7d1382fa106c458a300d13b9921de51e44692d121d2985e04b9",
+          "fingerprint": "c7a4b83f441ba2c4ab97cace2223d2826b8e6de343bd1af39d5bd4e443e6fdf3",
           "file": "src/file/index.ts",
           "line": 495,
           "severity": "high",
@@ -3735,7 +3783,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "937eab1295cde307b2ce65405b348527a64890e48161487da8e08d290807844a",
+          "fingerprint": "b6431e726837b6ae7d99253e5c2503fbb00416240a66173394232ab052e7900d",
           "file": "src/file/index.ts",
           "line": 563,
           "severity": "high",
@@ -3743,7 +3791,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e1c8cb6529585d86dda031255e9ca3fcb6a8bb23dc67158170c73f0254cb604f",
+          "fingerprint": "d78d13ea2c73bf9f3c6582df76aecd77accf2dd4fd2025e3b9152f29227acd5b",
           "file": "src/file/index.ts",
           "line": 611,
           "severity": "high",
@@ -3751,7 +3799,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "78b1c4a7ced2052c48e0e0225648c443dca23e35bf57de2222deb92dc6d9a53f",
+          "fingerprint": "2b6fd8527edcc2da52653ee111c85084d09e890e20b892e76e3b71b682774ee5",
           "file": "src/file/index.ts",
           "line": 736,
           "severity": "high",
@@ -3759,7 +3807,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "0500b3704d17f2ededb03e3124ccecdf3e60bf8ac5f13d51479f4f090684f15b",
+          "fingerprint": "b2d67dda392a29b3acfdc00c342cce18f217638d55e5ddc1dfd4e5968764830d",
           "file": "src/file/protected.ts",
           "line": 52,
           "severity": "high",
@@ -3767,7 +3815,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "78c7984843747b7250bf1efc8f284bd908b76e847004254304b59caa376a5f85",
+          "fingerprint": "1ee8063317fdaa91bff9b4c0c8b773408dd95c192ca9cab840737dc414601b41",
           "file": "src/file/protected.ts",
           "line": 53,
           "severity": "high",
@@ -3775,7 +3823,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e206cf8efa4317c4ff1fbcbe22f61de1f991b7ae66aeae3c188e50dfebe69557",
+          "fingerprint": "cb4bf4c2bafef48c1f998776b298826a73ff3e430a2be6daf2da195fdb67adb6",
           "file": "src/file/protected.ts",
           "line": 56,
           "severity": "high",
@@ -3783,7 +3831,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "204ecb8e2246bfe7325d79e78d56078e5357cc386c2dae07c50c24f16f876b9f",
+          "fingerprint": "324d473fff7f263a1a51a68886b3a13e8dd40a8af8d78584dd31a16d255f891a",
           "file": "src/file/ripgrep.ts",
           "line": 184,
           "severity": "high",
@@ -3791,7 +3839,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e0693fb3187a04b285095205218cfe5cf881129b2976dd924063e32e5052c195",
+          "fingerprint": "ae81bf2a45fcd4e1975b5d6c1f4ba3e67c91ea140f2e3914d42703e189db3c83",
           "file": "src/file/ripgrep.ts",
           "line": 202,
           "severity": "high",
@@ -3799,7 +3847,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b8b7720de6ec82330c375fe5f6f6798d1a30e691b8fe996ccbc08a0471123c87",
+          "fingerprint": "25910008b45d4dbc97a6c4f6b2b2ce7cf48dad29f1338208cd35e0cbd1f7a1eb",
           "file": "src/file/watcher.ts",
           "line": 134,
           "severity": "high",
@@ -3807,7 +3855,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "97d45b165e84ca8d681b8fe1b89051124c448783974e47ca4dc9e876d26784e0",
+          "fingerprint": "81f456088aabdceefa18b7720e1d948942bf8e31a101bda576cba71302136697",
           "file": "src/file/watcher.ts",
           "line": 197,
           "severity": "high",
@@ -3815,7 +3863,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "67b03efe628d96ccf142a6db691a54665becca5f3d56697c731abc43edc67735",
+          "fingerprint": "f0189d88d2973fac595deaebc373ce6cfb9cdca520d1b84f598bf1f5941dc98f",
           "file": "src/file/watcher.ts",
           "line": 225,
           "severity": "high",
@@ -3823,7 +3871,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "87e10232e8f161cc4fb4b466fd3113c4d76da1d798a957bf3b6b46dfac5545b8",
+          "fingerprint": "7966228115231a4f74d3291397800890d33df91e443cf1ffbafccee79241a20e",
           "file": "src/file/watcher.ts",
           "line": 229,
           "severity": "high",
@@ -3831,7 +3879,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "09ce7352948e9714cd2d51098cf9d8f6606b9a2876837dc23288c42aa579f25d",
+          "fingerprint": "4fa745825dedf7d140f64605fc6b1ccb8421e6a9acb93e1672b94be7dbf37b56",
           "file": "src/file/watcher.ts",
           "line": 358,
           "severity": "high",
@@ -3839,7 +3887,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "38071b929825f6507651dffd13f895734634452d339e9bafa260b65ccc4201e4",
+          "fingerprint": "a4fced5398ec2b1d2cfa407e68cca6f8ca816005bbbe8636416f4e6d8a358561",
           "file": "src/global/index.ts",
           "line": 22,
           "severity": "high",
@@ -3847,7 +3895,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "890fc5a5a83c5dd2517c8f194d9e29004ce1d1059c3696372492dadc97d7bc22",
+          "fingerprint": "28971cd6a932d61ce978de4149813b05137c27998aa679b230d50a99299042d7",
           "file": "src/global/index.ts",
           "line": 23,
           "severity": "high",
@@ -3855,7 +3903,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "795cc19a88a6a2f860f7a1305afada482c94575ee847de7a15f4dca45f99f687",
+          "fingerprint": "1046ed48cc35de529d232da9d9524c864537e8a8778493efe84cd607c4f65c76",
           "file": "src/global/index.ts",
           "line": 26,
           "severity": "high",
@@ -3863,7 +3911,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "326eff7f8459dbf159ac4be59b2cb7c0428c62bb876b0b9ebe9f60897fb31fae",
+          "fingerprint": "abcfe61376c5379812100a86c2f32ca8dd85e40b8022af0e57ed64aea0b9b1c9",
           "file": "src/global/index.ts",
           "line": 27,
           "severity": "high",
@@ -3871,7 +3919,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "48e558315790c334e7680c4b1ee8736ecef90e4a2da5a67a58856bd14865886d",
+          "fingerprint": "a8c3a349c0fc0bbdc29199b5bbce90c2b4f391a575cdbc660616165670be3a4c",
           "file": "src/global/index.ts",
           "line": 28,
           "severity": "high",
@@ -3879,7 +3927,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c1528ade6f5caa3c4b6d27893ab7268fcefd09b33263e3ca1e3c6594ecc5fd36",
+          "fingerprint": "574e0b6ec614bd72f72e33270fdfc54b1894666d543b9059727bc6cc1f77c8c8",
           "file": "src/global/index.ts",
           "line": 29,
           "severity": "high",
@@ -3887,7 +3935,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e09800663cb698327929a2efa40f88957802a9870e33f00b98f61c081058e554",
+          "fingerprint": "71bb3b5611e99adf97da6c8c6eeaecd2684e9f4eb090b281b9d40259e6bec3b2",
           "file": "src/global/index.ts",
           "line": 44,
           "severity": "high",
@@ -3895,7 +3943,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f452e199032387a5f1b8d41293a0ba108c37b1b6710046b027fe43f7b072b391",
+          "fingerprint": "88e0d5f45cc2327a18e9cb2f86680593bfbdde119209ab33b1a70cb6853069c7",
           "file": "src/global/index.ts",
           "line": 45,
           "severity": "high",
@@ -3903,7 +3951,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "fbfe42c02897c806218def77d007f7b121c65ca891847650ebfa819c357e0724",
+          "fingerprint": "0cf47881f6ecd7b7723de326cfec0115b27da3fc60fea9e46e4542d09322b04a",
           "file": "src/global/index.ts",
           "line": 85,
           "severity": "high",
@@ -3911,7 +3959,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "61fd65fdab4e98c188ff2ca03330a2e5888a8c228db0e6c7aba10d90b80b0712",
+          "fingerprint": "0200d8095ecc8b6a549cd28e839995b521d0acac6983316043cb2765ac0c6b0e",
           "file": "src/global/index.ts",
           "line": 114,
           "severity": "high",
@@ -3919,7 +3967,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7be90bf08fffaa95bfb4a91b70f40aa17c26f366a436320c92a2394f1919b9c3",
+          "fingerprint": "1f98d2f6548cd901a0633e8e4118092bab81c3f73b9fe606fe12370e98dbbf0d",
           "file": "src/global/index.ts",
           "line": 117,
           "severity": "high",
@@ -3927,7 +3975,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2e1b2a60df7998d4adc62b680c85bfc9e97ef4e15698674d15320592d938ecf3",
+          "fingerprint": "5644bc07b568b2dcb75e74017d35dbb1fddd00fdde0406527cf9f59b33d113f3",
           "file": "src/global/index.ts",
           "line": 129,
           "severity": "high",
@@ -3935,7 +3983,23 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b2022ab018ea8c0ff23b36b9a39a4e8f03cd3c0053a9f5d1d033bb2a30ac3832",
+          "fingerprint": "f1fb40c5b94cd87dc4cc61cb254883129e075708330ee750aed8f0b3743194dd",
+          "file": "src/hooks/lifecycle.ts",
+          "line": 149,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "fe23dcbaee42278eb9e8572afb25f7b4720f78a237d4eeb9d69a29c66957521f",
+          "file": "src/hooks/lifecycle.ts",
+          "line": 248,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "731433c94c1fef69d37d0adc4525c86df133749ea664ab72a13560857d2e34ae",
           "file": "src/import/compatibility.ts",
           "line": 40,
           "severity": "high",
@@ -3943,7 +4007,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a99d71fc99fbb0dc24ac2940000c56dfa1fa501a7414170ffea2d0e6702c04f4",
+          "fingerprint": "635546c79886eab7ab06c8fec8da0b8d311a3c69fe2ce27c5ddce3cbe28d0193",
           "file": "src/import/compatibility.ts",
           "line": 41,
           "severity": "high",
@@ -3951,7 +4015,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "cf6ccbdff3deba54aadacdd58fc5c5cab74a614075090b82a4c2b417bb4d5d06",
+          "fingerprint": "21bddb1225ae7c246abacf4a71619711f94259d2ad2c2852d363a824f86284c4",
           "file": "src/import/compatibility.ts",
           "line": 48,
           "severity": "high",
@@ -3959,7 +4023,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "1896bf1caf7e4545b575b32abc44e064d54edfc772a5df79289dc02789ef756b",
+          "fingerprint": "d845fde62ce2ded36b70e26c470fc4312443554c3ff777ed11d1255247fa658f",
           "file": "src/import/compatibility.ts",
           "line": 51,
           "severity": "high",
@@ -3967,7 +4031,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e364b908dfc2b7a38d319e424fba1579d18dead28b83516dd776d624d7feb609",
+          "fingerprint": "542619a8d59554db3f9e595505fadb88577c79761d7cba8cadbfe771a1f7def9",
           "file": "src/import/compatibility.ts",
           "line": 75,
           "severity": "high",
@@ -3975,7 +4039,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ddd2099c0b86780af1e0077c73b61d17dd6e4f6d6178aad80d9164cff5f5ea34",
+          "fingerprint": "2381e86096eebdbc601c68713437632688f702e4367a73d4a21937a358d2ac6d",
           "file": "src/import/compatibility.ts",
           "line": 76,
           "severity": "high",
@@ -3983,7 +4047,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7220afe1abd06827a4fe7773ef48e252ce413a7fd76b4b3d129c0c32224a0ee7",
+          "fingerprint": "21ee6edcce88b8483512f9f318a7e21a3d9f519eb6c5c060236da995506c633e",
           "file": "src/import/compatibility.ts",
           "line": 87,
           "severity": "high",
@@ -3991,7 +4055,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "65bc42ecffda174cb8912aa61b4fe1d57146350133db891614620eeae25c6377",
+          "fingerprint": "e7b090b57d1cfd050ec06caba8c2c83720123818dcdd25cb97614f50f6dadeb0",
           "file": "src/import/compatibility.ts",
           "line": 88,
           "severity": "high",
@@ -3999,7 +4063,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f4bc99494956edb38bdd954355ddd827bb4fa8658cde2157b761d7dd3a2604b1",
+          "fingerprint": "f6e3e9b785c67f2be28081bf916784d76524018930547d4024bfa44cc9d49519",
           "file": "src/import/compatibility.ts",
           "line": 98,
           "severity": "high",
@@ -4007,7 +4071,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ca4fde1cee410981b52b822e3b4ab92316b7122de759f93365e73ac98e39e6b8",
+          "fingerprint": "73b191505f701d0f45e2dbe480dfa449023d18f824b96bd827a0380096efddd3",
           "file": "src/import/compatibility.ts",
           "line": 99,
           "severity": "high",
@@ -4015,7 +4079,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "42c4f38c51b765eab0becfaacac94c3d829138847d480b04f366bcc9c260e261",
+          "fingerprint": "3354fff1b1a195df498d32ca4f82bc374ab6f02f3cf33d92ff7e5301187e9ab0",
           "file": "src/installation/index.ts",
           "line": 184,
           "severity": "high",
@@ -4023,7 +4087,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "672660f776131706e5db2143507eb5cac8630f1a8437bd26b96866abb19d8198",
+          "fingerprint": "d802bb65f1328344e5fdd1ae37661ad8a53f4332796428b3f64c62ce3cdfeacb",
           "file": "src/installation/index.ts",
           "line": 229,
           "severity": "high",
@@ -4031,31 +4095,55 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "cb86b97e633980a9bfe5652889aa3d278c68e2521ad71f2663112cf6873292f5",
+          "fingerprint": "5d11237491b6ec72ea3b49c73fb6a35c17d1404ae42ae8d30268c7300fbf2ac9",
           "file": "src/isolation/index.ts",
-          "line": 62,
+          "line": 73,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "21305330e69f9b49830b896ffecb68b405442fffe7a6856ed0779887908dda0a",
+          "fingerprint": "d9de722f4cf6c0937775eef3a5284956cd1ed5d2e5b33ddb7721b61c5b251c06",
           "file": "src/isolation/index.ts",
-          "line": 118,
+          "line": 133,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4d74728a96f88d9c9a6070906363976e3d001cbaf934eaeaab3b0e2fea5bc8e3",
+          "fingerprint": "2f260077a3140d0afbfea53e813fbc66945196a6b0c0fd3a27068da0ce9dc370",
           "file": "src/isolation/index.ts",
+          "line": 137,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "3c5e2b286bd3c16cbe7ca34470dee3938d8ac909067de51a54207534f745a78a",
+          "file": "src/isolation/os-sandbox.ts",
+          "line": 110,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "dd44ba3048d1fa6f7c8a9fe010ae45f6750281d74dcaff60705cf5a0593a093c",
+          "file": "src/isolation/os-sandbox.ts",
           "line": 122,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b5dbc27c84ef22941ed9d19d2a6f001b9ef5ebdb2c6e33a36da9b60acf82da6e",
+          "fingerprint": "eace547f2c30bfb30db4caee7cb613f5686c18d896430abbfd72bb75da3d3276",
+          "file": "src/isolation/os-sandbox.ts",
+          "line": 211,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "f36f6b70bd1068374acbf235b10d2bbac7d08b98251038245e67d1684cdc30cf",
           "file": "src/lsp/client.ts",
           "line": 511,
           "severity": "high",
@@ -4063,7 +4151,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "da4c31edc9699ef7a83e4d4c9a5631de71a50e40a458963be0d5890ba8cb9add",
+          "fingerprint": "5dbbac7cd5bb6f2e1746496dc53493dd3ac09a1fd1561a21c2c63a912aaeaad8",
           "file": "src/lsp/client.ts",
           "line": 643,
           "severity": "high",
@@ -4071,7 +4159,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "9a452ce524e5f646201770b843205562476653b3cab46a7ec7bb7eb7183c64d1",
+          "fingerprint": "5532c971fe0ee6e2370d6168424e488effdbfe7830acf27ee16de13503becf04",
           "file": "src/lsp/client.ts",
           "line": 652,
           "severity": "high",
@@ -4079,7 +4167,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6f8162a8bb9d349c63e37565ccf039f118c7f276942f5a53f12aff060ef5fc5c",
+          "fingerprint": "94f0410316c064b2f38076cf590848f81737787de73ef33ab845d2ac4e38d488",
           "file": "src/lsp/index-impl.ts",
           "line": 448,
           "severity": "high",
@@ -4087,7 +4175,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "d9c19a249c4b80c3f3cd9b7dc0f6ff4b7ead674879896afe287d984017316fb5",
+          "fingerprint": "1e7b89d763c8df39ac3d8d5468e0ecfa4843d628d69a4bf4ae4972758e04092a",
           "file": "src/lsp/index-impl.ts",
           "line": 626,
           "severity": "high",
@@ -4095,7 +4183,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "43a1e60ac1ea2d313d8eec7a2dd478edfaf7eeb02ce51921af24fb3cecc512c5",
+          "fingerprint": "76554bc2204b6744a7fea222a57d0f6c8f5081474402898f25aaf7385236d157",
           "file": "src/lsp/jdtls-data-dir.ts",
           "line": 11,
           "severity": "high",
@@ -4103,7 +4191,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "118b9e26759a4c9893d41b8c0f26ef9cd7b6733fcef11440a877423235814304",
+          "fingerprint": "75b4dd8aee5710e527d943b5e61b05d3db5977bd3c6cda5752237b4d5ed9fd01",
           "file": "src/lsp/server-defs/jvm-llvm-servers.ts",
           "line": 217,
           "severity": "high",
@@ -4111,7 +4199,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "8847940d94ad13f05266f740b5dbbed98493de6598aca2ca5304209278a9169d",
+          "fingerprint": "518b14e465e1590b6329d235721771b0d33e03d8a23e698fdb22b57552fcd95a",
           "file": "src/lsp/server-defs/jvm-llvm-servers.ts",
           "line": 251,
           "severity": "high",
@@ -4119,7 +4207,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "54b34e8af1838ee35a47c2f88665cd3259200dc31aadbe63e3d88b1bd0d75941",
+          "fingerprint": "5b3245dcab3f03553963c0b1bb8acdec390541506bd6964316bd1249ef5d331a",
           "file": "src/lsp/server-defs/jvm-llvm-servers.ts",
           "line": 290,
           "severity": "high",
@@ -4127,7 +4215,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "51571c3bdf11c9f3344901eb733b76e4ac7d1d953de59f51fd8ff8a72fa007cb",
+          "fingerprint": "2c47c4e098d8f675978301162e0b5003691da795173ef3b4027ef6dd398a8933",
           "file": "src/lsp/server-defs/jvm-llvm-servers.ts",
           "line": 295,
           "severity": "high",
@@ -4135,7 +4223,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "52f1ce421be24c7ece42fa8f9422e20f2e83aaae203a4bf8e87ee17442ab732e",
+          "fingerprint": "869f54f44af4c139b5979d41ab72b3b078d65f1837579f643737ae0c754b014a",
           "file": "src/lsp/server-defs/jvm-llvm-servers.ts",
           "line": 367,
           "severity": "high",
@@ -4143,7 +4231,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "287a4e715b999eb766e75ece0a629fd4e553001f8d6dae69dff79050640b4e55",
+          "fingerprint": "fb2ceb6101f40b8f4c96eecd171eca706791ab0c8efdcb3a545225ea7af17e50",
           "file": "src/lsp/server-defs/jvm-llvm-servers.ts",
           "line": 369,
           "severity": "high",
@@ -4151,7 +4239,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "60bf635e852623458d8e6c62db13ef6f54b6eaa45dfddec8667f3dc1aa50b1af",
+          "fingerprint": "e1714a47d0e36414d26617d615dccd013df90afbba5cf6e5165b63ef8a7bd5ad",
           "file": "src/lsp/server-defs/jvm-llvm-servers.ts",
           "line": 370,
           "severity": "high",
@@ -4159,7 +4247,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ed41122c5326ee6d5a546587c82741f96e88961cef104b3f691323302039383f",
+          "fingerprint": "03ce1c68d93a97ca8111e497d2e61c426afc34d6dfd7c9a588d97f8c23060d6e",
           "file": "src/lsp/server-defs/jvm-llvm-servers.ts",
           "line": 410,
           "severity": "high",
@@ -4167,7 +4255,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "fa8683ea4002632de581375a99fd0337c1ff36f6c3ea399b4b787f4fc6e282ef",
+          "fingerprint": "046c1387c3084aa50a69c5007ba405cbf802b255fb0a90682d2441a91bf7da63",
           "file": "src/lsp/server-defs/jvm-llvm-servers.ts",
           "line": 443,
           "severity": "high",
@@ -4175,7 +4263,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "fdbb6c0160f8e01049b4a5a9d089b36ab0f0f361dd5545d5d79f7c074b50dc35",
+          "fingerprint": "abf1693868792e92102b4591020a69c443cce3e0320fbb40b8a4f20b4b2985eb",
           "file": "src/lsp/server-defs/jvm-llvm-servers.ts",
           "line": 449,
           "severity": "high",
@@ -4183,7 +4271,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "3bfb4ac7e970a89cc54424b19d7f9686bbba812f492b19d035371e2db65df791",
+          "fingerprint": "c5f947944290ec8e8241df0ac3bb6034c522a9e1d820d6e5ca69c67c59f13558",
           "file": "src/lsp/server-defs/shared.ts",
           "line": 66,
           "severity": "high",
@@ -4191,7 +4279,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7a25812d94eb2291a97ac897a3050b4bff2056104d58d2b634def312ebc101f1",
+          "fingerprint": "4f8a2a56c8ee593dbaad3a97c1cad2547d17d396bf89c1fa87cb006780e7b119",
           "file": "src/lsp/server-defs/web-servers.ts",
           "line": 115,
           "severity": "high",
@@ -4199,7 +4287,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "94afa9b87ae6bcf0c1cc4569dcdb1f14f6c756c49d4dce9763fbbd5497bec8a9",
+          "fingerprint": "0b86061d13004efd432544e62799aa910473e20fb890693bbb44e463c33229db",
           "file": "src/lsp/server-defs/web-servers.ts",
           "line": 160,
           "severity": "high",
@@ -4207,7 +4295,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "37182a2f6bc74d58df8802c58099eafd279e21cc639193425e39f0a8ed13691e",
+          "fingerprint": "9a06e1325759c131fb3d49c2a457f1f99b92466b9496c57ba65e1f68acc2c26b",
           "file": "src/lsp/server-defs/web-servers.ts",
           "line": 161,
           "severity": "high",
@@ -4215,7 +4303,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b0dc004d08be1e180c9f194a1c15fa9ae7fdfba5c910ef4aa381377122b84dc8",
+          "fingerprint": "e035289595a2150c5b33a3a27b9505a5f5c9e8a76b731f9b9e0e807d1a2f7fd3",
           "file": "src/lsp/server-defs/web-servers.ts",
           "line": 164,
           "severity": "high",
@@ -4223,7 +4311,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4aa85af7ea206b1de589d21a3a261e0a35f64c650c834b2327fb43fe2174718d",
+          "fingerprint": "ed4eff9c2fdcb813722a73cb5f8e95fcb21340b1ffa7149fb95bddd049cd2b32",
           "file": "src/lsp/server-defs/web-servers.ts",
           "line": 201,
           "severity": "high",
@@ -4231,7 +4319,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4a3211359e157c454bb03f436a78d8f74afb8339613e24cd247359adb9b88044",
+          "fingerprint": "4d1ea2dd2c3fd7140c93bbe9062b45c4e08949c5aad9f6dfb93eca9f0e8cc1dc",
           "file": "src/lsp/server-helpers.ts",
           "line": 39,
           "severity": "high",
@@ -4239,7 +4327,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7eebd51fc2f5d144aaae76ceaab90bfa4d6e4c724f06a349d7259e26ee560d01",
+          "fingerprint": "d679bdef8db21ba2a44340c646b4122ded89942845dab3cbb5b76a667647eeb2",
           "file": "src/lsp/server-helpers.ts",
           "line": 237,
           "severity": "high",
@@ -4247,7 +4335,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2dbe1f601d30fd74aa3d1cc6de7e85e970871d584febee700f52f705bfd6fd13",
+          "fingerprint": "0ec197c4d8ef86fc86504388ace97a0f169558e399766386e804342c7cde3ae0",
           "file": "src/lsp/server-helpers.ts",
           "line": 305,
           "severity": "high",
@@ -4255,7 +4343,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "beda05a5e8a087d5eafe8e0f31c130c32cf9583466fdaeade0bc38b2373f8710",
+          "fingerprint": "9bcf99c42bb6b9014a25f88741cd719bd6de1c7a0f650d7ec811cfeb23cdbcad",
           "file": "src/lsp/server-helpers.ts",
           "line": 312,
           "severity": "high",
@@ -4263,7 +4351,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "19f53b3b7dfc4d1d66baf96208db1e38929ff7f2c1e3d1fd81550b8948b4c6de",
+          "fingerprint": "65ea2b933446eadc0dde962e7126f479ab4ec60a4da369fffdece6f419b3cc5b",
           "file": "src/lsp/server-helpers.ts",
           "line": 320,
           "severity": "high",
@@ -4271,7 +4359,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "89ba961a0aabb486a4841e1c29c068e1e53ad7ff7c6b759cf895b8056f14647c",
+          "fingerprint": "a66f31a6d6ea2a4fa01a3211e80fa086f846534dd36c02cd3f03a1befae36cd8",
           "file": "src/lsp/server-helpers.ts",
           "line": 365,
           "severity": "high",
@@ -4279,7 +4367,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "fa6813bf9b5e7a34b5a859f3f2002e53408c04952cadbb0c4e7233c65f4057be",
+          "fingerprint": "36a91756d0e54b59ad97c55db99ca50cd0bb92600103ed8fbd181a305d953b9f",
           "file": "src/lsp/server-helpers.ts",
           "line": 377,
           "severity": "high",
@@ -4287,7 +4375,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "3f579980ea115515a9ef6acf2efefef16b6c42cc464d66625a6e60d34c211a6a",
+          "fingerprint": "de49e533b133ad2225a77411eeeb392ec9af1ba2f8257613a84b1891574121cb",
           "file": "src/lsp/server-releases.ts",
           "line": 103,
           "severity": "high",
@@ -4295,7 +4383,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e8de150018246f6df5ebe9cbed876060eac9b89e39fcdcebadd116af74ae36d6",
+          "fingerprint": "54f073ef4acd32de8ea0e00c48055541e15e3a6842385cffaafadf36230e7024",
           "file": "src/lsp/server-releases.ts",
           "line": 111,
           "severity": "high",
@@ -4303,7 +4391,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "322ffc93d668193083328f42f8ffde8a8f12b019cf0ca99090301b4a380b9f01",
+          "fingerprint": "65e1b2b8a7e646f8c7c055e986e21f09b275ae3c84e1b6c7b76d0cf5fc0162bd",
           "file": "src/lsp/server-releases.ts",
           "line": 114,
           "severity": "high",
@@ -4311,7 +4399,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "333720997749b779f23f979c9354ab40c3e2d490cb18f5e4d5082bde5797ccbb",
+          "fingerprint": "75145a6f612c26eb8fac2395d7a083cf2424ac90c2730a259681b0019ce9169d",
           "file": "src/lsp/server-releases.ts",
           "line": 466,
           "severity": "high",
@@ -4319,7 +4407,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5434709c96ef0f899b132fa8ffd4b7267b52aef82381ad1eedb0d4fb6f290aff",
+          "fingerprint": "ec62271575cc244e49d450ae1dcc3ab9c14d225a0dcee9f51f914e1d350f8b9d",
           "file": "src/lsp/server-releases.ts",
           "line": 498,
           "severity": "high",
@@ -4327,7 +4415,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b45d841df16918be56d0f100fceb6f7a4aecc8e1a3e36e4aae7c1ca215cbc437",
+          "fingerprint": "0fcf7099ef5adaecad86743bd9f2e3b4e4cf1aa4ed24ff95455b27ff05155bfb",
           "file": "src/mcp/auth.ts",
           "line": 34,
           "severity": "high",
@@ -4335,7 +4423,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "20b0e0bf96b6a91aaffdfa9a005025af41595ae89823f3e0369918cecb923d42",
+          "fingerprint": "e4b179f36e57a538041bb2554d06add248f2a9075009b47f8577bb2cbd9b059c",
           "file": "src/mcp/discovery.ts",
           "line": 89,
           "severity": "high",
@@ -4343,7 +4431,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e4cad5cb5e08c67ec9213d351fcf86ac3835a3eef063f899979f9c216f4c335e",
+          "fingerprint": "ffacb2a8f782d65f75c3697c467f7d63a80677e2e2d2b548ef57fd2676aa3dc1",
           "file": "src/mcp/discovery.ts",
           "line": 90,
           "severity": "high",
@@ -4351,7 +4439,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "3010eb1a7a80dd91cc3bdcec08903a712b46343372c6ce1d8abd35ea4ead21ab",
+          "fingerprint": "f6ed3b5f8874c54444416bc47a121043245ee082794e853ed652f988993609ca",
           "file": "src/mcp/discovery.ts",
           "line": 92,
           "severity": "high",
@@ -4359,7 +4447,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7e84560a33a268691b2005130c9ab7fdcf66ec6c5c41b93514b4ef3d36da05df",
+          "fingerprint": "c951a3b2b6478f7ea1ff3f373592c12d421467c5848cdaf4dc546ae4a3edafa9",
           "file": "src/mcp/discovery.ts",
           "line": 93,
           "severity": "high",
@@ -4367,7 +4455,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "412e1134b3af151d5d6d8b5d6fb54f0400e0716fc06108018e0d192299270f88",
+          "fingerprint": "ec7fe463812f8a03fe538a0bf4fb6c2a3f7afd72cebaada851fbb92a0ac8588a",
           "file": "src/mcp/discovery.ts",
           "line": 97,
           "severity": "high",
@@ -4375,7 +4463,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b961981a603a93b411011bdfeec43e502528366860bc25b9dee7371aaa88bb9d",
+          "fingerprint": "2b0c0bd34df836d02b21194dd3bf2451919e48c445a187c9b116808b686f2d78",
           "file": "src/mcp/trust.ts",
           "line": 13,
           "severity": "high",
@@ -4383,7 +4471,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "eedb519a07b7698ff5d668223fbe73df3b15240aaf13c8503ed0545a82883dca",
+          "fingerprint": "edb74ad46c11366efc99427f5e598a6dc074282f2445ea1050837f4d8f2fe6eb",
           "file": "src/memory/generator.ts",
           "line": 110,
           "severity": "high",
@@ -4391,7 +4479,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "9153724df984c8bbd0db5d2eeee7015849432ad2c45d7ecd5d917f178c4e85b2",
+          "fingerprint": "5cb4da9519a7b457068983aed795ada1538e70923a129bdf8a43c22c80bc5e45",
           "file": "src/memory/generator.ts",
           "line": 130,
           "severity": "high",
@@ -4399,7 +4487,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "dc5fef5e315366379487894f2194dc32d6af89534d78605d97df320c5f10cd08",
+          "fingerprint": "675091267f2131a03b314e238e90c13d1d4d0e0b93cb919fd7d1a3c3c5b7c6da",
           "file": "src/memory/generator.ts",
           "line": 149,
           "severity": "high",
@@ -4407,7 +4495,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2ae64d645d6f0e204a37eea7e2fa15487051bb3e61f5a2d9bb0256fc13fd10b9",
+          "fingerprint": "a94329a03b90c9ac13ad4b3ae9f4a826ac20b8c01b7bf6faf6245ed9e6fccf4c",
           "file": "src/memory/generator.ts",
           "line": 164,
           "severity": "high",
@@ -4415,7 +4503,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "557638a659234a5527676f370d046cde6a7797961ecc577459d09eab717cd23b",
+          "fingerprint": "0d3f4c69d9f0689a87ee1a591032ee0915123bec7c93f753f0a095116f591052",
           "file": "src/memory/generator.ts",
           "line": 172,
           "severity": "high",
@@ -4423,7 +4511,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "03bf2ebd15d5b93fa954409f3821f3bce0cb800e30080f6893a12e94b461596c",
+          "fingerprint": "32140e31207e163f643af7960ce2d2c318c7a9c976bfcc8b99f943f363386d9d",
           "file": "src/memory/generator.ts",
           "line": 180,
           "severity": "high",
@@ -4431,7 +4519,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "d63fd05c708d2a1b3821bef19cef7cab8c530c59967d5eaadb0d30e75e335ca3",
+          "fingerprint": "9c8f7b70374549d6eec65241615c6aa62fa17b11c46db12e116cf4b625acd491",
           "file": "src/memory/generator.ts",
           "line": 198,
           "severity": "high",
@@ -4439,7 +4527,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4b56915d8502390c297c870078526d42df8a6ad5bcd7bcc30542936f5e8d8f3b",
+          "fingerprint": "8515f4aaefd2f489064c194450c1783260f8689695e1374e3f61893d00c11771",
           "file": "src/memory/generator.ts",
           "line": 222,
           "severity": "high",
@@ -4447,7 +4535,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "049fbc884e8b9ef7725601e57b6d4ef45fb590c6cbfcbfc969a6a424198fbe53",
+          "fingerprint": "b68917818b167d262528e43319dd9624dd605358650179985aaba3339c85f25b",
           "file": "src/memory/generator.ts",
           "line": 230,
           "severity": "high",
@@ -4455,7 +4543,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "95f6abe27792c11f8805141cfbc0e407df998d6a44025951171051920cb8f45c",
+          "fingerprint": "024c16b289ddeaf9f48939d1d3151db7bc019a87c21739bb5f936a8690745365",
           "file": "src/memory/generator.ts",
           "line": 238,
           "severity": "high",
@@ -4463,7 +4551,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "558acafad7feb5bc3848457abe739090831835d47913a39aab90a7996e58ae62",
+          "fingerprint": "ed5ed93942fc250bbeb22c89fc6c5c435f964247c8cd8b06731efddd4fdc8e93",
           "file": "src/memory/store.ts",
           "line": 16,
           "severity": "high",
@@ -4471,7 +4559,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6581c1cc6a82d511662f342aab11095f618a7b84ff1d5057cd5b2bec24c1a95a",
+          "fingerprint": "4f0eae0a24cfb98e9f4de6e7116da192603f1baa98667324c639b9422dea309c",
           "file": "src/memory/store.ts",
           "line": 20,
           "severity": "high",
@@ -4479,15 +4567,23 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "0cc6eada226dfe1748f8186641441b62d9a5b321eb25abf0aee4ff4792e68cca",
-          "file": "src/permission/index.ts",
-          "line": 605,
+          "fingerprint": "7528f02c85da620d40196cd2597b61abdd6fce58bc9fe00b24af21765473f316",
+          "file": "src/mode/memory.ts",
+          "line": 114,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5bbf21b9630a2a8b3ba62ff17238e7866a4ebfc02d87adbb36bcfbb86f875363",
+          "fingerprint": "468cbe1ee8fd1a6c095a0cda629458aa6c37da843da088ed0e3a07062d83a5db",
+          "file": "src/permission/index.ts",
+          "line": 610,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "4224ae6b2a39dc481a74d88395c1709c5bc3293486263010f1021b7db0e0e2f8",
           "file": "src/planner/verification/runner.ts",
           "line": 54,
           "severity": "high",
@@ -4495,7 +4591,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5c5851b418f40bd35a48ffd5300cf0dc9ef5d47c06f1bf9462e1b8ce426ad7fe",
+          "fingerprint": "e88103512553c430c5f14aae9a32074bf433a870e0ab191a14bd8fae6e0e364c",
           "file": "src/planner/verification/runner.ts",
           "line": 56,
           "severity": "high",
@@ -4503,23 +4599,23 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "0d76350de311802046da9a64dbdcfc627898898edd25ba9bf46ededd36d32f61",
+          "fingerprint": "31517602a6e836200e479071f7ed1493282b8641b4a4ac828876f312b980a254",
           "file": "src/planner/verification/runner.ts",
-          "line": 90,
+          "line": 132,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ee989a69da3280535e381f561fe53669c2a46be9683a4e48a451b1dd4ae09fac",
+          "fingerprint": "a858c8c34646a114e0fb4a57815fbd16c047deec1820d1ecc2d5404a18399124",
           "file": "src/planner/verification/runner.ts",
-          "line": 105,
+          "line": 148,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "45e68d880714aa27fee8a03a58fbcccbe3332fd629c2cff9e7dc3981078e119f",
+          "fingerprint": "a5a94b5953f187721da941710d807b66c4547fb77154ef3b757652f3ff8e5be1",
           "file": "src/project/project.ts",
           "line": 121,
           "severity": "high",
@@ -4527,7 +4623,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "769ce78bc1cd89b531367e09e225f181f45268573d82bb91cd4a53507a63be23",
+          "fingerprint": "d33707f969b9adc4995cff2aeee065f77d94706317ef4c99081335c10a8ded29",
           "file": "src/project/project.ts",
           "line": 126,
           "severity": "high",
@@ -4535,7 +4631,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6a1f9f09b3d302204a541d08dcc16eeec3d4b706ac19ff55680510f3c8a17cc8",
+          "fingerprint": "e9ab5364ace91a50c5dd9aa914925ae6c1657f8a5610b46821299a7c367a9e67",
           "file": "src/project/project.ts",
           "line": 166,
           "severity": "high",
@@ -4543,7 +4639,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2c1e0d3422b8db0c413906bf09adf35bccb9574fd75c5120aac25fae20bede12",
+          "fingerprint": "2a2def5921ff135d5b8719c1c68c3870a9424291e39c6df55dbf333feefa8752",
           "file": "src/project/project.ts",
           "line": 170,
           "severity": "high",
@@ -4551,7 +4647,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "350d172159a749a6b819f9e4a4a3b4a1fcdbd1e24beaa726d8fd8ed35d8f7bfe",
+          "fingerprint": "39ff69a3d0f1a4baf4892b80ebbf3696317806488d531652f6b795d75eb906f9",
           "file": "src/project/project.ts",
           "line": 228,
           "severity": "high",
@@ -4559,7 +4655,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a529ceb69def2ddd28e1d0b193f9af908c35fb8e1764470d4cefaad4eda10765",
+          "fingerprint": "4e0cdfd58b2c7279fc714f545a757c865ba213d9e6297d5a10fcf01c49320dce",
           "file": "src/project/project.ts",
           "line": 242,
           "severity": "high",
@@ -4567,7 +4663,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "df64a1f629bff4311f3c53e8bf2351a0bbfeca51acf5ffc66ac33ba707635fb9",
+          "fingerprint": "bacc66dac4fd75f1378e330563396fc3fbc7f0e599a6b772045982a5bb8fc9eb",
           "file": "src/provider/ax-engine/delete.ts",
           "line": 28,
           "severity": "high",
@@ -4575,7 +4671,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "dcb8a5de1b7a76013268ffd3ff1c5f88b6471e2d32ede2a175ce23997dff81de",
+          "fingerprint": "db86d021e03d30505d63e6669b48688db62e568699d46cf42516a6c2573123cb",
           "file": "src/provider/ax-engine/delete.ts",
           "line": 48,
           "severity": "high",
@@ -4583,7 +4679,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "841886e880e99d9a9757ab15d958914178c45db51ea159f956db5023d18d6cd5",
+          "fingerprint": "afa7a1f00b5a7142e04194ae34865369d07ab54796af1ddeaa091526014c1143",
           "file": "src/provider/ax-engine/delete.ts",
           "line": 82,
           "severity": "high",
@@ -4591,7 +4687,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c79f70fd5b8e673403a09afa82195baba29ac617775c044a216d7c841df5e11a",
+          "fingerprint": "96906e0a98bbbcd4f1386648d6c7c2863a2b35edfab3ce71d09e429fbd71e623",
           "file": "src/provider/ax-engine/delete.ts",
           "line": 105,
           "severity": "high",
@@ -4599,7 +4695,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "417e013001b284c4bd366fec069618a391d5d74d64f9a9a56c527193071a4784",
+          "fingerprint": "fa09afdaf43f6d69762ca67de83a6fdfd43c621a4fee2d3380520448f99a2ff6",
           "file": "src/provider/ax-engine/delete.ts",
           "line": 109,
           "severity": "high",
@@ -4607,15 +4703,15 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "59494ceaad80ff5faa37a0ab6e78072d932bed0126d8f762367dafcedf97a0c2",
+          "fingerprint": "4de8714d11518f6da079a2180464590470615637085059f41de13777e9ba31fb",
           "file": "src/provider/ax-engine/delete.ts",
-          "line": 141,
+          "line": 160,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "052ef149f52c430d541e1a71496d52eef1f83624f8a3cfa1bd6dae78b22e568d",
+          "fingerprint": "1942004a7e2ef450f8722db0968a69b6b4a10d3ebdb19d2d34016d616becd8e3",
           "file": "src/provider/ax-engine/hf-cache.ts",
           "line": 14,
           "severity": "high",
@@ -4623,7 +4719,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "be99dbf8eb38a2045752dbb4928cfed3ba99ab32d3622c3e3c199df57123ff6c",
+          "fingerprint": "be0cd1be2eee71f16679e054027233c12c7a46c166f08374e492c6e128cc13e1",
           "file": "src/provider/ax-engine/hf-cache.ts",
           "line": 16,
           "severity": "high",
@@ -4631,7 +4727,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "629b81bf26588b5e0c994557f3e0f1317db9a3d5e53d7f4a0f1700968f1990e2",
+          "fingerprint": "6f4f887eb934cb42f33e000ec97e9c95c3510e80ef66e7ededb855c36f89ae06",
           "file": "src/provider/ax-engine/hf-cache.ts",
           "line": 17,
           "severity": "high",
@@ -4639,7 +4735,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2b8ff7cd92c652b5dd35cc89c4ef3c4eb92b3ba2c2a25ef1fd470031f8164419",
+          "fingerprint": "0ebf5857cf945829f21e6a6550d69f1ee6a42ed7371f295ccb892cc9cde9e302",
           "file": "src/provider/ax-engine/hf-cache.ts",
           "line": 22,
           "severity": "high",
@@ -4647,7 +4743,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "801e10224fc1ee9f31d2bc07b7dd02b3623318ee5867febf98ae9584e9b9cf89",
+          "fingerprint": "e4b7fe2c3b729632a6304679dda06b145b2a0359a3704bc398609d113d0f3700",
           "file": "src/provider/ax-engine/hf-cache.ts",
           "line": 51,
           "severity": "high",
@@ -4655,7 +4751,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7ae5985c52856db23c021b67feb53931b490c7fcfef46eb80c1dd410dc2e4f06",
+          "fingerprint": "ccf5292f0c7b5edb8b6d34931548fd75d09b1df3525d6d4046ae48f1c9d2bda1",
           "file": "src/provider/ax-engine/hf-cache.ts",
           "line": 56,
           "severity": "high",
@@ -4663,7 +4759,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7d489c854b8a6b7ba96411163bf9ef69a2d2d1ec2dc61e21361e45689607f147",
+          "fingerprint": "b524e6040b7f47e080db4aacc05e16b800982923caf760dd8a6f6d13977b15fc",
           "file": "src/provider/ax-engine/hf-cache.ts",
           "line": 60,
           "severity": "high",
@@ -4671,7 +4767,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "10ee577c8e05a88b32bea1faf764efac0ba2e205189b1b4e65e2eb690a0a1a19",
+          "fingerprint": "943eeeb9cdc0071d6364a92f7b5ec4240ef91e773ae6ffbb2c6782c31a3f81b2",
           "file": "src/provider/ax-engine/hf-cache.ts",
           "line": 70,
           "severity": "high",
@@ -4679,7 +4775,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "90e57b334f46760ef77bbfb2341cfce163457bf98e022b27028f516e07258672",
+          "fingerprint": "71be61ac0b25494ce78282b3d5cfc7327fcd88e9e658ba2e922c2a238fc74f19",
           "file": "src/provider/ax-engine/hf-cache.ts",
           "line": 95,
           "severity": "high",
@@ -4687,7 +4783,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "d6b933da52fbc9e92132bffb40a88f8c312c301556f434591394de5a90e3e2a4",
+          "fingerprint": "9d418a6200b5ddb2b1e87ec14b5e1c221e79f25e23e2d418de4f461837848b28",
           "file": "src/provider/ax-engine/hf-cache.ts",
           "line": 100,
           "severity": "high",
@@ -4695,7 +4791,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f1b964f6d815e83b88a4fc2b2a0895e41627ea26e5b8e33c31d500bd18015fc0",
+          "fingerprint": "ba925f3757bf0f853234e0ad6c885c1032e91012aa2669b721a64758cf4a3074",
           "file": "src/provider/ax-engine/hf-cache.ts",
           "line": 105,
           "severity": "high",
@@ -4703,7 +4799,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "86981e5d88bd2e76773b464b50fda1320169c8563299bd7be7891ba17514e466",
+          "fingerprint": "a9d8c024e080106d90fad4b704aee9407838922a644b6e342d6248c7b23bba80",
           "file": "src/provider/ax-engine/hf-cache.ts",
           "line": 107,
           "severity": "high",
@@ -4711,7 +4807,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "67d01beaa47b10b4e61adb5164cead082849ff1fb9d8e14d2152e8fa49b7bdad",
+          "fingerprint": "dec5efbe11392ab794b5ecaba9b07b7c6ee93c72c01e76f95579f1b74ea9b791",
           "file": "src/provider/ax-engine/install.ts",
           "line": 176,
           "severity": "high",
@@ -4719,7 +4815,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "92aef0709c57b8917b35102c98f5dff12ab06e60f02ac9b22735300f378044c1",
+          "fingerprint": "090b179b6fbc70c252c3e507c162914c6735c570051931ce8a8369afb45c49e9",
           "file": "src/provider/ax-engine/model-cache.ts",
           "line": 118,
           "severity": "high",
@@ -4727,23 +4823,31 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "64526b27971299961a6b63fa7391aa41549eae5a618cc3682ff6206623e645f9",
+          "fingerprint": "626ccab21a2d0eecc3efe19cce84c84f66a6345811c52e9e7228c2a65f75112b",
           "file": "src/provider/ax-engine/model-cache.ts",
-          "line": 223,
+          "line": 231,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "eabe31f28a7f479892a4e77f60acdc4cfac5a5cd5235dbd9d01636eabfb41964",
+          "fingerprint": "be537e430e4245560887338ffc6e50a5c002d5dc9d220be0b2a9d0958bb8bdbc",
           "file": "src/provider/ax-engine/model-cache.ts",
-          "line": 523,
+          "line": 242,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "bda8937d7dd495360ec5d2a4f4106eb46d5fa19cd175612d0ffbd70e249f369a",
+          "fingerprint": "7b9493ff52d767b5178a83157f1fdf0574c116e58815598aa2c22e0ed4dc89d3",
+          "file": "src/provider/ax-engine/model-cache.ts",
+          "line": 581,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "0a215a9f59578ce38724068a90ac5cfcbb171c5e3179ec9b33d29e31847acbc1",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 7,
           "severity": "high",
@@ -4751,7 +4855,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "94a1d452698913c161617d745f2fc6a70b4f291cb564cbaf0c304af12897d543",
+          "fingerprint": "8881619c7787d3deac1fb9748b268370f27dacbfc8edc5aca66b8ba65384f8fe",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 8,
           "severity": "high",
@@ -4759,7 +4863,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "02a7e2ad4699baf65c1d9523c605d3ec3cca12d79794f10fdb253ebf1c2f725c",
+          "fingerprint": "c28777aa3ac5489ecb593d55f9b17ba5c86eea2711ce75f9032135acb92db85e",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 9,
           "severity": "high",
@@ -4767,7 +4871,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5b77156f0b8b6014204103af6f91efdaff6e8cce8279c26851a073f0a993b6fa",
+          "fingerprint": "9c8b7debe38b1f37cab0d04e9434f5c841e6a6227a2100d426abe6365ab53c80",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 11,
           "severity": "high",
@@ -4775,7 +4879,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "12ed6ac8a5ec3ca9f0fa4a5dcf1d6dd3589a1e72ba444b3686d7b116ca0b4b45",
+          "fingerprint": "e16d38711689dec8033917a91e82b217d66c96d91362284eb1891f99d73c271c",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 12,
           "severity": "high",
@@ -4783,7 +4887,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "836860dcdfde17da88bc8d01765464b7c9126aa153b4b8059dd3d663b04e5ca0",
+          "fingerprint": "f206e17b2313831cb978b64592cc1d90d4ebd734c8641ba35f82382077f19ac3",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 13,
           "severity": "high",
@@ -4791,7 +4895,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "866ad2e1dd73b7ff2e08f2a9c62d49e592a1b1e7256080bde12e8898f7cd8e93",
+          "fingerprint": "99871bd500b8586a845d11da4be08367a3279038871c33e2098fe989c7af93f5",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 14,
           "severity": "high",
@@ -4799,7 +4903,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "624f1e8649e73593d2c0c947cfbe97ca5ced9a6dc552e7b38b3d9ae92b2a8b21",
+          "fingerprint": "add4308cf8f99f198773c44e23250fb0908e25f11b5ad3f14c0784871da91f9c",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 15,
           "severity": "high",
@@ -4807,7 +4911,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "110a01acab3ed6f43c63b603b8e3aa8926bd04362452aca75921add9a7a5a966",
+          "fingerprint": "f57d5b1e173480918f4f5478915f737c6bd2be172986c865ba2730926bea25fb",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 16,
           "severity": "high",
@@ -4815,7 +4919,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "450ab7816b1b8986deeaab54e9ee5b07a89a701d72ce8df391279700167a0e6a",
+          "fingerprint": "d01805a920ed168a0bb36341ef62e7807a57beac9ca6f25e01fbb9a8d25e353f",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 17,
           "severity": "high",
@@ -4823,7 +4927,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "363acef9eff0920d3afaf485ebb60249cd29a6d98e9de2a7f2d33490a68758fe",
+          "fingerprint": "718c5699711bb7539a49df92774c7205de868d182fae829009457d29dff34353",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 18,
           "severity": "high",
@@ -4831,7 +4935,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7aa4766d2c072dc46c8880414a36fe04dee89da6c4520c0cdb5ed1d83867033b",
+          "fingerprint": "9da9a9a4c9f4b17b3e4524e33c8db0487cb516c661f7c4f3ce5fc3255ee78e94",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 19,
           "severity": "high",
@@ -4839,7 +4943,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "d1b1a21fea0e79327a46e84eb2dd15d5db9fa050e735faeef82578a2683cb16b",
+          "fingerprint": "a7f0023e82c09f29f3ed1607cc42ed3567bcd8e70e76b550703c16cb883b9c1a",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 20,
           "severity": "high",
@@ -4847,7 +4951,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5f55e6f25422ab3e9f235072a57e13812d8e3d19f7eb0acdfdaf3b65b4f73ea0",
+          "fingerprint": "785878c90a35c20ef6bfb001b1a004d69456e6c45dc99f0bc421e7520979652d",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 23,
           "severity": "high",
@@ -4855,7 +4959,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a429e799b395baec4ee92118792e2d4cbb5cb6d033e8b949a7e7d1b512620d06",
+          "fingerprint": "217528ecf03ef63c6b29ca357b9f98af866e9e72d6c44166788a1eaa0cd91821",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 27,
           "severity": "high",
@@ -4863,7 +4967,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e27186549be176e6252462ab77ac81aebd22555613ef99aa0bfb7c9cc1eed35a",
+          "fingerprint": "e23653c1b372ac58b40ce0b2fb30882188290afea0e35c81c47cf1b026f68e5b",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 31,
           "severity": "high",
@@ -4871,7 +4975,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "9584a898ff51b8862c9ae53a2e024f87d82382b2ba8d1028191f517a799d2636",
+          "fingerprint": "fac5446a6e1ac877841ca283bc5e1f669b40a8d22cf53e5dc9383f4356cc1137",
           "file": "src/provider/ax-engine/paths.ts",
           "line": 35,
           "severity": "high",
@@ -4879,15 +4983,15 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b5e6bbb5e71c523bff0d0cbe78c083e94cd555cd804c49aee0d8646fe72b2ec6",
+          "fingerprint": "241b3121cad360c391e96782c03cd11cf2ad827ee61ce484db31639de2787751",
           "file": "src/provider/ax-engine/provider-loader.ts",
-          "line": 146,
+          "line": 276,
           "severity": "high",
           "kind": "ssrf",
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "31e795e28b4e5ca735dcdf711ca3096c8f868c3c8164435792e624ef09567e65",
+          "fingerprint": "a4e7e03df6ce0f69b3b72778417d83be76a6822955f66ade90bc305357d61da7",
           "file": "src/provider/cli/attachments.ts",
           "line": 112,
           "severity": "high",
@@ -4895,7 +4999,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "cb76870c6518e4ccce6d6066b10b738deec7515b16dd07d4c6e7999803636d63",
+          "fingerprint": "a772d8cccf6e6f8176674ec643cd04458c752f77daafb16a48f48fa7c409bc0a",
           "file": "src/provider/cli/attachments.ts",
           "line": 113,
           "severity": "high",
@@ -4903,7 +5007,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "3002092e3b8a27ea93b1b209dde4eb696dc6e0011ea5f718073bf1776a93c0a8",
+          "fingerprint": "4646941ac5100a540f5fdd578bc92b0d8cf26a35cc265024687dec9829713255",
           "file": "src/provider/provider-impl.ts",
           "line": 1193,
           "severity": "high",
@@ -4911,7 +5015,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "19d04ac82e47b01cce90e6e8b019cae13f4c8fea4c85d2e1dd1ede0d2ed798ca",
+          "fingerprint": "2abf83df8060c0fda88bb59b444b92c68d884964208b39c91dd4831d3c705f97",
           "file": "src/provider/xai/auth-plugin.ts",
           "line": 19,
           "severity": "high",
@@ -4919,7 +5023,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "77dadd64dd937f6147296b9ce8bb0f348433b114fdaf2d3cd01912e8f37ba30f",
+          "fingerprint": "a80d9ce6272aca86a3af721fe81ecf3a5dce04c82d62bd523e26a1392234eb90",
           "file": "src/provider/xai/auth-plugin.ts",
           "line": 57,
           "severity": "high",
@@ -4927,7 +5031,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "56da1f24835b714f5c8a2259edca50cb672c5d2d3d87c24f70862033cd1a7c35",
+          "fingerprint": "cf7e1966dbc473a0f30ce2145a655276c01ac63562c5c3a5a5fd973b2f0116aa",
           "file": "src/pty/index.ts",
           "line": 186,
           "severity": "high",
@@ -4935,7 +5039,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "890a26084ac4fcb58f822d3a0b7487d2d0aebb0ec10a203848b9285746c1ee26",
+          "fingerprint": "b6fa6b16113ee14ed3b9e6af21f1bdb0f99ff49c527d331d9ed69521e024d1d0",
           "file": "src/pty/index.ts",
           "line": 189,
           "severity": "high",
@@ -4943,7 +5047,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "3bde20c664a42b507c4066899e1f32dd412dc1b0a4deba8b92b8c03841bf5696",
+          "fingerprint": "66b15a8b6ec77beb2aef6f26099c0ace9a7adb58ba4446bec70a44a131caf48e",
           "file": "src/pty/index.ts",
           "line": 374,
           "severity": "high",
@@ -4951,7 +5055,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4cf11434888c23714e109cd9fa22856f0830d50e2e0858fa7c153873d260d08b",
+          "fingerprint": "e6d50bc310356ab636db7a8b3103346ade36c6c4b9e8cd1026d0cc8059056fcd",
           "file": "src/quality/dre-graph-assets.ts",
           "line": 109,
           "severity": "high",
@@ -4959,7 +5063,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "f71a52a9543fdec014022fd7b4ae3db6fef608fca70e7893b0b47cc090de289a",
+          "fingerprint": "6df250d6bb4d6e5c0c416c13d00177bc9efafa0be3b125795cd806baa0a12480",
           "file": "src/quality/policy.ts",
           "line": 147,
           "severity": "high",
@@ -4967,7 +5071,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2916ce9d77430e670251c0c03add351532fde88ecb82634297c0a8cc5f121d49",
+          "fingerprint": "822cef44b21a04c7b9a069bce761e467a4e22e58e883441f1918e4b29dea9456",
           "file": "src/quality/policy.ts",
           "line": 188,
           "severity": "high",
@@ -4975,7 +5079,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "709379ba54e409fbf03660ef4d81a3ff7efdb5f60c2b765d98583fc83f74bd55",
+          "fingerprint": "a15672c015d5cee37c5b80dc202134a8f68da50ad0e899ccb432d90ba687e55c",
           "file": "src/quality/promotion-packaged-archive.ts",
           "line": 296,
           "severity": "high",
@@ -4983,7 +5087,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "97417175e2d2c4a635479ae8e148051d5725e015b41c96b5d6958a59f5f6dfdb",
+          "fingerprint": "7969d8149678f60a47acefe873d63d97c46b3475a6d1f0bb8b5efe053b2a2128",
           "file": "src/quality/promotion-portable-export.ts",
           "line": 328,
           "severity": "high",
@@ -4991,7 +5095,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b27f43f36b99b36daf33d23d0916d06a87edf686729c78bda856c6acb7bc5349",
+          "fingerprint": "602193a89d97c5291ec20664b9b90fdc59554c82d2677aed60a1c0022c347521",
           "file": "src/quality/shadow-runtime.ts",
           "line": 232,
           "severity": "high",
@@ -4999,7 +5103,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c332f6af93d142edf24ae4a695852fb82b1ee50a7b2bac6b36582efe407a15ba",
+          "fingerprint": "602193a89d97c5291ec20664b9b90fdc59554c82d2677aed60a1c0022c347521",
           "file": "src/quality/shadow-runtime.ts",
           "line": 253,
           "severity": "high",
@@ -5007,7 +5111,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5e6ed7ba41c08a31cc302c9bdc2c20d4e5049c3520e40deb78934f6e1993c588",
+          "fingerprint": "6c25e8abc8b24f496d09814609e0bb72cb8281858da30aa3f7aad80521cd713c",
           "file": "src/risk/score.ts",
           "line": 217,
           "severity": "high",
@@ -5015,7 +5119,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "26231dc70bc21e27365c68e0e80c81a1da62d49b0a437ca4cce85f085b8f8635",
+          "fingerprint": "d87810f3d1f7529c80e15c7d8389d7ca8a6a5d658b1a93a07ce64ebb961c698c",
           "file": "src/runtime/headless/runtime.ts",
           "line": 108,
           "severity": "high",
@@ -5023,7 +5127,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "63e889ee78555e202a831392b710e5f58e0bc2b540187a3a0f3c32306356b4cc",
+          "fingerprint": "b6fd1958d183132fa860398e42a702c5c3b371f6b4c8e82fe0176e111a176ff1",
           "file": "src/runtime/local-client.ts",
           "line": 15,
           "severity": "high",
@@ -5031,7 +5135,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "14027d608832f8d9cd995792e05bf9ac930c82d6f771ddcd0fed38908b19e51e",
+          "fingerprint": "511acd52ad992846fbed7d6b9e3dd834f7ab54866fc12b2d65bdc9edbb1c1282",
           "file": "src/sdk/programmatic-impl.ts",
           "line": 554,
           "severity": "high",
@@ -5039,7 +5143,7 @@
           "summary": "ssrf user-controlled"
         },
         {
-          "fingerprint": "a46913013fdd9db630ee8ad2ae88a07623e452543c9952d166def4fe012e0a93",
+          "fingerprint": "dfd32100f6ca4a4d1242570b2ce0f1a3c8ac0647d36218b0fa0c7f3cc011d0fb",
           "file": "src/server/routes/app-context-checks.ts",
           "line": 96,
           "severity": "high",
@@ -5047,7 +5151,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "09aeca9efaccc21c79575603f142af9b1cec23ab59c46c46d797bf56db34c18e",
+          "fingerprint": "bf2fb9dca03e9eb7da3691a6fa21eb30538e28d7ca52c7f22af7acfe52f31de2",
           "file": "src/server/routes/app-context-checks.ts",
           "line": 137,
           "severity": "high",
@@ -5055,7 +5159,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "0ca3d79df0e93db173dd77f2d407bf16a514583777e568372b703b15f5af83a7",
+          "fingerprint": "34c39b07b2c256b844736718a4f5da6dd541699b5de0de49329456a48e0b74f7",
           "file": "src/server/routes/app-context-checks.ts",
           "line": 161,
           "severity": "high",
@@ -5063,7 +5167,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "bcca4871329717dddb17d4c69e3a2668efcdae08c1b4fa4c61dd62a0b39d2cdd",
+          "fingerprint": "6de82a369d28ab1b274f0890948a94ef7f63706a732ceab110189aaf30cfc37e",
           "file": "src/server/routes/app-context-checks.ts",
           "line": 177,
           "severity": "high",
@@ -5071,7 +5175,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "be0c96bb559bce9c159b2b3bec2c1449e185daedfd94bb1315037512daff825b",
+          "fingerprint": "5382601910ab5a4bf6ceb8dc95e73f709b1d68be5ad2464e7e2695a247d23ee9",
           "file": "src/server/routes/app-context-checks.ts",
           "line": 178,
           "severity": "high",
@@ -5079,7 +5183,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "de1c9fd1968fed79e9de94ad8ce14dddeb40a6b10a6f0e638bc280add082da45",
+          "fingerprint": "f5b1914858af93553071c6d7340985f312bdbcebc67db8121bf6f8387fa89a0f",
           "file": "src/server/routes/app-context-checks.ts",
           "line": 201,
           "severity": "high",
@@ -5087,7 +5191,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "d3241e8512ef5ff6b4e38e91a62a624745ebd7425f11f184779a972dba8cf755",
+          "fingerprint": "abc9496f2eaa8d6ac9cdf09d64df166b8ff40fc6ab60b23ef7b770ba6e673021",
           "file": "src/server/routes/app-context-checks.ts",
           "line": 216,
           "severity": "high",
@@ -5095,7 +5199,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e72f900c302a3f28edbfaa2d9af0bcb6b2a09811ddd91d6860ccb6521cf7116d",
+          "fingerprint": "ebdb07e0773babfc5ad1b0a92e1f4738d4dd446854532bed4f3157e73576bec2",
           "file": "src/server/routes/app-context-templates.ts",
           "line": 14,
           "severity": "high",
@@ -5103,7 +5207,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "464e49e6c62d1f1471ee8aeee46f4b153920f53a724c1f9a0c1e90eb0fef7c4c",
+          "fingerprint": "a88f6868513ad850a3cf3e6681128a71c077617eaf6ef2e11fca04e8eec1d631",
           "file": "src/server/routes/app-context-templates.ts",
           "line": 21,
           "severity": "high",
@@ -5111,7 +5215,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "174dda60669b3c17640b016f17e60a2caa97a142c40a9540c198bdd34242938a",
+          "fingerprint": "a68404535c23b7390796eed7f2fdc54b3f468582aad5eba6a2c1b9d3af1a2430",
           "file": "src/server/routes/app-context-templates.ts",
           "line": 28,
           "severity": "high",
@@ -5119,7 +5223,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "1abc0122244677cae1f59c30282dba3886126467730d0c504eb37f6a95f41b60",
+          "fingerprint": "965b5e64c89769991819c6acfda1598a4f52489d42e9e37b2ebe863cc492f5a4",
           "file": "src/server/routes/app-context-templates.ts",
           "line": 35,
           "severity": "high",
@@ -5127,7 +5231,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "fe6ff32a9de156b84c514d0847e20c9e0aaf9e26ab631ae29f6fbd31fe5b78b5",
+          "fingerprint": "f8b524d34e5abe385294b2144cd9c984288c349a486c0443d99c6d8e78f1362d",
           "file": "src/server/routes/app-context-templates.ts",
           "line": 40,
           "severity": "high",
@@ -5135,7 +5239,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4d4ef4f9e4ad00771dbabe39a2c230d8f937ffdfc0e9b66389be284944368155",
+          "fingerprint": "460f25bcb18c4b6287c2da6821a47bf5de5106c2e1bfa05bd547aec3d1513519",
           "file": "src/server/routes/app-context-templates.ts",
           "line": 45,
           "severity": "high",
@@ -5143,7 +5247,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c545ca2cf23fb07b76e753f1c1c2bee1e84c3d812a1d60f497cb01a9f95e217c",
+          "fingerprint": "4ff2b43247d2814bc36a74a31816093df7501aca27b36d801420a191fe62b098",
           "file": "src/server/routes/app-context.ts",
           "line": 48,
           "severity": "high",
@@ -5151,7 +5255,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "765081d15b07b833e9c2b7b2babdb078de85242245f26aa61a80c4198f4c6371",
+          "fingerprint": "1809e0037eaf52e3ce9257a6c0038e08346b54006e61155ea57411996d2ed8ca",
           "file": "src/server/routes/experimental.ts",
           "line": 20,
           "severity": "high",
@@ -5159,7 +5263,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "12cc4e98648912183e4176a31c77e18df42ae139340f1cb620e9543241109151",
+          "fingerprint": "c8823f1747f7c94e744a26f9c9c97d297c11a2943eec2a5265e407f3018ff3cd",
           "file": "src/server/routes/project-config.ts",
           "line": 96,
           "severity": "high",
@@ -5167,7 +5271,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2c773e6b721bee0b1fe589dbb652d171522ceb06b1e21cb02782cf597485091d",
+          "fingerprint": "62e6beb61be55923d30b252530053bee23676ce65982ae9f9302578e5810eb1f",
           "file": "src/session/index.ts",
           "line": 455,
           "severity": "high",
@@ -5175,7 +5279,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ccafd477fb0171caa9e6189094278fe9a7341265fc99396f40eb69e7d4c38714",
+          "fingerprint": "ebf40a19f8a153a60085277cb3d629e49d63cffb0e82fe4896cdab4ada250967",
           "file": "src/session/instruction.ts",
           "line": 48,
           "severity": "high",
@@ -5183,7 +5287,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "0fcd67753881ca03377054c18831a468e36a6d6ca4226979099f22a7994ebd42",
+          "fingerprint": "cfdd4e4769b08533bc2f115abb7d32b2f9226f524e39a02719fa0e8781dd4800",
           "file": "src/session/instruction.ts",
           "line": 50,
           "severity": "high",
@@ -5191,7 +5295,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "0801f4a74283656d97f8e3b2ee425c28d54fd37fecec8c0259a1d8492adf456f",
+          "fingerprint": "c28ae6841bc59a2a30d29cf20b2e181af1107345e4b92d5257b94342dc8d38ce",
           "file": "src/session/instruction.ts",
           "line": 52,
           "severity": "high",
@@ -5199,7 +5303,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "20a462b5d29586bf16f09502c1094e6e77bf00eaafb43653e0f68f4439e03889",
+          "fingerprint": "79f874331842ed7f38c89d2584488d8f8370095ff7310838e541a4c4fa83a211",
           "file": "src/session/instruction.ts",
           "line": 115,
           "severity": "high",
@@ -5207,7 +5311,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4d0e9c55e6b6f1e51bce7a08fba76ad6653c92353bf83fb2e9805355b6b8f7ce",
+          "fingerprint": "57fff9637a54550341724869f6ede43ed2d56545c82df08ab3e472dba5d35660",
           "file": "src/session/instruction.ts",
           "line": 124,
           "severity": "high",
@@ -5215,7 +5319,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "46524d1e29172c7004f10fa6af39f08a31b62a2f9b63988d24b23f5492f22113",
+          "fingerprint": "09d0fc0840624946e8664ab77bbf4b68b2c42376d7e9a09698f0c4fab1cbac91",
           "file": "src/session/instruction.ts",
           "line": 138,
           "severity": "high",
@@ -5223,7 +5327,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b5631d6356fc39b76988d9469dbf1e89ab0292c9f71e1eed5f72eb7f2f3b6add",
+          "fingerprint": "c6332e2418910dedb9f8ad4a458cc30b5074372480963ca5de0c5bd16ff4a971",
           "file": "src/session/instruction.ts",
           "line": 152,
           "severity": "high",
@@ -5231,7 +5335,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f3ac369ef6eb0e02fd636912e9cb3ccc49eba97c47d3d89f18d3f3f2131f8b05",
+          "fingerprint": "2faf476fd273e9964c5bc712b38b080972037ee9d8ead8b3ff221d8f36e948fc",
           "file": "src/session/instruction.ts",
           "line": 271,
           "severity": "high",
@@ -5239,7 +5343,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2a5bbdb5966d7a1cc00c6328b10169ea165c2f13980ccd3c97b7a67033cd410c",
+          "fingerprint": "a2c78e64ab5a9911215cdd0624532ae4af1dc6dd97c8c6a4b4a57a1257c70aad",
           "file": "src/session/move.ts",
           "line": 65,
           "severity": "high",
@@ -5247,7 +5351,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "23d6009c86dcec54f9e277aba62daabf5f7af36b6970d84b4767a804b2c57dc3",
+          "fingerprint": "6d44d96eeeb353f7acf718bc74dd01ffb55166ba7d769ff6d0d40e9bb3a3cc28",
           "file": "src/session/move.ts",
           "line": 70,
           "severity": "high",
@@ -5255,7 +5359,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "8f7ec14989143324af22f498d8f7e2184c2678b40605ddb0b01c0e8a806a2690",
+          "fingerprint": "b0002243622e12e422795278b7ba4e517613c31c6001a11e66a470f9c70b46e8",
           "file": "src/session/super-long-runtime.ts",
           "line": 26,
           "severity": "high",
@@ -5263,15 +5367,95 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "935316e612162d4001777811c917cfc67894e3b72fb62995a853b4cc7f849be7",
+          "fingerprint": "f63776463deb05057a82f0b2a19b4c6defb4ef6c4c9aefe3671ba4cfa844f17a",
           "file": "src/session/system.ts",
-          "line": 102,
+          "line": 142,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e3a583f559cd766c9ae5d77ab9cba1de823dbdf17a30d2f0c370b3c5887fb52f",
+          "fingerprint": "c562ec92fae4586101ce30b38023651e8c0e95f373956d7423dd1112d64c4fcd",
+          "file": "src/session/verification-policy.ts",
+          "line": 193,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "ea02441dcdd5037142270191c05e0812602d8daf3132463d2b9ebdf555bcce6b",
+          "file": "src/session/verification-policy.ts",
+          "line": 194,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "a2dff71bd280960c6f42f44ce909df995c0990cc5e898a306535b23d894b1019",
+          "file": "src/session/verification-policy.ts",
+          "line": 195,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "6833440535345fa70450e9fe106fd2843c8743f02513d3f4ea40e777ccad7e3d",
+          "file": "src/session/verification-policy.ts",
+          "line": 204,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "4cfbbf38b2481d937505096f56159984e4d8af84e96a4642d1ad8c607ecd1280",
+          "file": "src/session/verification-policy.ts",
+          "line": 205,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "7c655ec46e97c8acce19fbe2c56d117373fa5a43272946f2b46e042de2dbf6ab",
+          "file": "src/session/verification-policy.ts",
+          "line": 206,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "ff14ed9edb5bc714cc1e70a942b169f76729511d67a951541901227476774387",
+          "file": "src/session/verification-policy.ts",
+          "line": 207,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "37d79ccbcc23ebe8ed6788f7ca15ef2622cb2966da0372286e6fac836d731829",
+          "file": "src/session/verification-policy.ts",
+          "line": 208,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "1a0fb7aba88523b0c6ed8a5d74d77db7d6c093efc7b65ed37cadd3bd9ab92fb0",
+          "file": "src/session/verification-policy.ts",
+          "line": 209,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "5854c12b70a136cc1a571eeb771bb420edec943744dd20c845b301ba7afdfeb5",
+          "file": "src/session/verification-policy.ts",
+          "line": 216,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "830b0220d608693b2444740cf005e42259f3660655d7bd4823a055ac147acde8",
           "file": "src/shell/shell.ts",
           "line": 74,
           "severity": "high",
@@ -5279,7 +5463,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "1c3c9bf4bb0f51a49d225d000ba85d261f220e22b5b51f04f306a7b78b26b492",
+          "fingerprint": "a78c88739f40af4a63b46de2ee0c556e5b5930a75e321fec45022458842e5240",
           "file": "src/skill/authoring.ts",
           "line": 185,
           "severity": "high",
@@ -5287,7 +5471,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "cc8a73b0526c5d542bb50bb38a5099848db4d9fd2ccbc98c0b5e49cfc824ec09",
+          "fingerprint": "02347c8b6650f99db88c7dc993fe73b51e72ff2016eba4970d90fd23fd756104",
           "file": "src/skill/authoring.ts",
           "line": 194,
           "severity": "high",
@@ -5295,7 +5479,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7fc5bce2f06e8b45eb9b29bed6dd0e34fd3a3dd8d827e98ecfd316b0f69e56d1",
+          "fingerprint": "04f5145d6cd53826db38a301cbed8e2ebf2ebda57f7ca84b7bad8cd4c35a60b2",
           "file": "src/skill/authoring.ts",
           "line": 212,
           "severity": "high",
@@ -5303,7 +5487,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "210f39cec453ec3e188440f933fd45c56d25dbaad70056090ad95eef7a574cd2",
+          "fingerprint": "55a3a995c96a1b2691002e4e36ee69f077f26b68ce5f17966893c5ed9864d0c0",
           "file": "src/skill/discovery.ts",
           "line": 144,
           "severity": "high",
@@ -5311,7 +5495,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "49d197f7cf7f36705fdbeed576eca07120ac61b842d5711ad35d211635fd6a22",
+          "fingerprint": "b1d1ac2374c94b3fa5ca2dd4cef177224a5efab66c59725eb43c39ffb5d26a1a",
           "file": "src/skill/discovery.ts",
           "line": 209,
           "severity": "high",
@@ -5319,7 +5503,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "94d8a2a3ac7ee94bcc03bf9c5529131687fea6ab1bde27ab777e6ae37ae6f7e2",
+          "fingerprint": "a61026d2650c7f05460dc6a1ec92b03ad0171f1b0e99cf55d50b871502cb0711",
           "file": "src/skill/index.ts",
           "line": 189,
           "severity": "high",
@@ -5327,7 +5511,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c0984b53f9453c9e0b388355b66358b6fac362914b8b807c7d76986faffc498c",
+          "fingerprint": "fbb1825953d3eaf2a63a1e9ba64c63fbcf0c561dd846e30651d62dc0ebfcdc52",
           "file": "src/skill/index.ts",
           "line": 235,
           "severity": "high",
@@ -5335,7 +5519,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a85f8b3b43b988905bdc0de9e820fc220cee856ff2560a17e862b5941cdeb085",
+          "fingerprint": "68af1f04b2940892dfbe815f0ec4abf7bc3bed42d1806edb3e461a42766a1328",
           "file": "src/snapshot/index.ts",
           "line": 90,
           "severity": "high",
@@ -5343,7 +5527,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f7f606c78ffaab16e8c1c854b82a730a9688edbe415c1e6c4e31dbdb7298be7d",
+          "fingerprint": "4afa55ed805e422fd58aafba359e981cf29a8cad3d3c5ba2b38cbce780db5b13",
           "file": "src/snapshot/index.ts",
           "line": 167,
           "severity": "high",
@@ -5351,7 +5535,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5ca2d2d18149d6306dac4998f6022e97283dec65a07e7d918795107e675c641f",
+          "fingerprint": "daf971ff7c54b63913a4d57464b14ab11c7f71096eddf66319e727e8640f5b0a",
           "file": "src/snapshot/index.ts",
           "line": 210,
           "severity": "high",
@@ -5359,7 +5543,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a0377116d38a7181c2e66d317085ad7d90a82e8dafbe624c3216b55bc19eb395",
+          "fingerprint": "658406f7998e80fab39f11130218db2ba52d3830a634bdba68768fdd0a9515ba",
           "file": "src/snapshot/index.ts",
           "line": 211,
           "severity": "high",
@@ -5367,7 +5551,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7e219a78185b00699fe5024237fdc80f81428dde50b6b6370c4408686533c15a",
+          "fingerprint": "e5119a6a30ba9c6889cfdcda3a8fa397a53045249560a5963d023c426986523b",
           "file": "src/snapshot/index.ts",
           "line": 378,
           "severity": "high",
@@ -5375,7 +5559,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "de76de05c16bb7eb351fb3bc287e28bbc958f000a2af84cd4a0dceff8352bef6",
+          "fingerprint": "d866aaef995033fc832c4fec78b3821105bcba194b42b9cdda65d34ac3b6ede5",
           "file": "src/storage/db.ts",
           "line": 39,
           "severity": "high",
@@ -5383,7 +5567,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "133a64ac1db2fb5610b2ebe8a4a398d2a24e9e3078a232cdf8d9a5732f675a8b",
+          "fingerprint": "bee87b6a7ab8c069b8affe371b3d7109e46b271ad6d994c498acd24d34189df5",
           "file": "src/storage/db.ts",
           "line": 43,
           "severity": "high",
@@ -5391,7 +5575,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e554adaf4c29b3209f27be60eeca729c6d16dac643ee96e91b201d8da0484463",
+          "fingerprint": "abe41f513a3d9886b40cb0aed43ad32d37f285b5906e48ee96c940e0665a566a",
           "file": "src/storage/db.ts",
           "line": 45,
           "severity": "high",
@@ -5399,7 +5583,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "85997c0df807e551f7c287f9ac891c77a9c792e2284ff884711ddb4487b05d78",
+          "fingerprint": "6c49eefc6f0a257483537e586c13992527209c686d6b05becd1a6cf8187ab19b",
           "file": "src/storage/db.ts",
           "line": 74,
           "severity": "high",
@@ -5407,7 +5591,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5441309d0b42aef580f35b58eb6fac559ce353db3d54c40348a905f469564f93",
+          "fingerprint": "db1c554a6b56640223e593cb087e896945b8299e237930ad836daa1095513c28",
           "file": "src/storage/db.ts",
           "line": 130,
           "severity": "high",
@@ -5415,7 +5599,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ebed6712c46feb82945915a7278dba0e5e446e689fedb227e8e3c909083b4feb",
+          "fingerprint": "5033301e0fcaeaab783aa055bb83078c9ac9089f071cecf16a2362419733e7ae",
           "file": "src/storage/json-migration.ts",
           "line": 81,
           "severity": "high",
@@ -5423,7 +5607,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "718b1ab4946f865ba319245a22df798152423e32a0c51fcd36ec47949e6aed63",
+          "fingerprint": "1975a56b058f32445c9e1b505d6ab82e49e20a2b9df9a41b95f4dfa03136faaf",
           "file": "src/storage/storage.ts",
           "line": 28,
           "severity": "high",
@@ -5431,7 +5615,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "1caab655e075e50b2811aa8e03e5e58741c6d557751f539529b393c3cc790769",
+          "fingerprint": "f4f2c1f99b7f99bcd93f33cb90b83a1fde343a90386568ad270b995550cb2be8",
           "file": "src/storage/storage.ts",
           "line": 35,
           "severity": "high",
@@ -5439,7 +5623,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a95ccd6e762035a07ca57837a01b477808f7dd09912a4c03e48ac4ca24a7c8a4",
+          "fingerprint": "25f2589d1221e656bd3eb94da0e16e6783519e21c853aa7d42d2b3087a20a148",
           "file": "src/storage/storage.ts",
           "line": 39,
           "severity": "high",
@@ -5447,7 +5631,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4961936b9ed75f417d47fea04b02c86492fd9d4a0e8529dc3243430b2a734043",
+          "fingerprint": "da247a55c506942ce58937d2482e656c52470d962c89a8e4e0d69cd89c4c9750",
           "file": "src/storage/storage.ts",
           "line": 44,
           "severity": "high",
@@ -5455,7 +5639,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6386d4fd741e4ca6a9ec4633f31e25b8d21c9a4b43b8f55a28731d6daf3aef0d",
+          "fingerprint": "43e59b614f90b0375424f4beea0ab54a733ab68c359e0aeff58ce9deb1fc77ff",
           "file": "src/storage/storage.ts",
           "line": 69,
           "severity": "high",
@@ -5463,7 +5647,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c37bba660f78354491fd2df2a7aac8a0633d7e4c46482d77b17c2e929c8fdd6c",
+          "fingerprint": "fac52e5769804ee7fef32c0f4844d121f2c5d12584e4025877e38c8096dcac2a",
           "file": "src/storage/storage.ts",
           "line": 84,
           "severity": "high",
@@ -5471,7 +5655,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b9c7512204bde91b6351cdcfd0dc11c526f75db1d80988b7908c790d06214d61",
+          "fingerprint": "86f9f99ca700215188976bc772f112be691963e1d55d4735f15ea0f6cd4152c3",
           "file": "src/storage/storage.ts",
           "line": 96,
           "severity": "high",
@@ -5479,7 +5663,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "8983182da49d2bf83f0d3ccd4e4294b7def3f130d0ff96b0e7fe5feb92ea4596",
+          "fingerprint": "d022fd73dd48b39b07e5fdbc283c778ced77bd3951e3d3d3b7d686187bf8000c",
           "file": "src/storage/storage.ts",
           "line": 109,
           "severity": "high",
@@ -5487,7 +5671,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c265e621508269d362af1b965cca85be8fc5b7c09e7e1e768cdb201a63cc3b79",
+          "fingerprint": "bb1b38277d54a0bab57396444fbb31d71986bc1237f14a463a38efe65c421e65",
           "file": "src/storage/storage.ts",
           "line": 131,
           "severity": "high",
@@ -5495,7 +5679,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f24958d4c91bbe669d06e4f9eb0a9651080d279b6a26463f5488e335e22d97b3",
+          "fingerprint": "830f02dba57652a22c3d3fd46c17de9d0fe59c8062ba26d80f80d0316ebca03d",
           "file": "src/storage/storage.ts",
           "line": 132,
           "severity": "high",
@@ -5503,7 +5687,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "02c9310eec8478f4229b5b4525f0d4ee67c1ce0df95c0a191f755c9f25e544af",
+          "fingerprint": "7bdadf195a960835fccffa36d9247722ba0ec9a5b1d99613de35f30a32db6f52",
           "file": "src/storage/storage.ts",
           "line": 163,
           "severity": "high",
@@ -5511,7 +5695,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "323a07ea1345a5441e760c2f6a53280765bd7d038f4d0e2e632d311291b37874",
+          "fingerprint": "708a9fcbdb2e027d3b24daa9cb4f42b2bd5ad4f5cb83685b69873c0cb2fc80ed",
           "file": "src/storage/storage.ts",
           "line": 172,
           "severity": "high",
@@ -5519,7 +5703,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7128bd735805327c11c46e4b455ecf5551be0c647c3f9d73b349be5c360a923c",
+          "fingerprint": "b91ca7a8dbcd40c84505bf08ed42d01320437c70491ff0e8ab9c9a848b2a0963",
           "file": "src/storage/storage.ts",
           "line": 195,
           "severity": "high",
@@ -5527,7 +5711,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e4678ea9ac157523e3b26fb2201fb77170575b16ebf6f140e3502fad3bad8f2a",
+          "fingerprint": "2f2de1564a4680cba3a7cc8b9788516ffdff10970d3350b0c81d9c778bb5d766",
           "file": "src/storage/storage.ts",
           "line": 209,
           "severity": "high",
@@ -5535,7 +5719,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "66f5bdd34d0b2170e5d1c2276559e1685e3e94c1536956a6e50ecf0fe978949a",
+          "fingerprint": "52c2c90412d9b009cce8021b9961620da2777859664d8dfa6927c7c67f9afe4e",
           "file": "src/storage/storage.ts",
           "line": 237,
           "severity": "high",
@@ -5543,7 +5727,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4025a79b1b5c1bfa504ef5f0a8065557044d12f2761b575542c843402f4275f3",
+          "fingerprint": "af1b6634af41e0bd1b87d555bea12a3f9d9b821fc690b696edc222440ad4a030",
           "file": "src/storage/storage.ts",
           "line": 246,
           "severity": "high",
@@ -5551,7 +5735,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5b7060432178d90e3597fc0e82d67e5c97b1de0ff1ae86aab1b56117e38f6b77",
+          "fingerprint": "bb6bcfb2097d7b0ef8505cf05259667e6075ac72ea3325884410bae259014886",
           "file": "src/storage/storage.ts",
           "line": 268,
           "severity": "high",
@@ -5559,7 +5743,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "ed6617124bb4ab79bf2dd158bb691ff01142999e1d3b24a34b81330fa6528ac8",
+          "fingerprint": "6cdc79b49e68745f084121160415a877751b316f4bc960857d92a80a3eeb28aa",
           "file": "src/storage/storage.ts",
           "line": 282,
           "severity": "high",
@@ -5567,7 +5751,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2e668a830940814f884a7c7a86ef6a0592c586f0fc287c622edc05d7b4df1c5e",
+          "fingerprint": "af1b6634af41e0bd1b87d555bea12a3f9d9b821fc690b696edc222440ad4a030",
           "file": "src/storage/storage.ts",
           "line": 299,
           "severity": "high",
@@ -5575,7 +5759,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "3d6342db9e358fa9a1b5b372dc44e1f76a79486818ea813b75629bd690d625d6",
+          "fingerprint": "145fd84d63659eba3a2a28e6ac8529128dbd4d2f0fa886269692633b843dd6e4",
           "file": "src/storage/storage.ts",
           "line": 337,
           "severity": "high",
@@ -5583,31 +5767,55 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "39db046ce87a08eaf5ac17a32bad292a13ae57874da790a7a055a52a8dc07d0c",
-          "file": "src/tool/bash-impl.ts",
-          "line": 509,
+          "fingerprint": "66b71a24ea9d9602ec68175078c2d8855f45c7f511afd79ae274fed83bf64df9",
+          "file": "src/tool/arena-implement.ts",
+          "line": 90,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "15672f4401614fc890165a23a9f7684f2885f007d45e40403313c533c420fd03",
-          "file": "src/tool/bash-impl.ts",
-          "line": 585,
+          "fingerprint": "4c179f72061e376f3455a61215190ec1b163b5a6b914352e86ed11765f5ae7aa",
+          "file": "src/tool/arena-implement.ts",
+          "line": 91,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e27fc81b2cc995eacd70efeadc0006b2356884d2fb4f7657908dfa2fc7e4a18f",
-          "file": "src/tool/bash-impl.ts",
-          "line": 624,
+          "fingerprint": "9a257c78097e7fe4f0d59b6ec530ad32a0b21723d842e84e72c59d19e5e1141c",
+          "file": "src/tool/arena.ts",
+          "line": 362,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "196d07d3232afbab4601f74f39a6a401d79c66ffbdc75be198d5fcea4749c264",
+          "fingerprint": "f94777cfcfa15d16dcd6717d4414d6dd50b7c3517be31f5fd275b9331138c3f0",
+          "file": "src/tool/bash-impl.ts",
+          "line": 510,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "f94777cfcfa15d16dcd6717d4414d6dd50b7c3517be31f5fd275b9331138c3f0",
+          "file": "src/tool/bash-impl.ts",
+          "line": 586,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "e4e092c4a26d5f39ba19c54146367be8beb44617092c2ff9e9ab363dd3a4308f",
+          "file": "src/tool/bash-impl.ts",
+          "line": 625,
+          "severity": "high",
+          "kind": "path_traversal",
+          "summary": "path_traversal user-controlled"
+        },
+        {
+          "fingerprint": "8bcc512d3a9832711a424a1666a91a79ffb1833d33c973e570db57aedf8a15c5",
           "file": "src/tool/external-directory.ts",
           "line": 17,
           "severity": "high",
@@ -5615,7 +5823,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "3cbcd990ec932c4339463356a405e8f206e06dd3ee1f6e94115670f92056a376",
+          "fingerprint": "08e46ae374dfee184c699fbf377538f9c8ffd0516de49037a85ca6261a3d78c6",
           "file": "src/tool/external-directory.ts",
           "line": 37,
           "severity": "high",
@@ -5623,7 +5831,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e2976771eafb04566b7b9e297a2bfbf8fffa37d98952b4775f5bb5f79becbb60",
+          "fingerprint": "42f253535c148de77a10f69b4aeb8867ebe6ffa5ae9ace2342f139bee55a144f",
           "file": "src/tool/file-path.ts",
           "line": 42,
           "severity": "high",
@@ -5631,7 +5839,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "bb36c3215c3cd77305a94792c0ff717096bf398ad4dc87c47e8ab1c674d24dee",
+          "fingerprint": "fc76a54c77e653e84dd48eb86a9d7c565fac34f40c6d856701fdce607ac7adde",
           "file": "src/tool/glob.ts",
           "line": 111,
           "severity": "high",
@@ -5639,7 +5847,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f43afdfe98fbb140ee1e40608169a2d5ef42bc8625ccee9b15973c9f8e695308",
+          "fingerprint": "6115014bb20464ecf03c3f8d95dc09df241cc5259f1783fb4793727558e1bdcc",
           "file": "src/tool/ls.ts",
           "line": 75,
           "severity": "high",
@@ -5647,7 +5855,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "359b9d0321e8cc5bc688bc66f3bd1bcac9e71b98a8bcca2bc7f79df661061a58",
+          "fingerprint": "e2dfa7cacfa8d3baad8a1c4ed4ce9929b269af6f3ff8eafbedaab938f3cf6541",
           "file": "src/tool/ls.ts",
           "line": 81,
           "severity": "high",
@@ -5655,7 +5863,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "acd403ebe05de93dd7e4514366f4a18d1f7e0f4afd3bb289000306939ca0ce5e",
+          "fingerprint": "5e300f44a34a8aaf9ddb26cacc3e19e0547241fe8c25570e6b7ddcd4a9132e3f",
           "file": "src/tool/read.ts",
           "line": 134,
           "severity": "high",
@@ -5663,7 +5871,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "4cfaa2ee20ea7064dbf791d6c5e1a3e6d8da639b93d5e3a2e892c622f6c6f62a",
+          "fingerprint": "e41fe87413070131c2270e5c10f67856c15b1b6e29cfd816935bb6610c7ee94f",
           "file": "src/tool/read.ts",
           "line": 155,
           "severity": "high",
@@ -5671,7 +5879,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f2ede160cefd935b5fa162666b634e5e6fd4d58eda187ef3d6b412c16006b314",
+          "fingerprint": "6319458c6f8042d7723e45d4d6ca96577420d2d78c2338d71b05feecb4f48361",
           "file": "src/tool/skill.ts",
           "line": 96,
           "severity": "high",
@@ -5679,7 +5887,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "35349dca9c7cf93902c558bbdcd55099aad0fc54a53a5ba40cf9bc25abcd87f0",
+          "fingerprint": "f13a6c8f33afa4842a781a2ebb81eb8b569aaafe91fec0e00dd605f9ebb2eb19",
           "file": "src/tool/truncate.ts",
           "line": 20,
           "severity": "high",
@@ -5687,7 +5895,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "080696357932595a2c3775c54f32d7533fbba4b3c3e7826b8433bcc176aa0c85",
+          "fingerprint": "588ad3abc2c3c9c6ddb58c429044b678d4c68648a476966bc919ab09f99e9888",
           "file": "src/tool/truncate.ts",
           "line": 87,
           "severity": "high",
@@ -5695,7 +5903,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2a773a16b1af3b633a01009d3117be8a012c55b2d6144c0c22732967a3d5526b",
+          "fingerprint": "b8d2cb4ac2286724ee0f4cf5d799efb95a9b0ee6c929c3d787a084b26427a88d",
           "file": "src/tool/truncate.ts",
           "line": 95,
           "severity": "high",
@@ -5703,7 +5911,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "c81ba870bebb47b04c52d2469305f3f31b18e016066be375096fe29af38bfca1",
+          "fingerprint": "a22d2688a0f0ea6e9e5287c7f9bc7873b5c5953fe1781c7d3de52322c7953306",
           "file": "src/tool/truncate.ts",
           "line": 104,
           "severity": "high",
@@ -5711,7 +5919,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "015568625b49f96fac74d2402fd3bc8a70451c54a0e031fa2b9614fe3b365780",
+          "fingerprint": "6c461d0678bff5df244494adcd4dd13b1ccaf621966a006fabbdbcd8f90a57af",
           "file": "src/tool/truncate.ts",
           "line": 162,
           "severity": "high",
@@ -5719,7 +5927,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "33a4aefd76ffe88545c45ee71425168e1633672dfde170b73d6730c7683ab1b4",
+          "fingerprint": "77bc86eebf9c11ccb1ec64961190150a9c8cb76360841d68987b430cba441a9a",
           "file": "src/tool/truncation-dir.ts",
           "line": 4,
           "severity": "high",
@@ -5727,7 +5935,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "99970cfa82a8e05646cce8f23de3bcebe28ccc4cc7163ac7c4452c6d689ded4f",
+          "fingerprint": "1a0e45c467e8b1bde6190d79337577d9022080f2474f481af8d26ff0bbecba51",
           "file": "src/util/archive.ts",
           "line": 12,
           "severity": "high",
@@ -5735,7 +5943,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "438f6de44f908533e53e5a002d1265d70f57923385ebfaea78c99c88bf93c8e6",
+          "fingerprint": "db4a0cb97c424c0d5f25fd937bd23c372608d251552a1f52eceeb554d0c40865",
           "file": "src/util/archive.ts",
           "line": 13,
           "severity": "high",
@@ -5743,7 +5951,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "19142156b0ec86f8647533afa4076f6405705ff8e4a0860a9f24a87a5cf06668",
+          "fingerprint": "ef1131bfdaa6e3ed952bc0ed73dd54e99a71e85b7cf77fdefcf37555c1ce1933",
           "file": "src/util/filesystem.ts",
           "line": 164,
           "severity": "high",
@@ -5751,7 +5959,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "6214d177856a50eecaf571ceb0eec38b4a7c23894a7add023d320c80844150a0",
+          "fingerprint": "12745eac4fbff68c337c7974dc85a254f6c5afc0fe1002e3df970ac58f860890",
           "file": "src/util/log.ts",
           "line": 180,
           "severity": "high",
@@ -5759,7 +5967,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2ae26033b639951f4eaa8b9b52616058bd7b8977ce6158a927fe10580782110a",
+          "fingerprint": "2ba0890a1eb29340593f6640ea3947c8244497fb83c3322328ae09a08f68b0de",
           "file": "src/util/log.ts",
           "line": 194,
           "severity": "high",
@@ -5767,7 +5975,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "24e40590b3eb7ed6cacc22aa3367f6c94cb00b003ee8dffa3c227c3fa596205d",
+          "fingerprint": "ee38fb1e64cb73030f7f8dd78186b8ffc8784d3c10f804610190a8bed850aabd",
           "file": "src/util/log.ts",
           "line": 200,
           "severity": "high",
@@ -5775,7 +5983,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "31f273813b116c783ab47436c9eaa146557968b68ea1a9f4fb6833ad9b3e702a",
+          "fingerprint": "3e16a6772534f6a4df3cbbd2d5a43dde1c2ceb530bec7408f9ba74bc76c5d1c9",
           "file": "src/util/log.ts",
           "line": 213,
           "severity": "high",
@@ -5783,7 +5991,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "cd4763a4b24a18a1dcc715b5f0141d91e4c105d9614d11dfd4c245b7f6adf25c",
+          "fingerprint": "ac271f034a29d6b61aa1e74e0e4a2b14fd6d1c89c91453bdcc3fada0a9197e15",
           "file": "src/util/log.ts",
           "line": 228,
           "severity": "high",
@@ -5791,7 +5999,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "cd58893d687aca0d59e69872e6fc64d5390cee22619a137c46963c2757459f06",
+          "fingerprint": "2937525719f70b3b8611f25ff9577d8eb13f4c9f2ffb5347fc41e99eb8d0575f",
           "file": "src/util/which.ts",
           "line": 8,
           "severity": "high",
@@ -5799,7 +6007,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "3c23571bdc9a912c6b2b78a26904c4d1da6fb19bba57e1780cad6a513f9be31d",
+          "fingerprint": "4df7e001c174155576256e1137fbd7e09cbc8fe2f8c1b5071940d8c755e2066c",
           "file": "src/util/which.ts",
           "line": 9,
           "severity": "high",
@@ -5807,7 +6015,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "a1dc7b69483e6ab7f0e489f0686a4cecd329b1bea2777e3319fe60c2f618ee5a",
+          "fingerprint": "64754f8b3a28c30673d3395ae900b3f8d3a7a8094369a5307df4f295a39a317a",
           "file": "src/util/which.ts",
           "line": 10,
           "severity": "high",
@@ -5815,7 +6023,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "271e4492f0d7dc14702b09b7f2b58902250e8e0063631045b3d1a1c936885b77",
+          "fingerprint": "d13e5136c79c66665b693952e3e7619e1788a4a9ae1d2fb5fe5bb4aae9e8f820",
           "file": "src/visual/artifact.ts",
           "line": 50,
           "severity": "high",
@@ -5823,7 +6031,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7b0699d4ca07c11c2ae76194990eca7693c45924fcc584605bb93f6630db9da7",
+          "fingerprint": "94fb8e0fa52c95b4745c5d2a458f80f00a018b785bca73bd7af3b8d1ed849aa6",
           "file": "src/visual/artifact.ts",
           "line": 58,
           "severity": "high",
@@ -5831,7 +6039,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "7cfd6e90f1a8faed12da1920dd9d0f8f8fa38a68b9e2f6cc403ea968b4e50449",
+          "fingerprint": "7a12a831f68d1fc6750699a98a71782bafea83bc28703082e8d71188e4ad33ed",
           "file": "src/visual/artifact.ts",
           "line": 84,
           "severity": "high",
@@ -5839,7 +6047,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "5121b02a8bd97255e4cbfd9fca84cc66387ebcfe34a7f7bc7a221b41606dd246",
+          "fingerprint": "5d34f4a22496a201b2c43eb2a8f4acf7c983ba0fd58e5d029dc7398ef82bcdcc",
           "file": "src/visual/artifact.ts",
           "line": 124,
           "severity": "high",
@@ -5847,7 +6055,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "1434708f2f9459f7883ab0058672b1b63466431bb86330e9ce048d74d1c5d865",
+          "fingerprint": "e318ba77b8dd48f9926fd99ea91d603537b876a12a0a57407dd6eedbba3652f3",
           "file": "src/visual/artifact.ts",
           "line": 145,
           "severity": "high",
@@ -5855,7 +6063,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "683d692003556c6adb4dba8a3ea11672d2037622c1efec7edb69c97c43a8b326",
+          "fingerprint": "5bc4761047bc5eaca4c48b0165e8728db5e8a8354975ef18215c109c95d631b2",
           "file": "src/visual/artifact.ts",
           "line": 169,
           "severity": "high",
@@ -5863,7 +6071,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "36cae8c117a78305db7082567e5bd3ce944782b1c2ad7b40184f9b1fbf8472dd",
+          "fingerprint": "77822be8763b4faec918da48f2dcf72271981b9021cd815c26e33f9567c94484",
           "file": "src/visual/native.ts",
           "line": 55,
           "severity": "high",
@@ -5871,7 +6079,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "eb437a526d564132eae3d42ee5576d966121351377ed5fc5fcc6050bb562db78",
+          "fingerprint": "e23393c1e9ad4516ac7fe811b5913a089827a73474108ded4ca247457d5496e0",
           "file": "src/visual/snapshot.ts",
           "line": 64,
           "severity": "high",
@@ -5879,7 +6087,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "cf8a1b5a2b93ea060fb219993991ef5aa7d58b1d0bd4fa5af8926b0a9fa531a5",
+          "fingerprint": "50359df0b852d36e971767fb7a5b68cf9b992d2dfea8fa9742dcd0ebddcc0da1",
           "file": "src/workflow/template.ts",
           "line": 209,
           "severity": "high",
@@ -5887,7 +6095,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "998a141052293d1e95f2ad615e8446e0134a7cb3edf4278c985b9a9dee6c6295",
+          "fingerprint": "bea8b9afcad0fc725c5027cbba692dfccf27729226d46239590cb09b9c161c5c",
           "file": "src/workflow/template.ts",
           "line": 267,
           "severity": "high",
@@ -5895,7 +6103,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "2b5d6a01f5e665c3475eeea29fb244975b1d8e03b74930dd65a86558f64689a7",
+          "fingerprint": "a1e17ab6fb8da52cb807d8b9d17ebc1d96972405531a3f2b6a05f6f35c4f7845",
           "file": "src/workflow/template.ts",
           "line": 268,
           "severity": "high",
@@ -5903,7 +6111,7 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "e5306c0203a706212b8c42c5b92aa0515053172f65d519645a418f84d8383658",
+          "fingerprint": "181f9c2f77bae971bbea48b02c62548b271116ce3e4fa6ecf9e6ccf053681f60",
           "file": "src/workflow/template.ts",
           "line": 280,
           "severity": "high",
@@ -5911,31 +6119,31 @@
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "f1f7bd8eea1fa2f8bc6166a4aae2d0a380a7f273472715b68c0483486cd51dab",
+          "fingerprint": "3e2709c82e3ee5b3634918afc58e38e9b3eaacc15be65d0d0d85705c5a41bfa3",
           "file": "src/worktree/index-impl.ts",
-          "line": 278,
+          "line": 288,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "dff6bd79ff24183caadf491a12c6f16d907dd2273ccf4d1036db63d40903b145",
+          "fingerprint": "b4edc78ece951d7fd3335236e9605410bafb472c8e75a491ee66cecf5030d3f9",
           "file": "src/worktree/index-impl.ts",
-          "line": 345,
+          "line": 355,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "b86c30b8c2269f2ba21f91fb7e92a66a471449153a03dcead627c4c0fa44598e",
+          "fingerprint": "2882d03f578cad2f545669612068eb49a84a2cd47a86bdc3227f45a59b02bfdf",
           "file": "src/worktree/index-impl.ts",
-          "line": 470,
+          "line": 480,
           "severity": "high",
           "kind": "path_traversal",
           "summary": "path_traversal user-controlled"
         },
         {
-          "fingerprint": "bc06974d0566f2b0c34b4b2b5d93baf7e24cba2acb2440a8330e2c811690b0fc",
+          "fingerprint": "91ac8c86dce40a968ad2d61b75a463c5807b050ca9afc1adfc128c2cbd3aa31a",
           "file": "src/debug-engine/detect-lifecycle.ts",
           "line": 258,
           "severity": "medium",
@@ -5943,7 +6151,7 @@
           "summary": "missing_validation user-controlled"
         },
         {
-          "fingerprint": "e6062950afe7594d86b36afcb874f7cf42e7cb8ba03fcb5ea8fc395c5b14c323",
+          "fingerprint": "2b6fdcabdd6fde484f9f265c3dce19eab2e3f37de0de81a5d7787fdf718a563c",
           "file": "src/desktop/webui.ts",
           "line": 159,
           "severity": "medium",
@@ -5951,7 +6159,7 @@
           "summary": "env_leak"
         },
         {
-          "fingerprint": "48b750a698607dab04ff0f97e3bb04bbc6afc6ab8c1c467434e9ad9ea4e36d5e",
+          "fingerprint": "66e26a3360a291416403469c480ce3456d051f01249539ddee2ae65e23986e20",
           "file": "src/desktop/webui.ts",
           "line": 251,
           "severity": "medium",
@@ -5959,7 +6167,7 @@
           "summary": "env_leak"
         },
         {
-          "fingerprint": "f28f84a4a8c58ef36d98557b0eb63e11e8d7eda12094afd93e3e189182ea2212",
+          "fingerprint": "b06f409d60d8bac8f10bbc685e6703fef38b99a6ca04431a3a953118092a0ab1",
           "file": "src/util/ssrf.ts",
           "line": 63,
           "severity": "medium",
@@ -5967,7 +6175,7 @@
           "summary": "missing_validation user-controlled"
         },
         {
-          "fingerprint": "bdd5dce273cb31cec3d8c51724a8d72d4987700cf50852a6a36ed7471b8bb17c",
+          "fingerprint": "75f5ee2168b01f2f49403b5765526efe038b9efc0a5eb4929bde57ff38e4e747",
           "file": "src/util/ssrf.ts",
           "line": 69,
           "severity": "medium",
@@ -5975,7 +6183,7 @@
           "summary": "missing_validation user-controlled"
         },
         {
-          "fingerprint": "e6c7dae350df9f6e975de735bc04179e8cb9d96f2a727cd25b9b14a678660a87",
+          "fingerprint": "ef66755047e27837f606ae1f1df6dfa444fee1c7f35066262738207a945d9f5f",
           "file": "src/util/ssrf.ts",
           "line": 70,
           "severity": "medium",
@@ -5983,7 +6191,7 @@
           "summary": "missing_validation user-controlled"
         },
         {
-          "fingerprint": "7545ec5aa92fa6d905106e54b733233ef4ba115031d82ada4bd52034837f8865",
+          "fingerprint": "8ab6e88e61e275bb98a66f9a240a877bd1d38572f8713ab5e7b77e435a25867d",
           "file": "src/util/ssrf.ts",
           "line": 71,
           "severity": "medium",
@@ -5991,7 +6199,7 @@
           "summary": "missing_validation user-controlled"
         },
         {
-          "fingerprint": "2010411f64cf8366426c4a4bd54fde3a34177894e2959151c8f17575ed30ede7",
+          "fingerprint": "134401a4f78d9ed91ceb81ef95a7a2a4c6cdd8023dec256ad2622eba485cbae4",
           "file": "src/util/ssrf.ts",
           "line": 79,
           "severity": "medium",
@@ -5999,7 +6207,7 @@
           "summary": "missing_validation user-controlled"
         },
         {
-          "fingerprint": "90cff78644852e76139539b8a85f84022497b3f6e88f0bd6efbedae9bd48872f",
+          "fingerprint": "8cb613d01e22c66e92fd98769517d0df2d40dd9b3a9fc7d4ee26ca1a127a7e29",
           "file": "src/util/ssrf.ts",
           "line": 80,
           "severity": "medium",
@@ -6009,10 +6217,10 @@
       ]
     },
     "hardcode_scan": {
-      "count": 34,
+      "count": 35,
       "findings": [
         {
-          "fingerprint": "3fbcac8c16bc21bddd6bde75e71dbff8b9761d5983b2308af72031e2e582b3d8",
+          "fingerprint": "631110289988842bf8a830c52fd9c66efa01ebf326a2254fd7ed82d65d33381d",
           "file": "src/cli/cmd/github-agent/github-api.ts",
           "line": 66,
           "severity": "medium",
@@ -6020,7 +6228,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "f490a4e0d5fab1aff2d811224d5602e4dc906c7e2c418d12676bd4b27017af80",
+          "fingerprint": "d9c86b0b5da4270bff73a08e5845e31990b2e92d12f2c42e36600eab73b6823e",
           "file": "src/cli/cmd/index-graph.ts",
           "line": 275,
           "severity": "medium",
@@ -6028,7 +6236,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "400fd5c7e3630f0c063570fb306bacf55bd1781f86ce2f2b557baf5f44fe2236",
+          "fingerprint": "b006250416be179404e7334fdb6340ab37158743639f16c84350ad1ec693de87",
           "file": "src/cli/cmd/mcp-impl.ts",
           "line": 285,
           "severity": "medium",
@@ -6036,7 +6244,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "b43c2576f211065138c162611069ccf3c68f622a08dea5030b98464d3df085a9",
+          "fingerprint": "a84c73ed702ef2703d9db7463e2ae6b71ccb935dc5ba01979c2038a46e0e5028",
           "file": "src/cli/cmd/mcp-impl.ts",
           "line": 747,
           "severity": "medium",
@@ -6044,15 +6252,15 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "69b5b4af5d2817d5cf10ff7980b0a277a2724785da3995309f53a213f7bc1c65",
+          "fingerprint": "28d80d7fae8cc8e970fdcf60241021a01adc4d3c98f2b8759270cf053564132e",
           "file": "src/config/schema-impl.ts",
-          "line": 226,
+          "line": 239,
           "severity": "medium",
           "kind": "inline_url",
           "summary": "inline_url"
         },
         {
-          "fingerprint": "fa89f204223ab31f17039c4f36bc7d37ad7b990b42beab7ced159cc1c57b7971",
+          "fingerprint": "d82b0606d7f119dcdf2141ee24f640700a03fd573b69e538d6843a6c5346193d",
           "file": "src/graph/format.ts",
           "line": 484,
           "severity": "medium",
@@ -6060,7 +6268,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "e023bcc331b3b1f448dcb9b2f9f2d5df87d4795214983f7aaaff215c4bbd4607",
+          "fingerprint": "b9c26ea4f12eebb2d2a5615644a1cf5f3659cc3185152df875e73d16ec86ef41",
           "file": "src/graph/format.ts",
           "line": 514,
           "severity": "medium",
@@ -6068,7 +6276,15 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "4558081caf543be36e9340beb41df91a403efccabf2d3b2bfbfdb1c8ccb1c54a",
+          "fingerprint": "501bbcdb2d5ce8ed46d7206599becdf6559c394a14e91fc7fcabdd038f2f1d4e",
+          "file": "src/isolation/os-sandbox.ts",
+          "line": 195,
+          "severity": "medium",
+          "kind": "inline_path",
+          "summary": "inline_path"
+        },
+        {
+          "fingerprint": "eabe1cf9c2e31eec1bfd82e4020c959bcfe17ae24e686f7862dd58e706d8e4fd",
           "file": "src/lsp/server-defs/other-servers.ts",
           "line": 226,
           "severity": "medium",
@@ -6076,7 +6292,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "95647d45c6fc1615440b83200896923aff5a901953f83bc266c65c7fc9e57b91",
+          "fingerprint": "cb7205f4bc29a1b302c3c15bc096a23a087957707003c68770354f1f15b9bab6",
           "file": "src/lsp/server-releases.ts",
           "line": 89,
           "severity": "medium",
@@ -6084,7 +6300,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "103df5b7663344ed777427571327668b5be714cd601512595c46916917f0f83f",
+          "fingerprint": "6d6c03cf4be41afdefdc541d3e4d309579eb9d0e24a3c90d7dfe837b80d294dd",
           "file": "src/mcp/templates/index.ts",
           "line": 30,
           "severity": "medium",
@@ -6092,7 +6308,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "1c5d3a62949c8ada824eac6fff7c5ebbcf9e127bb45784df8e9308bbfcf06928",
+          "fingerprint": "83ea93c16d0a648ce795cfa874eac4b9a827574208a19acb0dceadf5d17defab",
           "file": "src/mcp/templates/index.ts",
           "line": 32,
           "severity": "medium",
@@ -6100,7 +6316,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "e465ae4eeaaa8e119443c1d6285bb35dc9fb2a85513fe4c12a3ae1533d6c4130",
+          "fingerprint": "95e5a32af718b9e2a709a9b146cb42039cfd7015f0cea423f8b026c11e471c04",
           "file": "src/mcp/templates/index.ts",
           "line": 33,
           "severity": "medium",
@@ -6108,7 +6324,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "6d3f6ad571375be9d1ae1fd4899c34022490814f216eda08333f89c101d6cdc9",
+          "fingerprint": "777f911dbdb3cf62177d3c302a07a9ad561fa756a6edf00cf62b1682cebc540a",
           "file": "src/mcp/templates/index.ts",
           "line": 43,
           "severity": "medium",
@@ -6116,7 +6332,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "6447bf7cc3b7a3c038893ff28775ba12d2b8d3298af92036f05a198886e4fb06",
+          "fingerprint": "efb3a6b19393ed2859bfd2719dca59c6bebf39045566b6ed3710f2d07a6ac8b8",
           "file": "src/mcp/templates/index.ts",
           "line": 55,
           "severity": "medium",
@@ -6124,7 +6340,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "5efc69dee3d5493e27d3765c86b66e4ff0fa0b12d60428f1f89f8f7c6f3db051",
+          "fingerprint": "248398ee6300b5f80a1bbf335c158bbfe65244227fc904170d573657a56ad127",
           "file": "src/mcp/templates/index.ts",
           "line": 75,
           "severity": "medium",
@@ -6132,7 +6348,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "dd79f3b63fa2a5e3d1084b319ed6d110d2ad2c6e739769544c033d890fb8fe21",
+          "fingerprint": "bc053b6173d2668f6a621fc692f6fe5a52bf7a79fc37f13e2c1a8eb587f58c93",
           "file": "src/mcp/templates/index.ts",
           "line": 115,
           "severity": "medium",
@@ -6140,7 +6356,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "cfdbd0000d2ab6b88301e7a614deaa1dd9a16c716992d683a450a1e826dd7ee1",
+          "fingerprint": "817e58cd4561ae83ce90e3461bb7edc239ede066e10221e8d2f9dc71bf43aafc",
           "file": "src/mcp/templates/index.ts",
           "line": 128,
           "severity": "medium",
@@ -6148,7 +6364,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "87860fa4541207f5ce73c4e2c8f3bfeda20880c2f9c3d72b0c63d46345cbd0f8",
+          "fingerprint": "eb2fe20aaa2c9972f7b88c1482c851c7f8ce4445ecac713f41c56a23beae4141",
           "file": "src/mcp/templates/index.ts",
           "line": 130,
           "severity": "medium",
@@ -6156,7 +6372,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "7128a324089ede06ffee7be093ebb54839f6d02efb96ad9fc91ff5d1e4f4cef6",
+          "fingerprint": "0c95a8dfc88dd1e57070562022bc7d7172b3ac8a3a0f5da00160b6b097efddf9",
           "file": "src/mcp/templates/index.ts",
           "line": 142,
           "severity": "medium",
@@ -6164,7 +6380,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "1a1b0b2ed05b612971ff8efd838b95f959c61cc7cf509f833b103f8a2a140a31",
+          "fingerprint": "7a14f8971b708eada2ecd253a207d1740688f96c4389d9af8965460da5bc1339",
           "file": "src/mcp/templates/index.ts",
           "line": 152,
           "severity": "medium",
@@ -6172,7 +6388,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "704665cfc4aeaac9718ae65e77a939af7deaad29aeffcaf06945aae0857cdc6e",
+          "fingerprint": "982880f8df455c6e50b044614a84fb9243d70ef2f96842307f2da2b1bec1c315",
           "file": "src/mcp/templates/index.ts",
           "line": 164,
           "severity": "medium",
@@ -6180,15 +6396,15 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "43f35b3d4a24d5f7f145490a1f3ac50a716292a600db34311185e652bfb435d8",
+          "fingerprint": "c0d30d28641fd1c7d083b91c501138f7247552949df55c2b0ea84bb32df97d7b",
           "file": "src/provider/ax-engine/constants.ts",
-          "line": 74,
+          "line": 86,
           "severity": "medium",
           "kind": "inline_url",
           "summary": "inline_url"
         },
         {
-          "fingerprint": "cb395843f8d4052ae74e37ee61d9079f9b55d7e179464a50cf1d4084d9b5f968",
+          "fingerprint": "7645d2a090f2d9fe43867cdf643b4a29d14870bd3aa518ee2bc418895fa7a2d2",
           "file": "src/provider/error.ts",
           "line": 151,
           "severity": "medium",
@@ -6196,7 +6412,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "c374490230aa4cc8c95c35a1a7ef8adaeaa6fd48328afe63eef1be5b10ffeb9e",
+          "fingerprint": "0a0aea932addfa180b762e0f1d4b7393d385e1d5d1f831977ab7779ca4a8680d",
           "file": "src/provider/error.ts",
           "line": 192,
           "severity": "medium",
@@ -6204,7 +6420,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "323ec54d1d07dfe467c2ea577c96fcb15256672fb3c62190ff00d0c705676863",
+          "fingerprint": "f1dae2cd6f352578aa3ab531fdd8c1fc02761006217324c220e62967b83ecd00",
           "file": "src/quality/pr-diff.ts",
           "line": 64,
           "severity": "medium",
@@ -6212,7 +6428,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "8fcf9d30ebd21cf1c0e8a7688db3b866bf072c1ac25a65556640f3ec38092b94",
+          "fingerprint": "f0fe990bf2f68d67225e888177c4b8eb948a6bd4b1b8b70eee133415eef0587e",
           "file": "src/quality/pr-diff.ts",
           "line": 70,
           "severity": "medium",
@@ -6220,7 +6436,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "1dc926c57188eed404a9647e69c2de3f0381439404aaf096388100679d3b6e12",
+          "fingerprint": "9566f2b0bef709904f10a0961523e523d8f714f72179f7995a5184236c15200c",
           "file": "src/server/request-directory.ts",
           "line": 22,
           "severity": "medium",
@@ -6228,7 +6444,7 @@
           "summary": "inline_path"
         },
         {
-          "fingerprint": "9ce70a139aa358d024d51ae9e0df3aae6ed59e3b1e1089f33d92ab0191cae29c",
+          "fingerprint": "55545e1db1319289400cfccebb76e265f1284f4100753c3fcc307fdd97985d4d",
           "file": "src/cli/cmd/tui/component/dialog-provider.tsx",
           "line": 33,
           "severity": "low",
@@ -6236,7 +6452,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "35d1039cf6daed745a03bec9bf33cdc5e4fa50498115c964f8a6a27fcdd3544d",
+          "fingerprint": "c6cd457032177da8bc60b58a53d7e200580a96ef745c2dc2c373f35182ccca44",
           "file": "src/cli/cmd/tui/component/dialog-provider.tsx",
           "line": 34,
           "severity": "low",
@@ -6244,7 +6460,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "1a7a64f3f2b742b38d32bf1b8b30ca08749e8956a7a005e85b01127fcbb8a613",
+          "fingerprint": "c5bdaee3490d4731b799f797c3e1130fafd2a82656ae7dc482a32a2aac498735",
           "file": "src/cli/cmd/tui/component/dialog-provider.tsx",
           "line": 416,
           "severity": "low",
@@ -6252,7 +6468,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "7fe94a6bf93f3697da0252732cc0b85100dc7d67467e5c383d6c5b2792e7ceaf",
+          "fingerprint": "3592e6ec9410825af0200371e65ff921f21bad09f54715b644e58b606aafe4ae",
           "file": "src/provider/loaders.ts",
           "line": 416,
           "severity": "low",
@@ -6260,7 +6476,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "b81c86390ed92697f9f7b095d78b480ef743d085ab067d9c3038ecd53dbc2b95",
+          "fingerprint": "2b5b133e8d32563a80a302afb5229585b447f0ef87e035cdff4c5994893c35fe",
           "file": "src/provider/loaders.ts",
           "line": 417,
           "severity": "low",
@@ -6268,7 +6484,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "9e7295cf549ef581de238827c514a3516cd6368567725e7e72984fe0cf12dcbc",
+          "fingerprint": "8617a607af177f89b1a858ffaeeabe80c81daabc32dd4c1ff1eaf5e815e06c65",
           "file": "src/server/ipc-transport.ts",
           "line": 174,
           "severity": "low",
@@ -6276,7 +6492,7 @@
           "summary": "inline_url"
         },
         {
-          "fingerprint": "e39d93930679e6a5ce3cca72769532f447a23f2926500cedc0886506d53e6967",
+          "fingerprint": "4d5eae04863a3e26db28347fe07ff5c475164daed4d0cad838ad1dd081e58778",
           "file": "src/tool/visual/snapshot.ts",
           "line": 15,
           "severity": "low",

--- a/packages/ax-code/script/self-scan.ts
+++ b/packages/ax-code/script/self-scan.ts
@@ -27,7 +27,7 @@ type BaselineScanner = {
 }
 
 type BaselineFile = {
-  version: 1
+  version: 2
   scope: string
   scanners: Partial<Record<ScannerName, BaselineScanner>>
 }
@@ -109,20 +109,40 @@ function normalizeWhitespace(value: string | undefined) {
   return (value ?? "").replace(/\s+/g, " ").trim()
 }
 
-function normalizeRaceFinding(finding: DebugEngineTypes.RaceFinding): NormalizedFinding {
+function createSourceAnchor() {
+  const sourceLines = new Map<string, Promise<string[]>>()
+
+  return async (file: string, line: number, endLine?: number) => {
+    const absolute = path.isAbsolute(file) ? file : path.resolve(packageDir, file)
+    let lines = sourceLines.get(absolute)
+    if (!lines) {
+      lines = fs
+        .readFile(absolute, "utf8")
+        .then((content) => content.split("\n"))
+        .catch(() => [])
+      sourceLines.set(absolute, lines)
+    }
+
+    const source = await lines
+    // Source context stays stable when unrelated edits shift line numbers.
+    const start = Math.max(0, line - 1)
+    const end = Math.min(source.length, Math.max(line, endLine ?? line) + 2)
+    return normalizeWhitespace(source.slice(start, end).join("\n"))
+  }
+}
+
+type SourceAnchor = ReturnType<typeof createSourceAnchor>
+
+async function normalizeRaceFinding(
+  finding: DebugEngineTypes.RaceFinding,
+  sourceAnchor: SourceAnchor,
+): Promise<NormalizedFinding> {
   const file = normalizeFile(finding.file)
   const kind = finding.pattern
+  const anchor = normalizeWhitespace(finding.code) || (await sourceAnchor(finding.file, finding.line, finding.endLine))
   return {
     scanner: "race_scan",
-    fingerprint: fingerprint([
-      "race_scan",
-      file,
-      String(finding.line),
-      String(finding.endLine ?? ""),
-      finding.severity,
-      finding.pattern,
-      normalizeWhitespace(finding.code),
-    ]),
+    fingerprint: fingerprint(["race_scan:v2", file, finding.severity, finding.pattern, anchor]),
     file,
     line: finding.line,
     endLine: finding.endLine,
@@ -132,19 +152,22 @@ function normalizeRaceFinding(finding: DebugEngineTypes.RaceFinding): Normalized
   }
 }
 
-function normalizeLifecycleFinding(finding: DebugEngineTypes.LifecycleFinding): NormalizedFinding {
+async function normalizeLifecycleFinding(
+  finding: DebugEngineTypes.LifecycleFinding,
+  sourceAnchor: SourceAnchor,
+): Promise<NormalizedFinding> {
   const file = normalizeFile(finding.file)
   const kind = `${finding.resourceType}:${finding.pattern}`
+  const anchor = await sourceAnchor(finding.file, finding.line)
   return {
     scanner: "lifecycle_scan",
     fingerprint: fingerprint([
-      "lifecycle_scan",
+      "lifecycle_scan:v2",
       file,
-      String(finding.line),
       finding.severity,
       finding.resourceType,
       finding.pattern,
-      normalizeWhitespace(finding.cleanupLocation ?? ""),
+      anchor,
     ]),
     file,
     line: finding.line,
@@ -154,18 +177,22 @@ function normalizeLifecycleFinding(finding: DebugEngineTypes.LifecycleFinding): 
   }
 }
 
-function normalizeSecurityFinding(finding: DebugEngineTypes.SecurityFinding): NormalizedFinding {
+async function normalizeSecurityFinding(
+  finding: DebugEngineTypes.SecurityFinding,
+  sourceAnchor: SourceAnchor,
+): Promise<NormalizedFinding> {
   const file = normalizeFile(finding.file)
   const kind = finding.pattern
+  const anchor = await sourceAnchor(finding.file, finding.line)
   return {
     scanner: "security_scan",
     fingerprint: fingerprint([
-      "security_scan",
+      "security_scan:v2",
       file,
-      String(finding.line),
       finding.severity,
       finding.pattern,
       finding.userControlled ? "user-controlled" : "not-user-controlled",
+      anchor,
     ]),
     file,
     line: finding.line,
@@ -175,20 +202,16 @@ function normalizeSecurityFinding(finding: DebugEngineTypes.SecurityFinding): No
   }
 }
 
-function normalizeHardcodeFinding(finding: DebugEngineTypes.HardcodeFinding): NormalizedFinding {
+async function normalizeHardcodeFinding(
+  finding: DebugEngineTypes.HardcodeFinding,
+  sourceAnchor: SourceAnchor,
+): Promise<NormalizedFinding> {
   const file = normalizeFile(finding.file)
   const kind = finding.kind
+  const anchor = await sourceAnchor(finding.file, finding.line)
   return {
     scanner: "hardcode_scan",
-    fingerprint: fingerprint([
-      "hardcode_scan",
-      file,
-      String(finding.line),
-      String(finding.column),
-      finding.severity,
-      finding.kind,
-      finding.value,
-    ]),
+    fingerprint: fingerprint(["hardcode_scan:v2", file, finding.severity, finding.kind, finding.value, anchor]),
     file,
     line: finding.line,
     severity: finding.severity,
@@ -222,7 +245,7 @@ function baselineFromResults(results: ScanResult[]): BaselineFile {
     }
   }
   return {
-    version: 1,
+    version: 2,
     scope: sourceScope,
     scanners,
   }
@@ -231,7 +254,7 @@ function baselineFromResults(results: ScanResult[]): BaselineFile {
 async function readBaseline(file: string): Promise<BaselineFile> {
   const text = await fs.readFile(file, "utf8")
   const parsed = JSON.parse(text) as BaselineFile
-  if (parsed.version !== 1 || typeof parsed.scanners !== "object" || parsed.scanners === null) {
+  if (parsed.version !== 2 || typeof parsed.scanners !== "object" || parsed.scanners === null) {
     throw new Error(`Unsupported self-scan baseline format: ${file}`)
   }
   return parsed
@@ -242,37 +265,51 @@ async function writeBaseline(file: string, baseline: BaselineFile) {
   await fs.writeFile(file, `${JSON.stringify(baseline, null, 2)}\n`)
 }
 
-function baselineFingerprints(baseline: BaselineFile) {
-  const out = new Map<ScannerName, Set<string>>()
+function fingerprintCounts(findings: ReadonlyArray<Pick<BaselineEntry, "fingerprint">>) {
+  const counts = new Map<string, number>()
+  for (const finding of findings) counts.set(finding.fingerprint, (counts.get(finding.fingerprint) ?? 0) + 1)
+  return counts
+}
+
+function consumeFingerprintCount(counts: Map<string, number>, fingerprint: string) {
+  const count = counts.get(fingerprint) ?? 0
+  if (count === 0) return false
+  if (count === 1) counts.delete(fingerprint)
+  else counts.set(fingerprint, count - 1)
+  return true
+}
+
+function baselineFingerprintCounts(baseline: BaselineFile) {
+  const out = new Map<ScannerName, Map<string, number>>()
   for (const scanner of scannerOrder) {
-    out.set(scanner, new Set((baseline.scanners[scanner]?.findings ?? []).map((finding) => finding.fingerprint)))
+    out.set(scanner, fingerprintCounts(baseline.scanners[scanner]?.findings ?? []))
   }
   return out
 }
 
-function currentFingerprints(results: ScanResult[]) {
-  const out = new Map<ScannerName, Set<string>>()
+function currentFingerprintCounts(results: ScanResult[]) {
+  const out = new Map<ScannerName, Map<string, number>>()
   for (const result of results) {
-    out.set(result.scanner, new Set(result.findings.map((finding) => finding.fingerprint)))
+    out.set(result.scanner, fingerprintCounts(result.findings))
   }
   return out
 }
 
 function findNewFindings(results: ScanResult[], baseline: BaselineFile) {
-  const baselineByScanner = baselineFingerprints(baseline)
+  const baselineByScanner = baselineFingerprintCounts(baseline)
   return results.flatMap((result) => {
-    const accepted = baselineByScanner.get(result.scanner) ?? new Set<string>()
-    return result.findings.filter((finding) => !accepted.has(finding.fingerprint))
+    const accepted = new Map(baselineByScanner.get(result.scanner))
+    return result.findings.filter((finding) => !consumeFingerprintCount(accepted, finding.fingerprint))
   })
 }
 
 function findStaleBaselineEntries(results: ScanResult[], baseline: BaselineFile) {
-  const currentByScanner = currentFingerprints(results)
+  const currentByScanner = currentFingerprintCounts(results)
   const stale: NormalizedFinding[] = []
   for (const scanner of scannerOrder) {
-    const current = currentByScanner.get(scanner) ?? new Set<string>()
+    const current = new Map(currentByScanner.get(scanner))
     for (const finding of baseline.scanners[scanner]?.findings ?? []) {
-      if (!current.has(finding.fingerprint)) stale.push({ scanner, ...finding })
+      if (!consumeFingerprintCount(current, finding.fingerprint)) stale.push({ scanner, ...finding })
     }
   }
   return sortFindings(stale)
@@ -347,6 +384,7 @@ async function writeReport(file: string | undefined, content: string) {
 }
 
 async function runScans(): Promise<ScanResult[]> {
+  const sourceAnchor = createSourceAnchor()
   const commonInput = {
     include: sourceGlobs,
     excludeTests: true,
@@ -366,7 +404,9 @@ async function runScans(): Promise<ScanResult[]> {
         scanner: "race_scan",
         filesScanned: race.filesScanned,
         truncated: race.truncated,
-        findings: sortFindings(race.findings.map(normalizeRaceFinding)),
+        findings: sortFindings(
+          await Promise.all(race.findings.map((finding) => normalizeRaceFinding(finding, sourceAnchor))),
+        ),
       })
 
       const lifecycle = await DebugEngine.detectLifecycle(projectID, commonInput)
@@ -374,7 +414,9 @@ async function runScans(): Promise<ScanResult[]> {
         scanner: "lifecycle_scan",
         filesScanned: lifecycle.filesScanned,
         truncated: lifecycle.truncated,
-        findings: sortFindings(lifecycle.findings.map(normalizeLifecycleFinding)),
+        findings: sortFindings(
+          await Promise.all(lifecycle.findings.map((finding) => normalizeLifecycleFinding(finding, sourceAnchor))),
+        ),
       })
 
       const security = await DebugEngine.detectSecurity(projectID, commonInput)
@@ -382,7 +424,9 @@ async function runScans(): Promise<ScanResult[]> {
         scanner: "security_scan",
         filesScanned: security.filesScanned,
         truncated: security.truncated,
-        findings: sortFindings(security.findings.map(normalizeSecurityFinding)),
+        findings: sortFindings(
+          await Promise.all(security.findings.map((finding) => normalizeSecurityFinding(finding, sourceAnchor))),
+        ),
       })
 
       const hardcodes = await DebugEngine.detectHardcodes(projectID, {
@@ -393,7 +437,9 @@ async function runScans(): Promise<ScanResult[]> {
         scanner: "hardcode_scan",
         filesScanned: hardcodes.filesScanned,
         truncated: hardcodes.truncated,
-        findings: sortFindings(hardcodes.findings.map(normalizeHardcodeFinding)),
+        findings: sortFindings(
+          await Promise.all(hardcodes.findings.map((finding) => normalizeHardcodeFinding(finding, sourceAnchor))),
+        ),
       })
 
       return results


### PR DESCRIPTION
## Summary
- anchor accepted self-scan findings to matched source context instead of volatile line/column offsets
- compare fingerprint occurrences so identical new findings are still reported
- regenerate the self-scan baseline in the v2 format

## Validation
- `corepack pnpm --dir packages/ax-code run typecheck`
- `corepack pnpm --dir packages/ax-code run check:self-scan`
- `corepack pnpm --dir packages/ax-code run test:ci deterministic --rerun-on-fail 1`
- verified a line-only shift passes and a deliberately introduced path traversal finding fails