### PR TITLE
docs: reposition README and docs around execution evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
-**A local-first agent runtime for serious software work.**
+<h1 align="center">AX Code</h1>
 
-AX Code runs coding agents against your actual repositories through AX Code Desktop, a terminal TUI, one-shot CLI, VS Code, a TypeScript SDK, and a local HTTP server. It is built around durable sessions, explicit tools, sandboxed execution, provider routing, code intelligence, and MCP/plugin extensibility so teams can let agents act without losing control of the work.
+<p align="center"><strong>Inspect the run. Verify the change. Decide what stays.</strong></p>
 
-- Work interactively in the terminal with model, provider, agent, session, MCP, and skill controls
-- Run headless tasks for scripts, CI, bots, and internal automation with the same runtime
-- Preserve work with persistent sessions, replay, fork, export, compare, rollback, and repo instructions in `AGENTS.md`
-- Bound execution with `workspace-write`, `read-only`, or `full-access` isolation plus permission rules
-- Extend with MCP servers, plugins, custom agents, Agent Skills, SDK tools, and VS Code integration
+AX Code is an open-source coding-agent runtime for reviewable, reversible work. Every session is recorded as a structured event log with file snapshots, so you can reconstruct what the agent did, compare two runs against each other, and roll back what you do not want. Candidate implementations can be built in isolated Git worktrees and ranked against your repository's own checks — nothing merges automatically.
 
 Built by [DEFAI Digital](https://github.com/defai-digital).
 
@@ -19,271 +15,195 @@ Built by [DEFAI Digital](https://github.com/defai-digital).
 
 ---
 
-## Get Started
+## The problem
 
-### Supported Install Targets
+Coding agents now write real code in real repositories. The gap is what happens after the agent says it is done: which files it touched, which decisions it made, whether the result passes your checks, how one attempt compared with another, and how to undo the specific step that went wrong.
 
-| Platform                        | Status         | Install path                                           |
-| ------------------------------- | -------------- | ------------------------------------------------------ |
-| macOS Apple Silicon             | Active support | Homebrew CLI formula and Desktop cask                  |
-| Windows x64                     | Active support | PowerShell CLI installer and Desktop release installer |
-| Windows ARM64                   | Active support | PowerShell CLI installer and Desktop release installer |
-| Ubuntu 24.04+ (amd64 and arm64) | Active support | Bash CLI installer plus Desktop `.deb`/AppImage        |
+Most agents give you a transcript. AX Code gives you an execution record.
 
-**Recommended: AX Code Desktop**
+## What that looks like
 
-**macOS**
+Every session is recorded while it runs. Afterwards you can compare two runs directly:
 
-1. Install Homebrew if you do not already have it:
+```console
+$ ax-code compare ses_01H8XK ses_01H8XM
 
-```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  Session Comparison
+  ============================================================
+
+  A: ses_01H8XK
+     add rate limiting to the ingest API
+     Risk: HIGH (53/100) — 8 files changed, rewrite, cross-module change
+
+  B: ses_01H8XM
+     add rate limiting to the ingest API (second attempt)
+     Risk: CRITICAL (93/100) — 25 files changed, rewrite, security-related files,
+                               cross-module change, 15 tool failures
+
+  Risk Comparison
+  ----------------------------------------
+  Score: 53 → 93 (+40) ↑
+  Level: HIGH → CRITICAL
+  Files: 8 → 25
+  Failures: 0 → 15
+
+  Event Summary
+  ----------------------------------------
+  tool.call: 12 → 127
+  step.finish: 6 → 90
+  Total: 69 → 817
 ```
 
-2. Install AX Code CLI and Desktop:
+Or reconstruct a single run step by step, with timings:
+
+```console
+$ ax-code graph ses_01H8XK
+
+## Session ses_01H8XK
+
+Duration: 9m 54s | Risk: HIGH (53/100) | Tokens: 167,650 in / 18,494 out
+Agents: architect
+
+### Step 1 (8s) | tokens: 12263/587
+
+- read: api.ts → ok (5ms)
+- grep: rateLimit → ok (12ms)
+
+### Step 2 (4m 42s) | tokens: 12327/3626
+
+- task: explore rate limiter call sites → ok (215021ms)
+```
+
+The output format above is verbatim from these commands; the session IDs and task names are illustrative. The risk score is a deterministic heuristic computed from signals including churn, validation state, tool failures, touched paths, affected API surface, control-plane outcomes, and security-sensitive file patterns — it is a review aid, not a probability, a confidence measure, or a security assurance.
+
+## What you get
+
+**Inspect what the agent did.** `ax-code graph` reconstructs the session as an execution graph with per-step tool calls and timings. `ax-code compare` diffs two runs by risk, decision path, and event counts. `ax-code trace` produces replay-backed diagnostics. The evidence exports out of AX Code as JSONL (`ax-code audit export`), a Markdown report (`ax-code audit report`), or OpenTelemetry spans (`ax-code audit otlp`).
+
+**Undo precisely.** File changes are snapshotted to an out-of-tree Git object store during the run. `ax-code rollback <session> --list` shows recoverable points; `--step N` restores a specific one. Rollback depends on a usable snapshot, so it has real boundaries — see [Execution Evidence](docs/guides/execution-evidence.md).
+
+**Verify competing implementations.** In arena implement mode, each contestant gets an isolated worktree from the same clean base commit, its patch is snapshotted to a branch, your repository's typecheck/lint/test commands run, and candidates that verify rank above candidates that do not. AX Code does not merge the winner for you.
+
+**Understand impact before editing.** With the code-intelligence graph built (`ax-code index`), the agent can compute the blast radius of a proposed change — transitive callers, API boundaries hit, and a bounded risk score — deterministically, with no model call and no file reads.
+
+**Keep repository knowledge durable.** `ax-code wiki` compiles a source-backed wiki: deterministic page planning, source-hash change detection, protected manual sections, atomic writes, and lint checks including dead links. Page prose is model-generated from cited source; the planning, validation, and incremental-update framework around it is deterministic.
+
+## Get started
 
 ```bash
+# macOS
 brew install defai-digital/tap/ax-code
 brew install --cask defai-digital/tap/ax-code-desktop
-```
 
-Already have Homebrew? Start from step 2. The fully qualified commands add the shared DefAI Digital tap
-automatically.
-
-![Install AX Code with Homebrew](docs/images/install-homebrew-ax-code.gif)
-
-**Windows**
-
-1. Install the AX Code CLI with PowerShell (release archives are verified with minisign; if minisign is not on PATH the installer bootstraps a pinned official build):
-
-```powershell
+# Windows (CLI)
 powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://github.com/defai-digital/ax-code/releases/latest/download/install.ps1 | iex"
-```
 
-Set `AX_CODE_SKIP_MINISIGN_VERIFY=1` only if you intentionally accept an unverifiable download. For a download-and-inspect flow that also verifies `install.ps1` itself, see [Installation and Runtime Channels](docs/getting-started/install-runtime.md).
-
-2. Install AX Code Desktop separately from the [latest GitHub Release](https://github.com/defai-digital/ax-code/releases/latest):
-
-- Intel/AMD Windows: download and run the latest `AX-Code-<version>-win-x64.exe`.
-- Windows on Arm: download and run the latest `AX-Code-<version>-win-arm64.exe`.
-
-Windows Desktop installers are Authenticode-signed by **DEFAI Private Limited**. SmartScreen may still warn for a newly released build while it develops download reputation; continue only when Windows shows that expected publisher. Do not run an installer reported as **Unknown publisher**.
-
-The PowerShell `install.ps1` path installs the CLI only. It does not install the Desktop app.
-
-**Ubuntu 24.04+ (CLI)**
-
-Ubuntu Desktop/Server **24.04 LTS** and newer (glibc) on **amd64** and **arm64**:
-
-```bash
+# Ubuntu 24.04+ (CLI)
 curl -fsSL https://raw.githubusercontent.com/defai-digital/ax-code/main/install | bash
 ```
 
-Pin a version with `bash -s -- --version <release>`. The installer verifies the downloaded archive with minisign (bootstraps a pinned minisign build when needed). Set `AX_CODE_SKIP_MINISIGN_VERIFY=1` only if you intentionally accept an unverifiable download.
-
-Linux CLI archives are `ax-code-linux-x64.tar.gz` / `ax-code-linux-arm64.tar.gz`. AX Code Desktop for Linux ships as `.deb` and AppImage assets on `desktop-v*` releases (for example `AX-Code-<version>-linux-amd64.deb` and `AX-Code-<version>-linux-x86_64.AppImage`). Musl-based distros (for example Alpine) are not a supported install target for current release archives.
-
-AX Code Desktop is the primary graphical workspace. It shares the AX Code runtime and provider setup, and its source lives in this monorepo under [`desktop/`](desktop/). The standalone Desktop source repository has been retired.
-
-**Run**
+Then:
 
 ```bash
-ax-code
+ax-code                  # open the terminal UI
 ```
 
-Or open **AX Code** from Applications / Start Menu to use the Desktop app. The terminal UI can also start or open the browser web UI with `/webui`, and shell users can run `ax-code webui`. The web UI prefers `http://127.0.0.1:3100` and scans upward if that port is busy. No project setup or config file is required. On first launch, connect a provider from the Desktop onboarding flow or use `/connect` inside the terminal UI.
+Connect a provider from the Desktop onboarding flow, with `/connect` in the terminal UI, or with `ax-code providers login`. No project setup or config file is required.
 
-**CLI-only install**
+Release archives are verified with minisign. Platform support, update paths, signature verification, contributor source builds, and troubleshooting live in [Installation and Runtime Channels](docs/getting-started/install-runtime.md).
 
-Use this path for terminals, headless tasks, CI jobs, bots, servers, and SDK/integration hosts.
+![Install AX Code with Homebrew](docs/images/install-homebrew-ax-code.gif)
 
-**macOS**
+## When AX Code fits
 
-```bash
-brew install defai-digital/tap/ax-code
-```
+**Good fit:** consequential changes in Git repositories where the change has to be reviewed — refactors, migrations, cross-module fixes, security-sensitive edits; unattended or scheduled runs whose output someone must audit afterwards; teams that want model choice without handing the review record to a single hosted product.
 
-**Windows**
+**Poor fit:** inline autocomplete; a single quick disposable edit; fully managed cloud delegation; workflows where you will not use Git or run repository checks. A lighter editor assistant is the better tool for those.
 
-```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://github.com/defai-digital/ax-code/releases/latest/download/install.ps1 | iex"
-```
+## Surfaces
 
-Verifies the downloaded release archive with minisign (bootstraps a pinned minisign binary when needed). Set `AX_CODE_SKIP_MINISIGN_VERIFY=1` only if you intentionally accept an unverifiable download. Installs the node-bundled CLI under `%USERPROFILE%\.ax-code\bin`. Pin a version with `-Version <release>`. Uninstall with `.\install.ps1 -Uninstall`.
+The same runtime, session store, and evidence model back every surface.
 
-Supported CLI install paths are Homebrew (macOS), the GitHub release installer for Windows PowerShell, and the bash installer for Ubuntu 24.04+ on amd64/arm64. The Windows PowerShell and Ubuntu bash installers are CLI-only; use the platform Desktop release assets (macOS DMG/cask, Windows `.exe`, Ubuntu `.deb`/AppImage) for the Desktop app. npm packages are not a supported release channel. See [Installation and Runtime Channels](docs/getting-started/install-runtime.md) for the full matrix.
+| Surface              | Entry point                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------ |
+| Desktop app          | AX Code Desktop for macOS, Windows, and Ubuntu 24.04+, from [`desktop/`](desktop/)                     |
+| Terminal UI          | `ax-code` — provider, model, agent, session, MCP, and skill flows                                      |
+| One-shot / headless  | `ax-code run "review the auth flow"` for scripts, CI, and bots                                         |
+| Local service        | `ax-code serve` exposes the runtime over a local HTTP API and OpenAPI contract                         |
+| TypeScript embedding | `@ax-code/sdk` provides `createAgent()`, streaming events, sessions, and custom tools                  |
+| VS Code              | The [VS Code extension](https://marketplace.visualstudio.com/items?itemName=AutomatosX.ax-code-vscode) |
 
-AX Engine local inference is available only on eligible Apple Silicon Macs. Install its matching MLX runtime with `brew install defai-digital/ax-engine/ax-engine`; AX Code then starts and manages the local server on demand. Windows Desktop users should use hosted providers or OpenAI-compatible provider gateways; AX Code itself remains local-only and cannot be used as a remote server. For headless use, CI jobs, or preconfigured shells, AX Code also respects provider environment variables such as `GOOGLE_GENERATIVE_AI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `HF_TOKEN`, `UNOROUTER_API_KEY`, `ZHIPU_API_KEY`, Alibaba plan keys, and `GITHUB_TOKEN`.
+## Control model
 
-### Update
+AX Code starts with autonomous mode on and isolation set to `workspace-write`: network disabled, writes confined to the workspace, and protected paths such as `.git/` and `.ax-code/` blocked. The agent makes progress without asking about every low-risk step while the sandbox holds the boundary.
 
-`ax-code upgrade` and package-manager update commands apply to the node-bundled runtime shipped by supported installers.
-
-```bash
-ax-code upgrade
-```
-
-**macOS**
-
-```bash
-brew upgrade defai-digital/tap/ax-code
-brew upgrade --cask defai-digital/tap/ax-code-desktop
-```
-
-If `ax-code` is missing after a Homebrew upgrade (older setups installed the Desktop cask under the
-conflicting `ax-code` token, which makes Homebrew skip linking the CLI formula), restore it with:
-
-```bash
-brew link ax-code
-hash -r
-```
-
-If `ax-code --version` still shows an older version after `brew upgrade`, another `ax-code` earlier
-on PATH is shadowing Homebrew (commonly `~/.local/bin/ax-code` from `pnpm run setup:cli` or a
-previous curl install). Check with `which -a ax-code`, then move the extra launcher aside:
-
-```bash
-mv ~/.local/bin/ax-code ~/.local/bin/ax-code.bak
-hash -r
-ax-code --version
-```
-
-**Windows**
-
-```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://github.com/defai-digital/ax-code/releases/latest/download/install.ps1 | iex"
-```
-
-This updates the Windows CLI. AX Code Desktop updates through the Desktop auto-updater, or by downloading the latest `AX-Code-<version>-win-x64.exe` / `AX-Code-<version>-win-arm64.exe` installer from GitHub Releases. For unattended Desktop installs, run the NSIS installer with `/S` (for example `.\AX-Code-7.7.6-win-x64.exe /S`).
-
-### From Source (contributors)
-
-```bash
-git clone https://github.com/defai-digital/ax-code.git
-cd ax-code && pnpm install && pnpm run setup:cli
-```
-
-Requires [pnpm](https://pnpm.io) v10.33.4+ and [Node.js](https://nodejs.org) matching the root `package.json` engine (`>=24`, `>=26` for source-mode TUI commands that use `--experimental-ffi`). `setup:cli` builds and installs a node-bundled launcher. `ax-code doctor` should report `Runtime: Node vX.Y.Z (node-bundled)` — the same node-bundled runtime shipped by every supported install channel (Homebrew, Windows installer, and Ubuntu installer).
-
-Refresh the local bundled runtime after code changes:
-
-```bash
-pnpm --dir packages/ax-code run build -- --single
-pnpm run setup:cli -- --rebuild
-ax-code doctor
-```
-
-For contributor-only source debugging, install the checkout-bound launcher explicitly:
-
-```bash
-pnpm run setup:cli -- --source
-```
-
-That source launcher should report `Runtime: Node vX.Y.Z (source)` and is intentionally separate from the default node-bundled launcher.
-
----
-
-## What AX Code Does
-
-AX Code is designed for agent work that touches real files, shells, sessions, and team policy. The same runtime powers every surface:
-
-| Need                         | Use                                                                                                                                                              |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Desktop app                  | AX Code Desktop provides the graphical app from [`desktop/`](desktop/) for macOS, Windows, and Ubuntu 24.04+                                                     |
-| Interactive coding           | `ax-code` opens the terminal UI with provider, model, agent, session, MCP, and skill flows                                                                       |
-| One-shot automation          | `ax-code run "review the auth flow"` runs a bounded headless task                                                                                                |
-| Local service / integrations | `ax-code serve` exposes the runtime over a local HTTP API and OpenAPI contract                                                                                   |
-| TypeScript embedding         | `@ax-code/sdk` provides `createAgent()`, streaming events, sessions, custom tools, and tests                                                                     |
-| VS Code                      | The [VS Code extension](https://marketplace.visualstudio.com/items?itemName=AutomatosX.ax-code-vscode) uses the installed CLI/server while staying editor-native |
-
-## Current Capabilities
-
-- **Terminal command center**: prompt editing, provider/model picker, agent picker, session list, MCP status, skill dialog, sandbox/autonomous toggles, and live tool progress.
-- **Controlled execution**: tools such as read, edit, write, grep, glob, bash (foreground and background shells), web fetch/search, todo, task, and skill execution all pass through permission and isolation boundaries.
-- **Durable sessions**: resume, fork, compact, export/import, replay, compare, rollback, and inspect session risk instead of losing work when a chat closes.
-- **Repository intelligence**: `ax-code init` writes a thin `AGENTS.md`; the native `ax-code wiki` compiler creates source-backed semantic docs; `ax-code index`, `graph`, semantic diff, LSP-backed context, and risk/DRE views provide structural precision on larger codebases.
-- **Provider flexibility**: connect hosted or local providers from `/connect` or `ax-code providers login`; list available models with `ax-code models`.
-- **Extensibility**: add MCP servers, create custom agents, validate Agent Skills, and embed custom SDK tools without rebuilding the orchestration layer.
-
-## Control Model
-
-AX Code starts with autonomous mode on and runtime isolation in `workspace-write` by default: network is disabled, writes stay inside the workspace, and protected paths such as `.git/` and `.ax-code/` remain blocked. The agent can make progress without asking about every low-risk step, while the sandbox still enforces the boundary.
-
-- Use `/sandbox`, `--sandbox read-only`, `--sandbox workspace-write`, or `--sandbox full-access` to change isolation intentionally.
-- Use `/autonomous` or `AX_CODE_AUTONOMOUS=false` when you want the agent to stop for each permission or question.
-- Use `ax-code mcp list --tools`, `ax-code mcp trust`, and permission rules to control external MCP tool surfaces.
+- Change isolation intentionally with `/sandbox`, or `--sandbox read-only | workspace-write | full-access`.
+- Use `/autonomous` or `AX_CODE_AUTONOMOUS=false` to stop for each permission and question.
+- Control external tool surfaces with `ax-code mcp list --tools`, `ax-code mcp trust`, and permission rules.
 - Provider and MCP credentials are encrypted at rest; server mode is localhost-only by default.
 
-See [Sandbox Mode](docs/guides/sandbox.md), [Autonomous Mode](docs/guides/autonomous.md), [MCP Integrations](docs/integrations/mcp.md), and [SECURITY.md](SECURITY.md) for the full control model.
+Verification gates apply where they are enforceable: arena candidates and gated refactor application run your checks before a result is accepted. Ordinary interactive edits are not automatically verified — run `verify_project` or your own commands for those.
 
-## Typical Workflow
+See [Sandbox Mode](docs/guides/sandbox.md), [Autonomous Mode](docs/guides/autonomous.md), [MCP Integrations](docs/integrations/mcp.md), and [SECURITY.md](SECURITY.md).
 
-1. Open a repository and run `ax-code`.
-2. Use `/connect` to add a provider or switch models. For automation, use `ax-code providers login` or provider environment variables.
-3. Run `ax-code init` so `AGENTS.md` captures local conventions, safety rules, and project context. Use `ax-code init --wiki` (or `ax-code wiki generate`) when you want a native semantic wiki under `ax-wiki/`.
-4. Keep the default sandbox for broad edits; change it only when the task needs a different boundary.
-5. Run `ax-code index` on larger repos when structural code-intelligence (symbols, callers, refs) matters; use the wiki for architecture narrative.
-6. Use `ax-code run`, `ax-code serve`, or `@ax-code/sdk` when the same agent workflow needs to move into scripts, CI, bots, or applications.
+## Providers and models
 
-Grok runs exclusively through `Grok Build CLI`. Select `grok-build-cli` in `/connect`; AX Code invokes the local `grok` command and reuses its CLI login/session. The former direct `xai` cloud API provider is no longer supported.
+| Family                   | Providers                                                                                                  | Model source                                                      |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Cloud API providers      | Google, GroqCloud, OpenRouter, Hugging Face, UnoRouter, Alibaba plans, MiniMax plans, GitHub Copilot, Z.AI | Hosted provider model catalogs bundled with AX Code               |
+| CLI providers            | Claude Code, Codex CLI, Grok Build CLI, Qoder CLI, Kimi Code CLI                                           | One model ID per CLI bridge, reusing the local vendor CLI session |
+| AX Engine local provider | `ax-engine` on eligible Apple Silicon Macs                                                                 | Curated AXQ 6-bit MLX models served from the live catalog         |
 
-## Supported Providers and Models
+CLI bridges reuse a local vendor CLI and its login session. AX Code records its own tool execution in full; activity that happens inside a vendor CLI process is visible only through that bridge's output.
 
-Default setup flows support three provider families:
+See [Supported Providers and Models](docs/providers/supported-providers.md) for provider IDs and credentials, [Free-Tier API Quickstart](docs/providers/free-tier-apis.md) to evaluate without buying credits, and [AX Engine Model Selection](docs/providers/ax-engine-model-selection.md) for local inference.
 
-| Family                   | Providers                                                                                         | Model source                                                    |
-| ------------------------ | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| Cloud API providers      | Google, GroqCloud, OpenRouter, Hugging Face, UnoRouter, Alibaba plans, GitHub Copilot, and Z.AI   | Hosted provider model catalogs bundled with AX Code             |
-| CLI providers            | Claude Code, Gemini CLI, Codex CLI, Grok Build CLI, Qoder CLI, Antigravity CLI, and Kimi Code CLI | One model ID per CLI bridge, using the local vendor CLI session |
-| AX Engine local provider | `ax-engine` on eligible Apple Silicon Macs                                                        | Three curated AXQ 6-bit MLX models served from the live catalog |
+## Commands
 
-See [Supported Providers and Models](docs/providers/supported-providers.md) for provider IDs, credential variables, and
-the command that lists the exact model IDs bundled with your installed release.
+Evidence and review:
 
-To evaluate AX Code without purchasing model credits, use the [Free-Tier API Quickstart](docs/providers/free-tier-apis.md);
-free quotas and account terms are controlled by the external provider.
+| Command                      | Purpose                                             |
+| ---------------------------- | --------------------------------------------------- |
+| `ax-code graph <session>`    | Reconstruct a session as an execution graph         |
+| `ax-code compare <a> <b>`    | Compare two runs by risk, decision path, and events |
+| `ax-code replay <session>`   | Inspect and reconstruct the recorded event log      |
+| `ax-code risk <session>`     | Explainable risk signals and mitigations for a run  |
+| `ax-code rollback <session>` | List and restore snapshot points from a run         |
+| `ax-code branch <session>`   | Fork session state to try a different strategy      |
+| `ax-code trace <session>`    | Replay-backed diagnostics and timeline              |
+| `ax-code audit export`       | Export run evidence as JSON Lines                   |
+| `ax-code audit report`       | Generate a Markdown audit report for a run          |
+| `ax-code audit otlp`         | Export a run as OpenTelemetry trace spans           |
+| `ax-code dre-graph`          | Open the local run-report dashboard in a browser    |
 
-## Local AX Engine Models
+Everyday use:
 
-AX Engine local inference is optimized for eligible Apple Silicon Macs. The built-in AX Code provider uses a
-curated AXQ 6-bit MLX model set and defaults to Qwen3.8-27B AXQ with its packaged MTP sidecar. Ornith-1.0-35B
-provides the long-context reasoning option, while Qwen3-Coder-Next is the larger coding specialist. See
-[AX Engine Model Selection](docs/providers/ax-engine-model-selection.md) for memory and disk guidance.
+| Command                   | Purpose                                                         |
+| ------------------------- | --------------------------------------------------------------- |
+| `ax-code`                 | Open the interactive terminal UI                                |
+| `ax-code run "<task>"`    | Run a one-shot headless task                                    |
+| `ax-code init`            | Create or update repository `AGENTS.md` (`--wiki` adds AX Wiki) |
+| `ax-code index`           | Build the code-intelligence graph                               |
+| `ax-code wiki`            | Plan, generate, update, or lint the AX Wiki                     |
+| `ax-code providers login` | Configure provider credentials                                  |
+| `ax-code models`          | List available provider/model IDs                               |
+| `ax-code mcp add`         | Add a local or remote MCP server                                |
+| `ax-code agent create`    | Generate a custom project or global agent                       |
+| `ax-code serve`           | Start the local HTTP/OpenAPI server                             |
+| `ax-code doctor`          | Diagnose install, runtime, storage, and auth                    |
+
+`ax-code --help` lists the full command set.
 
 ## Documentation
 
-- [Start Here](docs/getting-started/start-here.md): understand what AX Code is, where the value comes from, and which docs to read next
-- [Documentation Hub](docs/README.md): guides, architecture, specs, and reference docs
-- [Sandbox Mode](docs/guides/sandbox.md): isolation modes, protected paths, and network controls
-- [Autonomous Mode](docs/guides/autonomous.md): unattended execution behavior and safeguards
-- [MCP Integrations](docs/integrations/mcp.md): trust, permissions, and prompt/resource safety for MCP servers
-- [Auto-Route](docs/guides/auto-route.md): keyword-based specialist routing and optional fast-model complexity routing
-- [Supported Providers and Models](docs/providers/supported-providers.md): Cloud API providers, CLI providers, and AX Engine model IDs
-- [Free-Tier API Quickstart](docs/providers/free-tier-apis.md): test AX Code with compatible free-tier or free-credit providers
-- [AX Engine Model Selection](docs/providers/ax-engine-model-selection.md): local AX Engine model ranking and memory guidance
-- [Semantic Layer](docs/architecture/semantic-layer.md): provenance and replay boundaries for graph and LSP-backed answers
-- [AX Wiki](docs/integrations/wiki.md): native source-backed semantic wiki; complements `ax-code index`
-- [Stability](docs/architecture/stability.md): crash hygiene, aborts vs faults, TUI lifecycle, timeouts
-
-## Common Commands
-
-| Command                                        | Purpose                                         |
-| ---------------------------------------------- | ----------------------------------------------- |
-| `ax-code`                                      | Open the interactive terminal UI                |
-| `ax-code run "debug why the build is failing"` | Run a one-shot headless task                    |
-| `ax-code providers login`                      | Configure provider credentials                  |
-| `ax-code models`                               | List available provider/model IDs               |
-| `ax-code init`                                 | Create or update repository `AGENTS.md`         |
-| `ax-code init --wiki`                          | AGENTS.md + native AX Wiki bootstrap            |
-| `ax-code wiki`                                 | AX Wiki plan / generate / update / lint / cards |
-| `ax-code index`                                | Build code-intelligence indexes                 |
-| `ax-code graph`                                | Inspect the repository graph                    |
-| `ax-code mcp list --tools`                     | Review MCP servers, exposed tools, and rules    |
-| `ax-code mcp add`                              | Add a local or remote MCP server                |
-| `ax-code agent create`                         | Generate a custom project or global agent       |
-| `ax-code skill list`                           | List discovered Agent Skills                    |
-| `ax-code serve`                                | Start the local HTTP/OpenAPI server             |
-| `ax-code doctor`                               | Diagnose install, runtime, storage, and auth    |
+- [Why AX Code](docs/why-ax-code.md) — what it optimizes for, who it is for, and how it differs from other agents
+- [Start Here](docs/getting-started/start-here.md) — product mental model and shortest paths by use case
+- [Execution Evidence](docs/guides/execution-evidence.md) — graph, replay, compare, risk, rollback, trace, and audit export
+- [Verified Multi-Model Changes](docs/guides/verified-multi-model-change.md) — council review and arena implementation
+- [Documentation Hub](docs/README.md) — guides, architecture, providers, and reference
+- [Sandbox Mode](docs/guides/sandbox.md) · [Autonomous Mode](docs/guides/autonomous.md) · [MCP Integrations](docs/integrations/mcp.md)
+- [Semantic Layer](docs/architecture/semantic-layer.md) — provenance and replay boundaries for graph and LSP answers
+- [AX Wiki](docs/integrations/wiki.md) · [Stability](docs/architecture/stability.md)
 
 ## Community
 
@@ -291,14 +211,16 @@ Report bugs, feature requests, and questions through [GitHub Issues](https://git
 
 ## Provenance
 
-AX Code is maintained by [DEFAI Private Limited](https://github.com/defai-digital). The repository includes code with upstream history from these MIT-licensed projects:
+AX Code began on the MIT-licensed [OpenCode](https://github.com/anomalyco/opencode) codebase, and that attribution is preserved here and in [NOTICE](NOTICE). DEFAI's independent work since then is what this README describes: the execution-evidence layer (event log, snapshots, replay reconstruction, run comparison, risk scoring, audit export), the deterministic debug and refactor engine with shadow-worktree verification, the code-intelligence graph and impact analysis, council and arena execution modes, the AX Wiki compiler, OS-level sandboxing, and AX Code Desktop.
 
-- [OpenCode](https://github.com/anomalyco/opencode): the AX Code CLI, runtime, session, provider, and tool foundations began as a DEFAI-maintained product built on the OpenCode codebase. See [NOTICE](NOTICE) for the root runtime attribution.
-- [OpenChamber](https://github.com/btriapitsyn/openchamber): AX Code Desktop includes code derived from OpenChamber, adapted for the AX Code Desktop product, packaging, settings, and runtime model. See [desktop/NOTICE](desktop/NOTICE) for the Desktop attribution.
-- [OpenTUI](https://github.com/anomalyco/opentui): the renderer snapshot underlying AX Code TUI began from OpenTUI's MIT-licensed work. AX Code owns the `@ax-code/tui` package, integration, patches, and release process.
-- [ax-cli](https://github.com/defai-digital/ax-cli): selected AX/CLI capabilities were ported from DEFAI's earlier ax-cli project. See [NOTICE](NOTICE) for the root attribution.
+The repository also includes code with upstream history from these MIT-licensed projects:
 
-These notices preserve license provenance and upstream credit. They do not mean the upstream OpenCode, OpenChamber, OpenTUI, or ax-cli projects maintain AX Code, AX Code Desktop, or current DEFAI modifications.
+- [OpenCode](https://github.com/anomalyco/opencode): the CLI, runtime, session, provider, and tool foundations. See [NOTICE](NOTICE).
+- [OpenChamber](https://github.com/btriapitsyn/openchamber): AX Code Desktop includes derived code. See [desktop/NOTICE](desktop/NOTICE).
+- [OpenTUI](https://github.com/anomalyco/opentui): the renderer snapshot underlying AX Code TUI. AX Code owns the `@ax-code/tui` package, integration, patches, and release process.
+- [ax-cli](https://github.com/defai-digital/ax-cli): selected AX/CLI capabilities ported from DEFAI's earlier project. See [NOTICE](NOTICE).
+
+These notices preserve license provenance and upstream credit. They do not mean the upstream projects maintain AX Code or current DEFAI modifications.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,17 +2,28 @@
 
 Status: Active
 Scope: public, current-state
-Last reviewed: 2026-07-25
+Last reviewed: 2026-08-21
 Owner: AX Code maintainers
+
+AX Code is an open-source coding-agent runtime for reviewable, reversible work: every session is recorded as a
+structured event log with file snapshots, candidate implementations can be verified against your repository's own
+checks, and nothing merges automatically. [Why AX Code](why-ax-code.md) explains what that optimizes for, who it is
+for, and what it deliberately does not claim.
 
 The root [README](../README.md) is the shortest path to install and launch AX Code. Use this hub when you need to
 configure a workflow, understand a runtime boundary, or integrate AX Code with another system.
+
+`module-quality-audit/`, `planning/`, and `prd/` under `docs/` are internal process records kept in Git for
+traceability. They are not product documentation; the public pages are the ones linked below.
 
 ## Choose by task
 
 | I want to…                                               | Start here                                                              |
 | -------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Decide whether AX Code fits my work                      | [Why AX Code](why-ax-code.md)                                           |
 | Understand AX Code before installing it                  | [Start Here](getting-started/start-here.md)                             |
+| Review, compare, or undo what an agent did               | [Execution Evidence](guides/execution-evidence.md)                      |
+| Get several models to attempt the same change            | [Verified Multi-Model Changes](guides/verified-multi-model-change.md)   |
 | Choose an install or runtime channel                     | [Installation and Runtime Channels](getting-started/install-runtime.md) |
 | Connect a hosted, CLI, custom, or local provider         | [Supported Providers and Models](providers/supported-providers.md)      |
 | Try AX Code with a free-tier model API                   | [Free-Tier API Quickstart](providers/free-tier-apis.md)                 |
@@ -28,12 +39,17 @@ configure a workflow, understand a runtime boundary, or integrate AX Code with a
 
 ## Getting started
 
+- [Why AX Code](why-ax-code.md) — what AX Code optimizes for, its intended audience, how it differs, and what it does
+  not claim.
 - [Start Here](getting-started/start-here.md) — product mental model and the shortest paths by use case.
 - [Installation and Runtime Channels](getting-started/install-runtime.md) — supported platforms, packages, updates, and
   contributor launchers.
 
 ## Runtime guides
 
+- [Execution Evidence](guides/execution-evidence.md) — graph, compare, replay, risk, rollback, branch, trace, and
+  audit export.
+- [Verified Multi-Model Changes](guides/verified-multi-model-change.md) — the council and arena workflow end to end.
 - [Sandbox Mode](guides/sandbox.md) — isolation modes, protected paths, network controls, and precedence.
 - [Autonomous Mode](guides/autonomous.md) — unattended execution, approvals, headless use, and safeguards.
 - [Loop Mode and Scheduled Tasks](guides/loop-mode.md) — recurring prompts, durable schedules, and long-run limits.

--- a/docs/architecture/semantic-layer.md
+++ b/docs/architecture/semantic-layer.md
@@ -13,7 +13,7 @@ This page documents shipped semantic behavior, not future code-graph ambitions. 
 
 - `packages/ax-code/src/tool/lsp.ts` and related LSP modules for live semantic operations.
 - `packages/ax-code/src/code-intelligence/` for indexed graph behavior.
-- `packages/ax-code/src/debug-engine/` for graph-backed debugging/refactoring consumers.
+- `packages/ax-code-reason/` for graph-backed debugging/refactoring analyses (impact, bug paths, races, lifecycle, duplication, hardcoded values, security findings, and gated refactor application).
 - Replay, export, and audit tests before claiming durable provenance guarantees.
 
 If a capability is planned or experimental, keep that status explicit.

--- a/docs/getting-started/start-here.md
+++ b/docs/getting-started/start-here.md
@@ -2,7 +2,7 @@
 
 Status: Active
 Scope: current-state
-Last reviewed: 2026-07-04
+Last reviewed: 2026-08-21
 Owner: ax-code runtime
 
 If the root [README](../../README.md) is the fastest way to install AX Code, this page is the fastest way to understand it.
@@ -22,11 +22,16 @@ That matters because AI coding is only useful in real repositories when you can 
 
 ## Where the Value Comes From
 
-- Control. Agents act through explicit tools, permission rules, and isolation modes such as `full-access`, `workspace-write`, or `read-only`.
-- Continuity. Sessions can be resumed, forked, compacted, exported, and replayed so long-running work does not disappear when a UI closes.
-- Context. `AGENTS.md` lets repository-specific conventions, safety rules, and collaboration defaults live with the code.
-- Portability. The same workflow can run against hosted providers or local runtimes without changing the tool surface.
-- Extensibility. The same runtime powers the TUI, CLI, VS Code extension, TypeScript SDK, headless server, MCP integrations, and custom tools.
+AX Code optimizes the moment _after_ the agent finishes: deciding whether to keep what it produced.
+
+- **Evidence.** Every session is recorded as a typed event log plus file snapshots, so `ax-code graph`, `compare`, `replay`, `risk`, and `audit` can reconstruct what happened after the conversation ends.
+- **Verification.** Where a gate is enforceable — arena candidates, gated refactor application — your repository's own typecheck, lint, and test commands decide whether a result is accepted.
+- **Reversibility.** Snapshots are recoverable per step, not only per session, from a Git object store kept outside your repository.
+- **Your decision.** AX Code ranks, scores, and reports. It does not merge for you.
+
+Supporting these: explicit tools with permission rules and isolation modes, durable sessions, `AGENTS.md` for repository conventions, provider portability, and one runtime behind the TUI, CLI, VS Code extension, SDK, headless server, and MCP integrations. Those are foundations rather than the reason to choose AX Code — see [Why AX Code](../why-ax-code.md).
+
+For the commands themselves, see [Execution Evidence](../guides/execution-evidence.md).
 
 ## Mental Model
 
@@ -100,16 +105,19 @@ Grok runs exclusively through `Grok Build CLI`. Select `grok-build-cli` in `/con
 
 ## Doc Map
 
-| Topic                    | Start here                                                            |
-| ------------------------ | --------------------------------------------------------------------- |
-| Product overview         | [Start Here](start-here.md)                                           |
-| Install/runtime channels | [Installation and Runtime Channels](install-runtime.md)               |
-| Providers and models     | [Supported Providers and Models](../providers/supported-providers.md) |
-| Free-tier API evaluation | [Free-Tier API Quickstart](../providers/free-tier-apis.md)            |
-| Sandbox and permissions  | [Sandbox Mode](../guides/sandbox.md)                                  |
-| Unattended execution     | [Autonomous Mode](../guides/autonomous.md)                            |
-| Routing and model tier   | [Auto-Route](../guides/auto-route.md)                                 |
-| SDK embedding            | [`@ax-code/sdk`](../../packages/sdk/js/README.md)                     |
-| HTTP/OpenAPI clients     | [HTTP and OpenAPI Compatibility](../sdk/http-openapi.md)              |
+| Topic                    | Start here                                                                                                                                                        |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Why choose AX Code       | [Why AX Code](../why-ax-code.md)                                                                                                                                  |
+| Product overview         | [Start Here](start-here.md)                                                                                                                                       |
+| Review / undo agent work | [Execution Evidence](../guides/execution-evidence.md)                                                                                                             |
+| Multi-model changes      | [Verified Multi-Model Changes](../guides/verified-multi-model-change.md)                                                                                          |
+| Install/runtime channels | [Installation and Runtime Channels](install-runtime.md)                                                                                                           |
+| Providers and models     | [Supported Providers and Models](../providers/supported-providers.md)                                                                                             |
+| Free-tier API evaluation | [Free-Tier API Quickstart](../providers/free-tier-apis.md)                                                                                                        |
+| Sandbox and permissions  | [Sandbox Mode](../guides/sandbox.md)                                                                                                                              |
+| Unattended execution     | [Autonomous Mode](../guides/autonomous.md)                                                                                                                        |
+| Routing and model tier   | [Auto-Route](../guides/auto-route.md)                                                                                                                             |
+| SDK embedding            | [`@ax-code/sdk`](../../packages/sdk/js/README.md)                                                                                                                 |
+| HTTP/OpenAPI clients     | [HTTP and OpenAPI Compatibility](../sdk/http-openapi.md)                                                                                                          |
 | VS Code integration      | [VS Code integration](../../packages/integration-vscode/README.md) · [Marketplace](https://marketplace.visualstudio.com/items?itemName=AutomatosX.ax-code-vscode) |
-| Architecture             | [Semantic Layer](../architecture/semantic-layer.md)                   |
+| Architecture             | [Semantic Layer](../architecture/semantic-layer.md)                                                                                                               |

--- a/docs/guides/execution-evidence.md
+++ b/docs/guides/execution-evidence.md
@@ -1,0 +1,151 @@
+# Execution Evidence
+
+Status: Active
+Scope: current-state
+Last reviewed: 2026-08-21
+Owner: AX Code runtime
+
+Every AX Code session is recorded while it runs. This page covers the commands that turn that recording into something you can review, compare, export, and undo.
+
+Use it when an agent has finished and you need to answer: what did it do, how risky was it, how did it compare with another attempt, and how do I get back?
+
+## What gets recorded
+
+During a run AX Code writes two independent things:
+
+- **A typed event log** — routing decisions, model activity, step boundaries, tool calls, and tool results. This is the source for `graph`, `replay`, `compare`, `trace`, and `audit`.
+- **File snapshots** — captured into a Git object store that lives **outside your repository**, under the AX Code data directory, using `refs/snapshots/<hash>`. Your working tree and your project's `.git/` are not modified to store them.
+
+Both are local. Nothing is uploaded.
+
+## Reconstruct a run
+
+```bash
+ax-code graph <sessionID>
+```
+
+Rebuilds the session as an execution graph: duration, risk summary, token counts, agents used, and every step with its tool calls and timings.
+
+```console
+## Session ses_01H8XK
+
+Duration: 9m 54s | Risk: HIGH (53/100) | Tokens: 167,650 in / 18,494 out
+Agents: architect
+
+### Step 1 (8s) | tokens: 12263/587
+
+- read: api.ts → ok (5ms)
+- grep: rateLimit → ok (12ms)
+```
+
+`--format` selects alternative outputs, including Mermaid and a topology view, when you want the graph in another tool.
+
+Note that this is the **session execution graph** — what the agent did. It is not the repository code graph; that is `ax-code index` and the code-intelligence layer.
+
+## Compare two runs
+
+```bash
+ax-code compare <sessionA> <sessionB>
+ax-code compare <sessionA> <sessionB> --deep
+```
+
+Reports the risk delta, files changed, tool-failure counts, the decision path each run took, and per-event-type counts. `--deep` adds step-level divergence analysis through replay comparison.
+
+This compares **runs**, not source code. It answers "the second attempt scored worse — where did it diverge," not "show me the code diff."
+
+A typical use is deciding between two strategies for the same task:
+
+```console
+  Risk Comparison
+  ----------------------------------------
+  Score: 53 → 93 (+40) ↑
+  Level: HIGH → CRITICAL
+  Files: 8 → 25
+  Failures: 0 → 15
+```
+
+## Inspect the recorded event log
+
+```bash
+ax-code replay <sessionID> --mode summary
+ax-code replay <sessionID> --mode verify
+ax-code replay <sessionID> --mode reconstruct
+ax-code replay <sessionID> --mode export
+```
+
+`verify` checks the recorded log for consistency. `reconstruct` rebuilds the step stream from events. `export` writes a portable replay package.
+
+**Replay reconstructs; it does not re-execute.** It does not re-run models, re-invoke tools, or reproduce external state. The `execute` mode prepares a reconstructed stream for programmatic comparison against the original and is intended for testing, not for re-running work.
+
+## Read the risk signals
+
+```bash
+ax-code risk <sessionID>
+ax-code risk <sessionID> --explain
+ax-code risk <sessionID> --json
+```
+
+The score is a **deterministic heuristic** derived from recorded signals, including how many files changed, whether the change spans multiple top-level areas, how many tool calls failed, whether validation ran, whether a diff snapshot exists, how much API surface is affected, how the run ended (a blocked completion gate or a step-limit/stalled finish both add weight), and whether security-sensitive paths were touched. Each contributing driver is listed with its weight, along with suggested mitigations.
+
+It is a review aid. It is not a probability, a calibrated confidence, or a statement that the code is secure. A LOW score on an unverified change still means the change is unverified.
+
+## Undo precisely
+
+```bash
+ax-code rollback <sessionID> --list      # show recoverable points
+ax-code rollback <sessionID> --dry-run   # show what would change
+ax-code rollback <sessionID> --step 4    # restore one step
+ax-code rollback <sessionID>             # restore the whole session
+```
+
+`--list` reads rollback points from the execution graph, so you can target a specific step rather than reverting the entire run.
+
+**Boundaries worth knowing before you rely on it:** rollback restores from snapshots taken during the run. A file that was never snapshotted — because it was changed outside the session, or was not in a recoverable state — cannot be restored this way. Use `--dry-run` first on anything consequential.
+
+## Try a different strategy
+
+```bash
+ax-code branch <sessionID>
+ax-code branch <sessionID> --from <messageID>
+```
+
+Forks the session's stored state so a second attempt starts from a chosen point instead of from scratch.
+
+This forks **session state** — messages and goals. It is not a Git branch and not a worktree. For isolated Git candidates, see [Verified Multi-Model Changes](verified-multi-model-change.md).
+
+## Diagnose
+
+```bash
+ax-code trace <sessionID>
+ax-code trace <sessionID> --logs
+```
+
+Replay-backed diagnostics with a risk-scored timeline. `--logs` switches to legacy log-file analysis instead of replay events, which is useful when you are investigating an operational problem rather than reviewing a change.
+
+## Export the evidence
+
+```bash
+ax-code audit export --all --since 2026-08-01     # JSON Lines
+ax-code audit export --all --risk HIGH            # filter by minimum risk
+ax-code audit report <sessionID>                  # Markdown report
+ax-code audit otlp <sessionID>                    # OpenTelemetry spans
+ax-code audit prune --days 90                     # delete old events
+```
+
+JSONL and OTLP make the run record consumable by your own review or observability pipeline. The Markdown report is meant for humans attaching evidence to a PR or a change record.
+
+## Browse it
+
+```bash
+ax-code dre-graph                 # latest session
+ax-code dre-graph --index         # session index
+```
+
+Opens a local browser dashboard with the run summary, timeline, changes, validation state, risk detail, branch information, and rollback points. The server binds to loopback only.
+
+## Related
+
+- [Why AX Code](../why-ax-code.md) — what this evidence layer is for
+- [Verified Multi-Model Changes](verified-multi-model-change.md) — producing candidates worth comparing
+- [Semantic Layer](../architecture/semantic-layer.md) — provenance envelopes on graph and LSP answers
+- [Web Dashboard](dashboard.md) — the workspace-level view

--- a/docs/guides/verified-multi-model-change.md
+++ b/docs/guides/verified-multi-model-change.md
@@ -1,0 +1,89 @@
+# Verified Multi-Model Changes
+
+Status: Active
+Scope: current-state
+Last reviewed: 2026-08-21
+Owner: AX Code runtime
+
+A workflow page for the job "I have a consequential change, I want more than one attempt at it, and I want the repository's own checks to decide which attempt is worth keeping."
+
+For the mode reference — flags, configuration keys, ranking inputs — see [Execution Modes](modes.md). This page is the end-to-end task.
+
+## When this is worth it
+
+Running several models costs several times as much as running one. It pays off when the change is consequential and the failure is expensive to discover later: a refactor across module boundaries, a migration, a fix in security-sensitive code, or a change where you genuinely do not know which approach is right.
+
+It is not worth it for a one-line edit, a rename, or anything you could verify by reading.
+
+## Two different tools
+
+| Tool      | What it produces                        | Writes files?              |
+| --------- | --------------------------------------- | -------------------------- |
+| `council` | independent review opinions, aggregated | No                         |
+| `arena`   | candidate implementations, ranked       | Only in isolated worktrees |
+
+Use `council` to decide **what** to do — it fans a design or review question out to several connected providers and aggregates the answers into consensus, strict-majority, minority, and singleton findings, with optional anonymous debate rounds. It is advisory. Agreement among models is not proof of correctness; it is a signal about how contested the question is.
+
+Use `arena` to decide **which implementation** to keep.
+
+## The arena implement workflow
+
+### 1. Prepare
+
+Implement mode requires a Git project with at least one commit and a **clean primary worktree**. Contestant worktrees are created from an exact base commit and cannot inherit uncommitted changes, so commit or stash first.
+
+You also need at least two distinct connected providers, and `modes.arena.enabled: true`.
+
+### 2. Run
+
+```
+/arena <task description>
+```
+
+Each contestant gets its own Git worktree created from the recorded base commit, and an implement agent runs in it. Your primary working tree is not modified by contestants.
+
+### 3. What AX Code does with each candidate
+
+- Snapshots the contestant's tracked **and untracked** changes into a durable branch commit, including any commits the agent made itself.
+- Runs detected project verification commands — typecheck, test, lint — but only after a non-empty patch is captured. An empty patch cannot win.
+- Ranks **verify-first** by default: only completed, non-empty patches that pass verification are eligible to win. Among passing candidates it prefers lower risk and more diverse patches.
+
+### 4. Decide
+
+The report gives you worktree paths, branch names, and commit ranges.
+
+**AX Code does not merge the winner.** Inspect, merge, or cherry-pick yourself. That is deliberate: verification means "your configured checks passed on this patch," which is a real signal but not a substitute for review.
+
+### 5. Review and, if needed, reverse
+
+Once a candidate is in your tree, the evidence commands apply as normal:
+
+```bash
+ax-code graph <sessionID>       # what the winning run actually did
+ax-code risk <sessionID>        # heuristic risk signals for the change
+ax-code rollback <sessionID> --dry-run
+```
+
+See [Execution Evidence](execution-evidence.md).
+
+## What "verified" means here, precisely
+
+It means: the project's detected typecheck, lint, and test commands ran against that candidate's patch, and they passed.
+
+It does not mean the change is correct, complete, secure, or well-designed. If your test suite does not cover the changed behavior, a passing candidate proves only that nothing already covered broke. Verification raises the floor; it does not certify the ceiling.
+
+It also does not extend to ordinary interactive editing. Arena candidates and gated refactor application run checks; a normal `edit` or `write` in a regular session does not automatically. Run `verify_project` when you want that evidence recorded for an ordinary run.
+
+## Cost and failure modes
+
+- **Cost scales with contestants.** Each runs a full implement agent.
+- **A dirty worktree stops the run** before anything else happens, by design.
+- **Fewer than two providers** makes the comparison meaningless, and the tool reports rather than inventing a ranking.
+- **All candidates can fail verification.** That is a useful result: it usually means the task was underspecified or the repository's checks are stricter than the agents assumed.
+
+## Related
+
+- [Execution Modes](modes.md) — full reference for council, arena, and the other modes
+- [Execution Evidence](execution-evidence.md) — reviewing and reversing the result
+- [Why AX Code](../why-ax-code.md) — why verification-first ranking is the wedge
+- [Multi-Model Routing Best Practices](multi-model-routing.md) — splitting premium and support work

--- a/docs/why-ax-code.md
+++ b/docs/why-ax-code.md
@@ -1,0 +1,78 @@
+# Why AX Code
+
+Status: Active
+Scope: current-state
+Last reviewed: 2026-08-21
+Owner: AX Code maintainers
+
+Most coding agents optimize the moment of writing code. AX Code optimizes the moment after: deciding whether to keep what the agent produced.
+
+## What AX Code optimizes for
+
+Agent output is cheap to generate and expensive to review. When an agent touches twenty files across three modules, the reviewer's problem is not "is this line correct" but "what did it actually do, does it pass, and what happens if I need to undo it."
+
+AX Code is built around that problem:
+
+- **Evidence.** Every session is recorded as a typed event log — routing decisions, model activity, steps, tool calls, tool results — plus file snapshots taken during the run.
+- **Verification.** Where a gate is enforceable, your repository's own checks decide. Arena candidates and gated refactor application run typecheck, lint, and tests before a result is accepted.
+- **Reversibility.** Snapshot points are recoverable per step, not only per session.
+- **Your decision.** AX Code ranks, scores, and reports. It does not merge for you.
+
+## Who it is for
+
+**Primary audience:**
+
+- senior and staff engineers making consequential changes
+- open-source and internal-platform maintainers
+- teams operating medium-to-large Git repositories
+- engineers evaluating refactors, migrations, and cross-module fixes
+- anyone running unattended or scheduled agent work that a human must audit afterwards
+
+**Not the primary audience:**
+
+- someone who wants inline autocomplete
+- a user making one quick, disposable edit
+- a team whose priority is fully managed cloud delegation
+- someone unwilling to use Git or run repository checks
+
+For those cases a lighter editor assistant is genuinely the better tool, and this page would rather say so than oversell.
+
+## How it differs
+
+Rather than a feature checklist that decays, here is what each category optimizes for:
+
+| Category                    | Optimizes for                      | Where AX Code differs                                               |
+| --------------------------- | ---------------------------------- | ------------------------------------------------------------------- |
+| First-party model agents    | one model's experience, end to end | AX Code is model-agnostic and keeps the record locally              |
+| Editor agents               | interactive in-IDE flow            | AX Code targets the review and audit step, not the typing step      |
+| Lightweight terminal agents | speed and simplicity               | AX Code accepts more concepts in exchange for an inspectable record |
+| Cloud agents                | managed delegation and autonomy    | AX Code keeps execution and evidence on your machine, Apache-2.0    |
+
+Several capabilities that AX Code ships are, as of 2026, broadly available elsewhere: sandboxing, checkpoints and restore, MCP, hooks, skills, subagents, worktree isolation, scheduling, provider choice, and running one prompt across several models. None of those alone is a reason to choose AX Code.
+
+The combination that is harder to assemble elsewhere is: an isolated candidate implementation, gated on the repository's own checks, ranked verification-first, with the full execution record retained locally and exportable — and no automatic merge.
+
+## What we do not claim
+
+Positioning is only useful if it survives contact with the product. Explicitly:
+
+- **`replay` reconstructs; it does not re-execute.** It rebuilds and verifies the recorded event stream. It does not re-run models, tools, or the outside world.
+- **`risk` is a deterministic heuristic**, computed from churn, validation state, tool failures, touched paths, and security-sensitive file patterns. It is not a probability, a calibrated confidence, or a security assurance.
+- **`branch` forks session state**, not a Git branch or worktree. Arena is the Git-worktree implementation path.
+- **`compare` compares runs**, not source code. It reports risk, decision path, and event counts — it is not a code diff viewer.
+- **Verification gates are not universal.** They apply to arena candidates and gated refactor application. Ordinary interactive edits are not automatically verified.
+- **AX Wiki prose is model-generated** from cited sources. The planning, validation, incremental update, and protected-section framework around it is deterministic.
+- **CLI-bridge visibility is partial.** AX Code records its own tool execution in full; work happening inside a vendor CLI process is visible only through that bridge's output.
+- **Some capabilities are opt-in.** The `workflow` runtime requires `AX_CODE_WORKFLOW_RUNTIME=1`.
+
+## Provenance, plainly
+
+AX Code began on the MIT-licensed OpenCode codebase. That is preserved in [NOTICE](../NOTICE) and stated in the README rather than buried.
+
+What DEFAI built on that foundation is the subject of this page: the execution-evidence layer, the deterministic debug and refactor engine with shadow-worktree verification, the code-intelligence graph and impact analysis, council and arena execution modes, the AX Wiki compiler, OS-level sandboxing, and AX Code Desktop.
+
+## Next
+
+- [Execution Evidence](guides/execution-evidence.md) — the commands that make a run reviewable
+- [Verified Multi-Model Changes](guides/verified-multi-model-change.md) — council and arena
+- [Start Here](getting-started/start-here.md) — the product mental model

--- a/docs/why-ax-code.md
+++ b/docs/why-ax-code.md
@@ -71,6 +71,8 @@ AX Code began on the MIT-licensed OpenCode codebase. That is preserved in [NOTIC
 
 What DEFAI built on that foundation is the subject of this page: the execution-evidence layer, the deterministic debug and refactor engine with shadow-worktree verification, the code-intelligence graph and impact analysis, council and arena execution modes, the AX Wiki compiler, OS-level sandboxing, and AX Code Desktop.
 
+**Integrating with a project is not deriving from it.** The provenance section of the README, and [NOTICE](../NOTICE), exist to carry license obligations under Apache-2.0 Section 4(d) — they list only upstreams whose code AX Code actually copies and redistributes. Projects that AX Code merely talks to are not listed there, however closely they were studied while building the bridge. The CLI providers are the clearest case: Claude Code, Codex CLI, Grok Build CLI, Qoder CLI, and Kimi Code CLI are named in the provider tables because AX Code invokes those local binaries and reuses their login sessions, not because any of their code ships here. Model-ID patterns, capability tables, and vendor-specific parsing in `packages/ax-code/src/provider/` are AX Code's own interoperability logic. Files that genuinely are verbatim derivations carry a one-line provenance header naming the upstream, so an audit can tell deliberate reuse from a missed cleanup.
+
 ## Next
 
 - [Execution Evidence](guides/execution-evidence.md) — the commands that make a run reviewable


### PR DESCRIPTION
## Why

Users who actually run AX Code rate it well, but readers of the README do not perceive that value. The front door was selling a distribution rather than a product:

- **164 of 307 README lines were install instructions.** `## Get Started` began at line 22; `## What AX Code Does` did not appear until line 186 — past the halfway point.
- The opening claim, "a local-first agent runtime for serious software work," is one Claude Code, Codex CLI, OpenCode, and Aider all make in near-identical words.
- Every occurrence of `verif*` in the README was about **minisign download signatures**, not the product's verification doctrine.
- `impact`, `blast radius`, `council`, `arena`, `refactor`, and `audit` appeared **zero times**.
- The command table listed 15 of ~40 commands, omitting `compare`, `risk`, `rollback`, `replay`, `branch`, `trace`, and `audit` — the differentiated half.
- Those same flagship subsystems had **no public documentation page at all**.

`.internal/adr/ADR-048` had already decided a positioning doctrine (Plan → Execute → Verify, hard completion gates, "multi-provider harness, not single-model brand"). None of it was reflected in the README.

## What changed

Reposition around what AX Code optimizes for: the moment *after* the agent finishes, when someone must decide whether to keep the work.

- **README** — leads with positioning and real `compare` / `graph` output. Install matrix, update paths, and troubleshooting move to `install-runtime.md`. Command table split so evidence commands come first. **307 → 227 lines.**
- **`docs/why-ax-code.md`** (new) — ICP, anti-ICP, category comparison, and an explicit "What we do not claim" section.
- **`docs/guides/execution-evidence.md`** (new) — `graph`, `compare`, `replay`, `risk`, `rollback`, `branch`, `trace`, `audit`, each with its boundaries.
- **`docs/guides/verified-multi-model-change.md`** (new) — the council/arena workflow, linking to `modes.md` rather than duplicating it, per the repo's own no-duplication rule.
- **`start-here.md`** — "Where the Value Comes From" rewritten around evidence, verification, reversibility, and human decision.

## Accuracy fixes found while verifying claims against source

| Defect | Evidence |
|---|---|
| README advertised **Gemini CLI** and **Antigravity CLI** as CLI providers | Both in `RETIRED_PROVIDER_IDS` (`provider/retired-providers.ts:4`); removed in v7.7.6 per its own release notes |
| Provider table omitted **MiniMax plans** | Present in `DEFAULT_SETUP_PROVIDER_IDS` and in `supported-providers.md` |
| `ax-code graph` described as "repository graph" | It builds the **session execution** graph (`cli/cmd/graph.ts:11`); repository structure is `ax-code index` |
| `semantic-layer.md` pointed at `packages/ax-code/src/debug-engine/` | Directory no longer exists; now `packages/ax-code-reason/` |

## Claims are deliberately bounded

`replay` reconstructs rather than re-executes; `risk` is a deterministic heuristic, not a confidence measure; `branch` forks session state, not a git branch; `compare` is not a code diff; verification gates cover arena and gated refactor apply but **not** ordinary edits; AX Wiki prose is model-generated; CLI-bridge visibility is partial.

The final commit records why integration is not derivation, so the provenance section keeps carrying only real Apache-2.0 §4(d) obligations.

## Review method

Positioning was reviewed independently by Codex (gpt-5.6-sol, reasoning max) and Qwen 3.8 Max, then reconciled. A follow-up adversarial fact-check caught fabricated tool labels in the `graph` example before merge — real output uses `path.basename`, and `task_parallel` has no case in `extractTarget`, so it can only render `[object Object]`. Corrected against source.

## Testing

`pnpm run test:scripts` — **113/113 pass** (link resolution, hub reachability, lifecycle metadata). Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)